### PR TITLE
fix: remove NcMultiselect from styleguide config

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -180,12 +180,6 @@ module.exports = async () => {
 						],
 					},
 					{
-						name: 'NcMultiselect',
-						components: [
-							'src/components/NcMultiselect*/*.vue',
-						],
-					},
-					{
 						name: 'NcPickers',
 						components: [
 							'src/components/Nc*Picker*/*.vue',


### PR DESCRIPTION
The `NcMultiselect` component was removed from the library, this PR removes its leftover from the styleguide config.