### PR TITLE
fix: `exports` field of package used deprecated syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./dist/": "./dist/"
+    "./dist/*": "./dist/*"
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
### ☑️ Resolves
Fixes eslint issues of libraries using the package like:
> "@nextcloud/vue/dist/Components/NcButton.js" is not found        n/no-missing-import

Using directory exports is deprecated since Node 14, instead wildcard exports should be used.
This causes eslint-plugin-n to fail because it does not support the deprecated syntax.

See server PR as example of failing lint: https://github.com/nextcloud/server/actions/runs/5908640226/job/16028330790?pr=39970

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
