### PR TITLE
Fix modal focus trap with additional elements and arrow navigation

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -616,18 +616,26 @@ export default {
 			}
 		},
 
-		// Key Handlers
-		handleKeydown(e) {
-			switch (e.keyCode) {
-			case 37: // left arrow
-				this.previous(e)
-				break
-			case 39: // right arrow
-				this.next(e)
-				break
-			case 27: // escape key
-				this.close(e)
-				break
+		/**
+		 * @param {KeyboardEvent} event - keyboard event
+		 */
+		handleKeydown(event) {
+			if (event.key === 'Escape') {
+				return this.close(event)
+			}
+
+			const arrowHandlers = {
+				ArrowLeft: this.previous,
+				ArrowRight: this.next,
+			}
+			if (arrowHandlers[event.key]) {
+				// Ignore arrow navigation, if there is a current focus outside the modal.
+				// For example, when the focus is in Sidebar or NcActions's items,
+				// arrow navigation should not be intercept by modal slider
+				if (document.activeElement && !this.$el.contains(document.activeElement)) {
+					return
+				}
+				return arrowHandlers[event.key](event)
 			}
 		},
 
@@ -714,6 +722,9 @@ export default {
 				allowOutsideClick: true,
 				fallbackFocus: contentContainer,
 				trapStack: getTrapStack(),
+				// Esc can be used without stop in content or additionalTrapElements where it should not deacxtivate modal's focus trap.
+				// Focus trap is deactivated on modal close anyway.
+				escapeDeactivates: false,
 			}
 
 			// Init focus trap

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -717,7 +717,7 @@ export default {
 			}
 
 			// Init focus trap
-			this.focusTrap = createFocusTrap(contentContainer, options)
+			this.focusTrap = createFocusTrap([contentContainer, ...this.additionalTrapElements], options)
 			this.focusTrap.activate()
 		},
 		clearFocusTrap() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/39415

Two problems with focus trap break navigation with modal.

**Problem 1:** When Viewer is opened with sidebar, focus on the sidebar is not possible
Source: `additionalTrapElements` are not used on init but only on change. 

**Problem 2:** `NcModal` intercept arrow navigation for slider (next/prev)

### 🖼️ Screenshots

#### 🏚️ Before

https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/abd9cf42-73bc-4cae-be4f-ebd49bb2b656

https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/cae07f32-b44b-42c6-bb40-ee3dac0e59a5

#### 🏡 After

https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/7bea1fb3-4618-486a-ab83-6bca3374ad2c

### 🚧 Tasks

- [x] Also use `additionalTrapElements` on init
- [x] On keyboard navigation handler check if there is an active element. 
  - If there is an element and it's outside the modal, then it is
    - either element from `additionalTrapElements`
    - or some pop over element like emoji picker or nc actions that also have its own navigation
  - **Alternative solution:** always disable arrow navigation if there is an active element

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
