### PR TITLE
Add accessible label to textarea

### DIFF
--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -76,11 +76,14 @@ export default {
 				<input :id="id" type="submit" class="action-text-editable__submit">
 
 				<!-- name -->
-				<strong v-if="name" class="action-text__name">
+				<label v-if="name"
+					class="action-text-editable__name"
+					:for="computedId">
 					{{ name }}
-				</strong>
+				</label>
 
-				<textarea :disabled="disabled"
+				<textarea :id="computedId"
+					:disabled="disabled"
 					:value="value"
 					v-bind="$attrs"
 					:class="['action-text-editable__textarea', { focusable: isFocusable }]"
@@ -150,6 +153,10 @@ export default {
 		 */
 		isFocusable() {
 			return !this.disabled
+		},
+
+		computedId() {
+			return GenRandomId()
 		},
 	},
 
@@ -347,5 +354,4 @@ li:last-child > .action-text-editable {
 li:first-child > .action-text-editable {
 	margin-top: $icon-margin - $input-margin;
 }
-
 </style>


### PR DESCRIPTION
Replace `strong` with `label`

The text is now not bolded which is consistent with the action input visible label

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/24800714/501be6d0-459f-4f2a-82ed-7f657035c993) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/24800714/999543ab-fe31-422b-b8f1-2798fc91c1ef)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable