### PR TITLE
Feature: Add visible inner label for `NcInputField` on border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
   - `name` propery is now required for `NcActions*`, `NcAppNavigationItem` and `NcBreadcrumb*`
   - See linked pull request for full migration guide
 - chore: Drop `install` entry point and replace it with an Vue Plugin [\#4349](https://github.com/nextcloud-libraries/nextcloud-vue/pull/4349) ([susnux](https://github.com/susnux))
+- `NcInputField`: The `labelVisible` property was removed for accessibility it is required to always show a label.
+  You can still use the `labelOutside` property to remove the inner label from the component.
 
 ### :rocket: Enhancements
 - enh\(NcDatetime\): New component for displaying timestamps as time relative from now [\#4219](https://github.com/nextcloud-libraries/nextcloud-vue/pull/4219) ([susnux](https://github.com/susnux))

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -23,6 +23,10 @@
 
 <docs>
 This component is made to be used inside of the [NcActions](#NcActions) component slots.
+
+It is recommended to not only provide a placeholder, but also a label.
+The label should describe what input is expected and the placehold what format the input should have.
+
 All undocumented attributes will be bound to the input, the datepicker or the select component, e.g. `maxlength`, `not-before`.
 For the `NcSelect` component, all events will be passed through. Please see the `NcSelect` component's documentation for more details and examples.
 ```vue
@@ -33,18 +37,18 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 					<Pencil :size="20" />
 				</template>
 			</NcActionInput>
-			<NcActionInput :value.sync="text" :show-trailing-button="false">
+			<NcActionInput :value.sync="text" :show-trailing-button="false" label="Input without trailing button">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
 			</NcActionInput>
-			<NcActionInput :value.sync="text">
+			<NcActionInput :value.sync="text" label="Input with placeholder">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
 				This is the placeholder
 			</NcActionInput>
-			<NcActionInput type="password" :value.sync="text">
+			<NcActionInput type="password" :value.sync="text" label="Password with visible label">
 				<template #icon>
 					<Key :size="20" />
 				</template>
@@ -56,7 +60,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				</template>
 				Password placeholder
 			</NcActionInput>
-			<NcActionInput type="color" :value.sync="color">
+			<NcActionInput type="color" :value.sync="color" label="Favorite color">
 				<template #icon>
 					<Eyedropper :size="20" />
 				</template>
@@ -68,7 +72,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				</template>
 				Input with visible label
 			</NcActionInput>
-			<NcActionInput :disabled="true" value="This is a disabled input">
+			<NcActionInput :disabled="true" label="This is a disabled input">
 				<template #icon>
 					<Close :size="20" />
 				</template>
@@ -157,6 +161,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				<NcDatetimePicker v-if="datePickerType"
 					ref="datetimepicker"
 					:value="value"
+					style="z-index: 99999999999;"
 					:placeholder="text"
 					:disabled="disabled"
 					:type="datePickerType"
@@ -186,59 +191,60 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 					v-bind="$attrs"
 					v-on="$listeners" />
 
-				<template v-else>
-					<div class="action-input__container">
-						<label v-if="label"
-							class="action-input__text-label"
-							:class="{ 'action-input__text-label--hidden': !labelVisible }"
-							:for="inputId">
-							{{ label }}
-						</label>
-						<div class="action-input__input-container">
-							<NcPasswordField v-if="type==='password'"
-								:id="inputId"
-								:value="value"
-								:label="text"
-								:disabled="disabled"
-								:input-class="{ focusable: isFocusable }"
-								trailing-button-icon="arrowRight"
-								:show-trailing-button="showTrailingButton && !disabled"
-								v-bind="$attrs"
-								v-on="$listeners"
-								@trailing-button-click="$refs.form.requestSubmit()"
-								@input="onInput"
-								@change="onChange" />
+				<NcPasswordField v-else-if="type==='password'"
+					:id="inputId"
+					:value="value"
+					:label="label"
+					:label-outside="!label"
+					:placeholder="text"
+					:disabled="disabled"
+					:input-class="{ focusable: isFocusable }"
+					trailing-button-icon="arrowRight"
+					:show-trailing-button="showTrailingButton && !disabled"
+					v-bind="$attrs"
+					v-on="$listeners"
+					@trailing-button-click="$refs.form.requestSubmit()"
+					@input="onInput"
+					@change="onChange" />
 
-							<NcColorPicker v-else-if="type==='color'"
-								:id="inputId"
-								:value="value"
-								class="colorpicker__trigger"
-								v-bind="$attrs"
-								v-on="$listeners"
-								@input="onInput"
-								@submit="$refs.form.requestSubmit()">
-								<button :style="{'background-color': value}"
-									class="colorpicker__preview"
-									:class="{ focusable: isFocusable }" />
-							</NcColorPicker>
-
-							<NcTextField v-else
-								:id="inputId"
-								:value="value"
-								:label="text"
-								:disabled="disabled"
-								:input-class="{ focusable: isFocusable }"
-								:type="type"
-								trailing-button-icon="arrowRight"
-								:show-trailing-button="showTrailingButton && !disabled"
-								v-bind="$attrs"
-								v-on="$listeners"
-								@trailing-button-click="$refs.form.requestSubmit()"
-								@input="onInput"
-								@change="onChange" />
-						</div>
+				<div v-else-if="type === 'color'" class="action-input__container">
+					<label v-if="label && type === 'color'"
+						class="action-input__text-label"
+						:class="{ 'action-input__text-label--hidden': !labelVisible }"
+						:for="inputId">
+						{{ label }}
+					</label>
+					<div class="action-input__input-container">
+						<NcColorPicker id="inputId"
+							:value="value"
+							class="colorpicker__trigger"
+							v-bind="$attrs"
+							v-on="$listeners"
+							@input="onInput"
+							@submit="$refs.form.requestSubmit()">
+							<button :style="{'background-color': value}"
+								class="colorpicker__preview"
+								:class="{ focusable: isFocusable }" />
+						</NcColorPicker>
 					</div>
-				</template>
+				</div>
+
+				<NcTextField v-else
+					:id="inputId"
+					:value="value"
+					:label="label"
+					:label-outside="!label"
+					:placeholder="text"
+					:disabled="disabled"
+					:input-class="{ focusable: isFocusable }"
+					:type="type"
+					trailing-button-icon="arrowRight"
+					:show-trailing-button="showTrailingButton && !disabled"
+					v-bind="$attrs"
+					v-on="$listeners"
+					@trailing-button-click="$refs.form.requestSubmit()"
+					@input="onInput"
+					@change="onChange" />
 			</form>
 		</span>
 	</li>

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -33,13 +33,7 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 </docs>
 
 <template>
-	<div class="input-field">
-		<label v-if="!labelOutside && isValidLabel"
-			class="input-field__label"
-			:class="{ 'input-field__label--hidden': !labelVisible }"
-			:for="computedId">
-			{{ label }}
-		</label>
+	<div class="input-field" :class="{ 'input-field--disabled': disabled }">
 		<div class="input-field__main-wrapper">
 			<input v-bind="$attrs"
 				:id="computedId"
@@ -54,12 +48,23 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 					{
 						'input-field__input--trailing-icon': showTrailingButton || hasTrailingIcon,
 						'input-field__input--leading-icon': hasLeadingIcon,
+						'input-field__input--label-outside': labelOutside,
 						'input-field__input--success': success,
 						'input-field__input--error': error,
 					}]"
 				:value="value"
 				v-on="$listeners"
 				@input="handleInput">
+			<!-- Label -->
+			<label v-if="!labelOutside && isValidLabel"
+				class="input-field__label"
+				:class="[{
+					'input-field__label--trailing-icon': showTrailingButton || hasTrailingIcon,
+					'input-field__label--leading-icon': hasLeadingIcon,
+				}]"
+				:for="computedId">
+				{{ label }}
+			</label>
 
 			<!-- Leading icon -->
 			<div v-show="hasLeadingIcon" class="input-field__icon input-field__icon--leading">
@@ -84,8 +89,8 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 			<!-- Success and error icons -->
 			<div v-else-if="success || error"
 				class="input-field__icon input-field__icon--trailing">
-				<Check v-if="success" :size="18" />
-				<AlertCircle v-else-if="error" :size="18" />
+				<Check v-if="success" :size="20" style="color: var(--color-success-text);" />
+				<AlertCircle v-else-if="error" :size="20" style="color: var(--color-error-text);" />
 			</div>
 		</div>
 		<p v-if="helperText.length > 0"
@@ -147,9 +152,9 @@ export default {
 		},
 
 		/**
-		 * The hidden input label for accessibility purposes. This will also
-		 * be used as a placeholder unless the placeholder prop is populated
-		 * with a different string.
+		 * The input label, always provide one for accessibility purposes.
+		 * This will also be used as a placeholder unless the placeholder
+		 * prop is populated with a different string.
 		 */
 		label: {
 			type: String,
@@ -162,16 +167,6 @@ export default {
 		 * this component
 		 */
 		labelOutside: {
-			type: Boolean,
-			default: false,
-		},
-
-		/**
-		 * We normally have the label hidden visually and use it for
-		 * accessibility only. If you want to have the label visible just above
-		 * the input field pass in true to this prop.
-		 */
-		labelVisible: {
 			type: Boolean,
 			default: false,
 		},
@@ -277,11 +272,7 @@ export default {
 		},
 
 		computedPlaceholder() {
-			if (this.labelVisible) {
-				return this.hasPlaceholder ? this.placeholder : ''
-			} else {
-				return this.hasPlaceholder ? this.placeholder : this.label
-			}
+			return this.hasPlaceholder ? this.placeholder : this.label
 		},
 
 		isValidLabel() {
@@ -340,26 +331,40 @@ export default {
 	position: relative;
 	width: 100%;
 	border-radius: var(--border-radius-large);
+	margin-block-start: 6px; // for the label in active state
 
 	&__main-wrapper {
-		height: 36px;
+		height: 38px; // 44px - 6px margin
 		position: relative;
+	}
+
+	&--disabled {
+		opacity: 0.7;
+		filter: saturate(0.7);
 	}
 
 	&__input {
 		margin: 0;
-		padding: 0 12px;
+		padding-inline: 10px 6px; // align with label 8px margin label + 4px padding label - 2px border input
+		height: 38px !important;
+		width: 100%;
+
 		font-size: var(--default-font-size);
+		text-overflow: ellipsis;
+
 		background-color: var(--color-main-background);
 		color: var(--color-main-text);
 		border: 2px solid var(--color-border-maxcontrast);
-		height: 36px !important;
 		border-radius: var(--border-radius-large);
-		text-overflow: ellipsis;
+
 		cursor: pointer;
-		width: 100%;
 		-webkit-appearance: textfield !important;
 		-moz-appearance: textfield !important;
+
+		// Center text if external label is used
+		&--label-outside {
+			padding-block: 0;
+		}
 
 		&:active:not([disabled]),
 		&:hover:not([disabled]),
@@ -367,18 +372,41 @@ export default {
 			border-color: var(--color-primary-element);
 		}
 
+		// Hide placeholder while not focussed -> show label instead (only if internal label is used)
+		&:not(:focus,&--label-outside)::placeholder {
+			opacity: 0;
+		}
+
 		&:focus {
 			cursor: text;
+		}
+
+		&:disabled {
+			cursor: default;
 		}
 
 		&:focus-visible {
 			box-shadow: unset !important; // Override server rules
 		}
 
+		&--leading-icon {
+			padding-inline-start: 32px;
+		}
+
+		&--trailing-icon {
+			padding-inline-end: 32px;
+		}
+
 		&--success {
 			border-color: var(--color-success) !important; //Override hover border color
 			&:focus-visible {
 				box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px
+			}
+
+			// Align label text color with border color (on hover / focus)
+			&:focus + .input-field__label,
+			&:hover:not(:placeholder-shown) + .input-field__label {
+				color: var(--color-success-text);
 			}
 		}
 
@@ -387,28 +415,66 @@ export default {
 			&:focus-visible {
 				box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px
 			}
+
+			// Align label text color with border color (on hover / focus)
+			&:focus + .input-field__label,
+			&:hover:not(:placeholder-shown) + .input-field__label {
+				color: var(--color-error-text);
+			}
 		}
 
-		&--leading-icon {
-			padding-left: 28px;
-		}
-
-		&--trailing-icon {
-			padding-right: 28px;
+		// Align label text color with border color (on hover / focus)
+		&:not(&--success, &--error) {
+			&:focus + .input-field__label,
+			&:hover:not(:placeholder-shown) + .input-field__label {
+				color: var(--color-primary-element);
+			}
 		}
 	}
 
 	&__label {
-		padding: 4px 0;
-		display: block;
+		position: absolute;
+		margin-inline: 12px 0;
+		// fix height and line height to center label
+		height: 17px;
+		max-width: fit-content;
+		line-height: 1;
+		inset-block-start: 12px;
+		inset-inline: 0;
+		// Fix color so that users do not think the input already has content
+		color: var(--color-text-maxcontrast);
+		// only one line labels are allowed
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		// forward events to input
+		pointer-events: none;
+		// Position transition
+		transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick), background-color var(--animation-quick) var(--animation-slow);
 
-		&--hidden {
-			position: absolute;
-			left: -10000px;
-			top: auto;
-			width: 1px;
-			height: 1px;
-			overflow: hidden;
+		&--leading-icon {
+			// 32px icon + 2px border
+			margin-inline-start: 34px;
+		}
+
+		&--trailing-icon {
+			// 32px icon + 2px border
+			margin-inline-end: 34px;
+		}
+	}
+
+	&__input:focus + &__label,
+	&__input:not(:placeholder-shown) + &__label {
+		inset-block-start: -6px;
+		font-size: 13px; // minimum allowed font size for accessibility
+		background-color: var(--color-main-background);
+		height: 14px;
+		padding-inline: 4px;
+		margin-inline-start: 8px;
+
+		transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick);
+		&--leading-icon {
+			margin-inline-start: 30px;
 		}
 	}
 
@@ -420,21 +486,22 @@ export default {
 		align-items: center;
 		justify-content: center;
 		opacity: 0.7;
+
 		&--leading {
-			bottom: 2px;
-			left: 2px;
+			inset-block-end: 3px;
+			inset-inline-start: 2px;
 		}
 
 		&--trailing {
-			bottom: 2px;
-			right: 2px;
+			inset-block-end: 3px;
+			inset-inline-end: 2px;
 		}
 	}
 
 	&__clear-button.button-vue {
 		position: absolute;
-		top: 2px;
-		right: 1px;
+		inset-block-end: 3px;
+		inset-inline-end: 2px;
 		min-width: unset;
 		min-height: unset;
 		height: 32px;
@@ -443,14 +510,12 @@ export default {
 	}
 
 	&__helper-text-message {
-		padding: 4px 0;
+		padding-block: 4px;
 		display: flex;
 		align-items: center;
 
 		&__icon {
-			margin-right: 8px;
-			align-self: start;
-			margin-top: 4px;
+			margin-inline-end: 8px;
 		}
 
 		&--error {

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -33,23 +33,25 @@ General purpose password field component.
 			label="Old password" />
 		<div class="external-label">
 			<label for="textField">New password</label>
-			<NcPasswordField :value.sync="text2"
-				id="textField"
-				:label-outside="true" />
+			<NcPasswordField id="textField"
+				:value.sync="text2"
+				:label-outside="true"
+				placeholder="Min. 12 characters" />
 		</div>
 		<div class="external-label">
 			<label for="textField2">New password</label>
-			<NcPasswordField :value.sync="text3"
+			<NcPasswordField id="textField2"
+				:value.sync="text3"
 				:error="true"
-				id="textField2"
 				:label-outside="true"
+				placeholder="Min. 12 characters"
 				helper-text="Password is insecure" />
 		</div>
 
 		<NcPasswordField :value.sync="text4"
 			label="Good new password"
-			:label-visible="true"
 			:success="true"
+			placeholder="Min. 12 characters"
 			helper-text="Password is secure" />
 
 		<NcPasswordField :value.sync="text5"

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -24,6 +24,9 @@
 See [NcInputField](#/Components/NcFields?id=ncinputfield) for a list of all available props.
 
 General purpose text field component.
+It is recommended to not only provide a placeholder, but also a label.
+The label should describe what input is expected and the placehold what format the input should have.
+
 Note: the inner html `input` element inherits all the attributes from the
 NcTextField component so you can add things like `autocomplete`, `maxlength`
 and `minlength`.
@@ -36,32 +39,39 @@ and `minlength`.
 			trailing-button-icon="close"
 			:show-trailing-button="text1 !== ''"
 			@trailing-button-click="clearText">
-			<Magnify :size="16" />
+			<Magnify :size="20" />
+		</NcTextField>
+		<NcTextField :value.sync="text4"
+			label="Internal label"
+			placeholder="That can be used together with placeholder"
+			trailing-button-icon="close"
+			:show-trailing-button="text4 !== ''"
+			@trailing-button-click="clearText">
+			<Lock :size="20" />
 		</NcTextField>
 		<NcTextField :value.sync="text2"
 			label="Success state"
+			placeholder="Placeholders are possible"
 			:success="true"
 			@trailing-button-click="clearText">
 		</NcTextField>
 		<NcTextField :value.sync="text3"
 			label="Error state"
+			placeholder="Enter something valid"
 			:error="true"
 			@trailing-button-click="clearText">
 		</NcTextField>
-		<NcTextField :value.sync="text4"
-			label="Internal label"
-			placeholder="That can be used together with placeholder"
-			:label-visible="true"
-			trailing-button-icon="close"
-			:show-trailing-button="text4 !== ''"
-			@trailing-button-click="clearText">
-			<Lock :size="16" />
-		</NcTextField>
+		<NcTextField label="Disabled"
+			:disabled="true" />
+		<NcTextField label="Disabled + Success"
+			:success="true"
+			:disabled="true" />
 		<div class="external-label">
 			<label for="textField">External label</label>
 			<NcTextField :value.sync="text5"
 				id="textField"
 				:label-outside="true"
+				placeholder="Input with external label"
 				@trailing-button-click="clearText" />
 		</div>
 	</div>


### PR DESCRIPTION
### ☑️ Resolves

Alternative to #4287 as requested by @marcoambrosini 

### 🖼️ Screenshots

https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/20b1cb4e-9f5a-4e27-98c5-b3cc4a9e2124

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
