### PR TITLE
fix(NcRichContenteditable): make the default placeholder short

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -265,5 +265,5 @@ msgstr ""
 msgid "Undo changes"
 msgstr ""
 
-msgid "Write message, use \"@\" to mention someone, use \":\" for emoji autocompletion …"
+msgid "Write a message …"
 msgstr ""

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -35,7 +35,6 @@ This component displays contenteditable div with automated `@` [at] autocompleti
 			:auto-complete="autoComplete"
 			:maxlength="100"
 			:user-data="userData"
-			placeholder="Try mentioning user @Test01 or inserting emoji :smile"
 			@submit="onSubmit" />
 		<br>
 
@@ -45,7 +44,6 @@ This component displays contenteditable div with automated `@` [at] autocompleti
 			:maxlength="400"
 			:multiline="true"
 			:user-data="userData"
-			placeholder="Try mentioning user @Test01 or inserting emoji :smile"
 			@submit="onSubmit" />
 
 		<h5>Output - raw</h5>
@@ -222,7 +220,7 @@ export default {
 
 		placeholder: {
 			type: String,
-			default: t('Write message, use "@" to mention someone, use ":" for emoji autocompletion …'),
+			default: t('Write a message …'),
 		},
 
 		autoComplete: {


### PR DESCRIPTION
### ☑️ Resolves

* A part of fixing https://github.com/nextcloud/server/issues/37087
* Used in https://github.com/nextcloud/server/pull/40294
* Alternative to https://github.com/nextcloud-libraries/nextcloud-vue/pull/4482

The default placeholder is very long, because it is not a placeholder, but a description with instructions of using the input.

This PR proposes to remove the instruction from the default placeholder.

In case of merging this PR we need to find a way to explain users what they can do with the input at least with user documentation.

See discussion in the issue.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/90f9a592-2b8e-4277-a3c4-ff9679188328) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d3dcada4-6cb0-4a93-bd7e-ec99bed062a2)


### 🚧 Tasks

- [x] Make the default placeholder short

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
