### PR TITLE
Vue 3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,7 @@
 export * from './components/index.js'
 
 export * from './composables/index.js'
-// Not yet adjusted for vue3
-// export * from './functions/index.js'
+export * from './functions/index.js'
 export * from './directives/index.js'
 export * from './mixins/index.js'
 

--- a/src/utils/ValidateChildren.js
+++ b/src/utils/ValidateChildren.js
@@ -19,7 +19,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import Vue from 'vue'
+import { warn } from 'vue'
 
 /**
  * Validate children of a vue component
@@ -38,7 +38,7 @@ const ValidateChildren = (vm, allowed) => {
 		// that you import  with import myActionWrapper from 'myActionWrapper'
 		if (!(isChildren || isWrappedChildren)) {
 			// warn
-			Vue.util.warn(`${child.$options.name} is not allowed inside the ${vm.$options.name} component`, vm)
+			warn(`${child.$options.name} is not allowed inside the ${vm.$options.name} component`, vm)
 
 			// cleanup
 			vm.$children.splice(index, 1)

--- a/src/utils/ValidateSlot.js
+++ b/src/utils/ValidateSlot.js
@@ -19,7 +19,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import Vue from 'vue'
+import { warn } from 'vue'
 
 /**
  * Validate children of a vue component
@@ -45,7 +45,7 @@ const ValidateSlot = (slots, allowed, vm) => {
 			// only warn when html elment or forbidden component
 			// sometimes text nodes are present which are hardly removeable by the developer and spam the warnings
 			if (isHtmlElement || isForbiddenComponent) {
-				Vue.util.warn(`${isHtmlElement ? node.tag : node.componentOptions.tag} is not allowed inside the ${vm.$options.name} component`, vm)
+				warn(`${isHtmlElement ? node.tag : node.componentOptions.tag} is not allowed inside the ${vm.$options.name} component`, vm)
 			}
 
 			// cleanup


### PR DESCRIPTION
This PR aims at migrating all components to vue3.

Known issues:
- [x] Rendering markdown with `NcRichText` does not work
- [ ] There is no vue3 compatible release of `@nextcloud/vue-select` yet

Breaking changes:
- Requires the app to use vue3
- The `exact` prop of `NcAppNavigationItem`, `NcBreadcrumb`, `NcButton` and `NcListItem` components is removed as vue-router 4 does not support it anymore

Compiling the Tasks apps [vue3](https://github.com/nextcloud/tasks/tree/vue3) branch from https://github.com/nextcloud/tasks/pull/1971 together with this PR here already gives a fully working app. See here:
![Screenshot 2023-03-07 at 12-59-11 Aufgaben - Nextcloud](https://user-images.githubusercontent.com/2496460/223415974-76fcde27-4aa7-4c7e-bdc5-51668d30ffa1.png)

