### PR TITLE
[stable7] Prevent accessible name conflicts on action menu

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -659,7 +659,11 @@ export default {
 		},
 
 		/**
-		 * Aria label for the actions menu
+		 * Aria label for the actions menu.
+		 *
+		 * If `menuName` is defined this will not be used to prevent
+		 * any accessible name conflicts. This ensures that the
+		 * element can be activated via voice input.
 		 */
 		ariaLabel: {
 			type: String,
@@ -1104,7 +1108,7 @@ export default {
 						ref: 'menuButton',
 						attrs: {
 							'aria-haspopup': isNav ? null : 'menu',
-							'aria-label': this.ariaLabel,
+							'aria-label': this.menuName ? null : this.ariaLabel,
 							'aria-controls': this.opened ? this.randomId : null,
 							'aria-expanded': this.opened.toString(),
 						},


### PR DESCRIPTION
Backport https://github.com/nextcloud-libraries/nextcloud-vue/pull/4447