### PR TITLE
fix(NcSelect): Use named export of VueSelect to prevent issues when imported in ESM projects

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -526,7 +526,7 @@ export default {
 </template>
 
 <script>
-import VueSelect from '@nextcloud/vue-select'
+import { VueSelect } from '@nextcloud/vue-select'
 import '@nextcloud/vue-select/dist/vue-select.css'
 import {
 	autoUpdate,


### PR DESCRIPTION
### ☑️ Resolves

> TypeError: _nextcloud_vue_select__WEBPACK_IMPORTED_MODULE_4__.props is undefined

With mixed exports the default is not imported but the whole exports object, can be tested with a simple script.
Just name this script `some-name.mjs` and run `node ./some-name.mjs` (of cause in that directory must be a node_modules with `@nextcloud/vue-select` installed).

```js
import VueSelect from '@nextcloud/vue-select'
console.warn(VueSelect)
```


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
