### PR TITLE
Implement slot for title in ListItem

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -84,6 +84,12 @@
 			<template #icon>
 				<NcAvatar :size="44" user="janedoe" display-name="Jane Doe" />
 			</template>
+			<template #title>
+				<span style="display: flex; color: var(--color-primary);">
+					Title of the element with content
+					<div class="icon-edit" />
+				</span>
+			</template>
 			<template #subtitle>
 				In this slot you can put both text and other components such as icons
 			</template>
@@ -169,6 +175,12 @@
 		<template #icon>
 			<div class="icon-edit" />
 		</template>
+		<template #title>
+			<span style="display: flex; color: var(--color-primary);">
+				Title of the element with content
+				<div class="icon-edit" />
+			</span>
+		</template>
 		<template #subtitle>
 			This one is with subtitle
 		</template>
@@ -230,7 +242,8 @@
 						<!-- First line, title and details -->
 						<div class="line-one">
 							<span class="line-one__title">
-								{{ title }}
+								<!-- @slot Slot for the first line of the component. prop 'title' is a fallback if no slots provided -->
+								<slot name="title">{{ title }}</slot>
 							</span>
 							<span v-if="showDetails"
 								class="line-one__details">
@@ -596,6 +609,7 @@ export default {
 
 // NcListItem
 .list-item {
+	box-sizing: border-box;
 	display: block;
 	position: relative;
 	flex: 0 0 auto;


### PR DESCRIPTION
Signed-off-by: Maksim Sukharev <antreesy.web@gmail.com>

## Problem
Right now there is no stable opportunity to manipulate 'Title' sub-component (see issues and PR below) - only through the access to DOM element via `querySelector` or using `:deep` selector for scoped styles.

**Related:**
- https://github.com/nextcloud/nextcloud-vue/issues/3687
- https://github.com/nextcloud/spreed/pull/8605

## Proposal
Add the ability to integrate a developer-controlled sub-component via Vue `slot`. Proposed solution should not affect current realisations, because required prop `title` is provided as a fallback for slot.

![image](https://user-images.githubusercontent.com/93392545/216314544-fa4342a2-f833-477f-b9a3-b2e6e7705976.png)
- [x] Examples for documentation is provided


## :warning:  IMPORTANT
`.list-item` selector doesn't inherit `box-sizing: border-box` by default (If NcContent is not used). Fixed by this PR.