### PR TITLE
fix(NcModal): prev/next color and sizing fix

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -882,11 +882,13 @@ export default {
 		z-index: 10000;
 		// ignore display: none
 		display: flex !important;
-		height: 35vw;
+		height: 35vh;
+		min-height: 300px;
 		position: absolute;
 		transition: opacity 250ms,
 			visibility 250ms;
-		color: var(--color-primary-element-text);
+		// hover the mask
+		color: white;
 
 		&:focus-visible {
 			// Override NcButton focus styles


### PR DESCRIPTION
| Before | After |
|:---------:|:------:|
|![2023-07-27_21-30_1](https://github.com/nextcloud/nextcloud-vue/assets/14975046/b0c719c4-0fcd-4119-981f-39cc71e1c2fa)|![2023-07-27_21-30](https://github.com/nextcloud/nextcloud-vue/assets/14975046/5b85c12c-ad84-47f3-b657-47a060a9e39d)|