### PR TITLE
Lazy load NcDatetimePicker in NcActionInput

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -245,7 +245,7 @@ For the multiselect component, all events will be passed through. Please see the
 </template>
 
 <script>
-import NcDatetimePicker from '../NcDatetimePicker/index.js'
+const NcDatetimePicker = () => import('../NcDatetimePicker/index.js')
 import NcDateTimePickerNative from '../NcDateTimePickerNative/index.js'
 import NcPasswordField from '../NcPasswordField/index.js'
 import NcSelect from '../NcSelect/index.js'


### PR DESCRIPTION
Mostly for discussion at the current stage. Related https://github.com/nextcloud/server/pull/38329

`NcDatetimePicker` depends on `NcTimezonePicker`, which in turn depends on `@nextcloud/calendar-js`, which makes it bundle unnecessarily large. One solution is to lazy load this particular component only if needed.