### PR TITLE
fix(`NcListItem`) - remove empty wrapper for additional elements from DOM if not needed

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -251,7 +251,9 @@
 								</span>
 
 								<!-- Counter and indicator -->
-								<span v-if="showAdditionalElements" class="line-two__additional_elements">
+								<span v-if="counterNumber != 0 || hasIndicator"
+									v-show="showAdditionalElements"
+									class="line-two__additional_elements">
 									<NcCounterBubble v-if="counterNumber != 0"
 										class="line-two__counter"
 										:type="counterType">
@@ -407,7 +409,7 @@ export default {
 		},
 
 		/**
-		 * If different from from 0 this component will display the
+		 * If different from 0 this component will display the
 		 * NcCounterBubble component
 		 */
 		 counterNumber: {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #nextcloud/spreed#10210
* Before component:
  * ...creates an empty `<span>` wrapper and fill it with children conditionally;
  * ...removes wrapper on hover (or if menu actions are forced) - look at bold text jumping;
* After component:
  * ...creates wrapper only if children should be there, otherwise skips;
  * ... hides wrapper with `display: none` on hover

### 🖼️ Screenshots (Talk)

🏚️ Before | 🏡 After
---|---
![open-chats-before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/f5284a3e-7197-442f-8ae0-e3ee3b6fa499) | ![open-chats-after](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/a993b085-be76-487d-843c-bf551a7974ed)

### 🚧 Tasks

- [ ] Visual check
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
