### PR TITLE
fix(NcRichContenteditable): add aria-placeholder

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -157,6 +157,7 @@ export default {
 		}"
 		:contenteditable="canEdit"
 		:placeholder="placeholder"
+		:aria-placeholder="placeholder"
 		aria-multiline="true"
 		class="rich-contenteditable__input"
 		role="textbox"

--- a/tests/unit/components/NcRichContenteditable/NcRichContenteditable.spec.js
+++ b/tests/unit/components/NcRichContenteditable/NcRichContenteditable.spec.js
@@ -118,4 +118,17 @@ describe('NcRichContenteditable', () => {
 		expect(handlers.paste).toHaveBeenCalledTimes(1)
 		expect(handlers.blur).toHaveBeenCalledTimes(1)
 	})
+
+	it('should has accessible placeholder from placeholder prop', async () => {
+		const PLACEHOLDER = 'TEST_PLACEHOLDER'
+		const { wrapper } = mountNcRichContenteditable({
+			propsData: {
+				placeholder: PLACEHOLDER,
+			},
+		})
+		// Accessible placeholder
+		expect(wrapper.attributes('aria-placeholder')).toBe(PLACEHOLDER)
+		// Used in CSS for visible placeholder
+		expect(wrapper.attributes('placeholder')).toBe(PLACEHOLDER)
+	})
 })


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/37087

**The solution in this PR is different from the suggestion in the linked issue.**

Using `aria-describedby` requires a layout update, adding a wrapper element for `NcRichContenteditable` with the `div[contenteditable]` itself and a new visually hidden describing element. Though the layout of the element is not a part of its public interface, I think developers expect the component to be a directly `contenteditable` element and I prefer to keep current simple layout as long as it's possible.

A good and very simple alternative solution IMO is [`aria-placeholder`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder).

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/93f241de-2432-4306-a0de-0607e0061b02) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/fdf82881-203c-4f76-af67-c10bf07f7a37)


### 🚧 Tasks

- [x] Add `aria-placeholder`

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
