### PR TITLE
fix: build module on dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "author": "John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>",
   "license": "AGPL-3.0",
   "scripts": {
-    "dev": "webpack --node-env development --progress",
+    "dev": "webpack --node-env development --progress && npm run dev:module",
+    "dev:module": "vite build --mode development",
     "watch": "webpack --node-env development --progress --watch",
     "watch:module": "vite build --mode development --watch",
     "build": "webpack --node-env production --progress && npm run build:module",


### PR DESCRIPTION
### ☑️ Resolves

This adds a build step to build the module in development mode. Before, `npm run dev` would not build the module, preventing the library from being used, e.g. via `npm link` while developing.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
