### PR TITLE
fix(build): Replaced `SCOPE_VERSION` variable need to be stringified

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -70,7 +70,7 @@ export default defineConfig((env) => {
 		libraryFormats: ['es', 'cjs'],
 		replace: {
 			PRODUCTION: JSON.stringify(env.mode === 'production'),
-			SCOPE_VERSION,
+			SCOPE_VERSION: JSON.stringify(SCOPE_VERSION),
 			TRANSLATIONS: ';' + JSON.stringify(TRANSLATIONS),
 		},
 	})


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud-libraries/nextcloud-vue/pull/4428#issuecomment-1681039520

Without this the `SCOPE_VERSION` is interpreted as octal number (because the md5 hash generated from version `8.0.0-beta.3` starts with 0.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
