### PR TITLE
Prevent accessible name conflicts on action menu

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -670,7 +670,11 @@ export default {
 		},
 
 		/**
-		 * Aria label for the actions menu
+		 * Aria label for the actions menu.
+		 *
+		 * If `menuName` is defined this will not be used to prevent
+		 * any accessible name conflicts. This ensures that the
+		 * element can be activated via voice input.
 		 */
 		ariaLabel: {
 			type: String,
@@ -1114,7 +1118,7 @@ export default {
 						ref: 'menuButton',
 						attrs: {
 							'aria-haspopup': isNav ? null : 'menu',
-							'aria-label': this.ariaLabel,
+							'aria-label': this.menuName ? null : this.ariaLabel,
 							'aria-controls': this.opened ? this.randomId : null,
 							'aria-expanded': this.opened.toString(),
 						},


### PR DESCRIPTION
Only add an aria label to the action menu button when the menu name is not set to ensure activatability via voice input

Ref: https://ashleemboyer.com/blog/don-t-overwrite-visual-labels-with-aria-label

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable