### PR TITLE
Fix contrast for selected item

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1018,6 +1018,8 @@ body {
 	.vs__selected {
 		min-height: 36px;
 		padding: 0 0.5em;
+		border: 2px var(--vs-selected-border-style) var(--color-border-maxcontrast)!important;
+		border-radius: calc(var(--vs-border-radius) - 4px)!important;
 	}
 
 	.vs__clear {


### PR DESCRIPTION
### ☑️ Resolves

* Fixes part of https://github.com/nextcloud/server/issues/36980 regarding "the keyboard focus in the list is not noticeable.", see https://github.com/nextcloud/server/issues/36980#issuecomment-1669768669

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/server/assets/25978914/abc6c920-ee81-4725-b019-40cdaeb9b106) | ![Peek 2023-08-17 13-37](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/e963558d-74a3-4cab-a316-0a5ccca7ca73)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
