### PR TITLE
Properly align AppNavigationToggle with first navigation item

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -56,8 +56,8 @@ $navigation-width: 300px;
 // mobile breakpoint
 $breakpoint-mobile: 1024px;
 
-// top-bar spacing
-$topbar-margin: 4px;
-
 // navigation spacing
 $app-navigation-settings-margin: 3px;
+
+// navigation items
+$app-navigation-padding: calc(var(--default-grid-baseline, 4px) * 2);

--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -357,10 +357,6 @@ export default {
 	&:not(.app-content--has-list) {
 		overflow: auto;
 	}
-
-	// Variables
-	// the whitespace between the topbar content and its edges
-	--topbar-margin: #{$topbar-margin};
 }
 
 .app-content-wrapper {

--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -142,6 +142,14 @@ export default {
 }
 </script>
 
+<style lang="scss">
+.app-navigation,
+.app-content {
+	/** Distance of the app naviation toggle and the first navigation item to the top edge of the app content container */
+	--app-navigation-padding: #{$app-navigation-padding};
+}
+</style>
+
 <style lang="scss" scoped>
 .app-navigation {
 	// Set scoped variable override
@@ -184,7 +192,7 @@ export default {
 		display: flex;
 		flex-direction: column;
 		gap: var(--default-grid-baseline, 4px);
-		padding: calc(var(--default-grid-baseline, 4px) * 2);
+		padding: var(--app-navigation-padding);
 	}
 	&__content {
 		height: 100%;

--- a/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
+++ b/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
@@ -83,8 +83,8 @@ export default {
 
 button.app-navigation-toggle {
 	position: absolute;
-	top: $topbar-margin;
-	right: - $topbar-margin;
+	top: var(--app-navigation-padding);
+	right: calc(0px - var(--app-navigation-padding));
 	margin-right: - $clickable-area;
 }
 


### PR DESCRIPTION
Currently the toggle is set at `4px` while the app navigation items are placed at `8px` (using that variable), this looks slightly displaced.

So this PR moves the padding calculation into a variable and uses the variable for the toggle (besides the navigation items).

**Before / Currently:**
![toggle slightly misplaced](https://user-images.githubusercontent.com/1855448/191350997-a93e293f-8031-4863-af1d-20166d4ab626.png)

**After / This PR:**
![Toggle centered](https://user-images.githubusercontent.com/1855448/191351105-1a5fe899-134e-4b32-b1ac-6490cf71339d.png)
