### PR TITLE
Feature: Add visible inner label for `NcInputField`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
   - `label` property was renamed to `name` for `NcMentionBubble`
   - `name` propery is now required for `NcActions*`, `NcAppNavigationItem` and `NcBreadcrumb*`
   - See linked pull request for full migration guide
+- `NcInputField`: The `labelVisible` property was removed for accessibility it is required to always show a label.
+  You can still use the `labelOutside` property to remove the inner label from the component.
 
 ### :rocket: Enhancements
 - enh\(NcDatetime\): New component for displaying timestamps as time relative from now [\#4219](https://github.com/nextcloud-libraries/nextcloud-vue/pull/4219) ([susnux](https://github.com/susnux))

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -23,6 +23,10 @@
 
 <docs>
 This component is made to be used inside of the [NcActions](#NcActions) component slots.
+
+It is recommended to not only provide a placeholder, but also a label.
+The label should describe what input is expected and the placehold what format the input should have.
+
 All undocumented attributes will be bound to the input, the datepicker or the select component, e.g. `maxlength`, `not-before`.
 For the `NcSelect` component, all events will be passed through. Please see the `NcSelect` component's documentation for more details and examples.
 ```vue
@@ -33,18 +37,18 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 					<Pencil :size="20" />
 				</template>
 			</NcActionInput>
-			<NcActionInput :value.sync="text" :show-trailing-button="false">
+			<NcActionInput :value.sync="text" :show-trailing-button="false" label="Input without trailing button">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
 			</NcActionInput>
-			<NcActionInput :value.sync="text">
+			<NcActionInput :value.sync="text" label="Input with placeholder">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
 				This is the placeholder
 			</NcActionInput>
-			<NcActionInput type="password" :value.sync="text">
+			<NcActionInput type="password" :value.sync="text" label="Password with visible label">
 				<template #icon>
 					<Key :size="20" />
 				</template>
@@ -56,7 +60,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				</template>
 				Password placeholder
 			</NcActionInput>
-			<NcActionInput type="color" :value.sync="color">
+			<NcActionInput type="color" :value.sync="color" label="Favorite color">
 				<template #icon>
 					<Eyedropper :size="20" />
 				</template>
@@ -68,7 +72,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				</template>
 				Input with visible label
 			</NcActionInput>
-			<NcActionInput :disabled="true" value="This is a disabled input">
+			<NcActionInput :disabled="true" label="This is a disabled input">
 				<template #icon>
 					<Close :size="20" />
 				</template>
@@ -157,6 +161,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				<NcDatetimePicker v-if="datePickerType"
 					ref="datetimepicker"
 					:value="value"
+					style="z-index: 99999999999;"
 					:placeholder="text"
 					:disabled="disabled"
 					:type="datePickerType"
@@ -186,59 +191,60 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 					v-bind="$attrs"
 					v-on="$listeners" />
 
-				<template v-else>
-					<div class="action-input__container">
-						<label v-if="label"
-							class="action-input__text-label"
-							:class="{ 'action-input__text-label--hidden': !labelVisible }"
-							:for="inputId">
-							{{ label }}
-						</label>
-						<div class="action-input__input-container">
-							<NcPasswordField v-if="type==='password'"
-								:id="inputId"
-								:value="value"
-								:label="text"
-								:disabled="disabled"
-								:input-class="{ focusable: isFocusable }"
-								trailing-button-icon="arrowRight"
-								:show-trailing-button="showTrailingButton && !disabled"
-								v-bind="$attrs"
-								v-on="$listeners"
-								@trailing-button-click="$refs.form.requestSubmit()"
-								@input="onInput"
-								@change="onChange" />
+				<NcPasswordField v-else-if="type==='password'"
+					:id="inputId"
+					:value="value"
+					:label="label"
+					:label-outside="!label"
+					:placeholder="text"
+					:disabled="disabled"
+					:input-class="{ focusable: isFocusable }"
+					trailing-button-icon="arrowRight"
+					:show-trailing-button="showTrailingButton && !disabled"
+					v-bind="$attrs"
+					v-on="$listeners"
+					@trailing-button-click="$refs.form.requestSubmit()"
+					@input="onInput"
+					@change="onChange" />
 
-							<NcColorPicker v-else-if="type==='color'"
-								:id="inputId"
-								:value="value"
-								class="colorpicker__trigger"
-								v-bind="$attrs"
-								v-on="$listeners"
-								@input="onInput"
-								@submit="$refs.form.requestSubmit()">
-								<button :style="{'background-color': value}"
-									class="colorpicker__preview"
-									:class="{ focusable: isFocusable }" />
-							</NcColorPicker>
-
-							<NcTextField v-else
-								:id="inputId"
-								:value="value"
-								:label="text"
-								:disabled="disabled"
-								:input-class="{ focusable: isFocusable }"
-								:type="type"
-								trailing-button-icon="arrowRight"
-								:show-trailing-button="showTrailingButton && !disabled"
-								v-bind="$attrs"
-								v-on="$listeners"
-								@trailing-button-click="$refs.form.requestSubmit()"
-								@input="onInput"
-								@change="onChange" />
-						</div>
+				<div v-else-if="type === 'color'" class="action-input__container">
+					<label v-if="label && type === 'color'"
+						class="action-input__text-label"
+						:class="{ 'action-input__text-label--hidden': !labelVisible }"
+						:for="inputId">
+						{{ label }}
+					</label>
+					<div class="action-input__input-container">
+						<NcColorPicker id="inputId"
+							:value="value"
+							class="colorpicker__trigger"
+							v-bind="$attrs"
+							v-on="$listeners"
+							@input="onInput"
+							@submit="$refs.form.requestSubmit()">
+							<button :style="{'background-color': value}"
+								class="colorpicker__preview"
+								:class="{ focusable: isFocusable }" />
+						</NcColorPicker>
 					</div>
-				</template>
+				</div>
+
+				<NcTextField v-else
+					:id="inputId"
+					:value="value"
+					:label="label"
+					:label-outside="!label"
+					:placeholder="text"
+					:disabled="disabled"
+					:input-class="{ focusable: isFocusable }"
+					:type="type"
+					trailing-button-icon="arrowRight"
+					:show-trailing-button="showTrailingButton && !disabled"
+					v-bind="$attrs"
+					v-on="$listeners"
+					@trailing-button-click="$refs.form.requestSubmit()"
+					@input="onInput"
+					@change="onChange" />
 			</form>
 		</span>
 	</li>

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -377,6 +377,16 @@ export default {
 			opacity: 0;
 		}
 
+		// Align label text color with border color
+		&:not(:placeholder-shown) + .input-field__label {
+			color: var(--color-text-maxcontrast);
+		}
+
+		&:focus + .input-field__label,
+		&:hover:not(&--success, &--error):not(:placeholder-shown) + .input-field__label {
+			color: var(--color-primary-element);
+		}
+
 		&:focus {
 			cursor: text;
 		}
@@ -394,12 +404,24 @@ export default {
 			&:focus-visible {
 				box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px
 			}
+
+			// Align label text color with border color
+			&:focus + .input-field__label,
+			&:hover:not(:placeholder-shown) + .input-field__label {
+				color: var(--color-success-text);
+			}
 		}
 
 		&--error {
 			border-color: var(--color-error) !important; //Override hover border color
 			&:focus-visible {
 				box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px
+			}
+
+			// Align label text color with border color
+			&:focus + .input-field__label,
+			&:hover:not(:placeholder-shown) + .input-field__label {
+				color: var(--color-error-text);
 			}
 		}
 
@@ -444,32 +466,6 @@ export default {
 	&__input:not(:placeholder-shown) + &__label {
 		inset-block-start: -4px;
 		font-size: 13px; // minimum allowed font size for accessibility
-	}
-
-	// Align label text color with border color
-	&__input {
-		&:not(:placeholder-shown) + .input-field__label {
-			color: var(--color-text-maxcontrast);
-		}
-
-		&:focus + .input-field__label,
-		&:hover:not(&--success, &--error):not(:placeholder-shown) + .input-field__label {
-			color: var(--color-primary-element);
-		}
-
-		&--success {
-			&:focus + .input-field__label,
-			&:hover:not(:placeholder-shown) + .input-field__label {
-				color: var(--color-success-text);
-			}
-		}
-
-		&--error {
-			&:focus + .input-field__label,
-			&:hover:not(:placeholder-shown) + .input-field__label {
-				color: var(--color-error-text);
-			}
-		}
 	}
 
 	&__icon {

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -33,23 +33,25 @@ General purpose password field component.
 			label="Old password" />
 		<div class="external-label">
 			<label for="textField">New password</label>
-			<NcPasswordField :value.sync="text2"
-				id="textField"
-				:label-outside="true" />
+			<NcPasswordField id="textField"
+				:value.sync="text2"
+				:label-outside="true"
+				placeholder="Min. 12 characters" />
 		</div>
 		<div class="external-label">
 			<label for="textField2">New password</label>
-			<NcPasswordField :value.sync="text3"
+			<NcPasswordField id="textField2"
+				:value.sync="text3"
 				:error="true"
-				id="textField2"
 				:label-outside="true"
+				placeholder="Min. 12 characters"
 				helper-text="Password is insecure" />
 		</div>
 
 		<NcPasswordField :value.sync="text4"
 			label="Good new password"
-			:label-visible="true"
 			:success="true"
+			placeholder="Min. 12 characters"
 			helper-text="Password is secure" />
 
 		<NcPasswordField :value.sync="text5"

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -24,6 +24,9 @@
 See [NcInputField](#/Components/NcFields?id=ncinputfield) for a list of all available props.
 
 General purpose text field component.
+It is recommended to not only provide a placeholder, but also a label.
+The label should describe what input is expected and the placehold what format the input should have.
+
 Note: the inner html `input` element inherits all the attributes from the
 NcTextField component so you can add things like `autocomplete`, `maxlength`
 and `minlength`.
@@ -36,32 +39,39 @@ and `minlength`.
 			trailing-button-icon="close"
 			:show-trailing-button="text1 !== ''"
 			@trailing-button-click="clearText">
-			<Magnify :size="16" />
+			<Magnify :size="20" />
+		</NcTextField>
+		<NcTextField :value.sync="text4"
+			label="Internal label"
+			placeholder="That can be used together with placeholder"
+			trailing-button-icon="close"
+			:show-trailing-button="text4 !== ''"
+			@trailing-button-click="clearText">
+			<Lock :size="20" />
 		</NcTextField>
 		<NcTextField :value.sync="text2"
 			label="Success state"
+			placeholder="Placeholders are possible"
 			:success="true"
 			@trailing-button-click="clearText">
 		</NcTextField>
 		<NcTextField :value.sync="text3"
 			label="Error state"
+			placeholder="Enter something valid"
 			:error="true"
 			@trailing-button-click="clearText">
 		</NcTextField>
-		<NcTextField :value.sync="text4"
-			label="Internal label"
-			placeholder="That can be used together with placeholder"
-			:label-visible="true"
-			trailing-button-icon="close"
-			:show-trailing-button="text4 !== ''"
-			@trailing-button-click="clearText">
-			<Lock :size="16" />
-		</NcTextField>
+		<NcTextField label="Disabled"
+			:disabled="true" />
+		<NcTextField label="Disabled + Success"
+			:success="true"
+			:disabled="true" />
 		<div class="external-label">
 			<label for="textField">External label</label>
 			<NcTextField :value.sync="text5"
 				id="textField"
 				:label-outside="true"
+				placeholder="Input with external label"
 				@trailing-button-click="clearText" />
 		</div>
 	</div>


### PR DESCRIPTION
### ☑️ Resolves

* Resolves #4126 

The inner label is now visible, to disable any label set `label-outside` to true, `label-visible` property is removed.
The label is shown instead of the placeholder if the input is empty and not focused, when focused the label is moved up and scaled but always shown.

Also the action input is adjusted for this change.

### 🖼️ Screenshots

#### NcInputField
![new](https://github.com/nextcloud/nextcloud-vue/assets/1855448/320a0525-344e-4d70-a11e-3c6cafa0d50d)

#### NcActionInput
![new-action](https://github.com/nextcloud/nextcloud-vue/assets/1855448/dee2f03d-8560-4bdb-8186-416374d400db)


### 🚧 Tasks

- Maybe adjust the datetime picker to this changes in a followup, @nextcloud/designers ?

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
