### PR TITLE
fix(NcCheckboxRadioSwitch): If no text is provided the element should be a circle

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -604,6 +604,11 @@ export default {
 		&, * {
 			cursor: pointer;
 		}
+
+		&-text:empty {
+			// hide text if empty to ensure checkbox outline is a circle instead of oval
+			display: none;
+		}
 	}
 
 	&__icon > * {
@@ -627,6 +632,12 @@ export default {
 	&--checked:not(&--disabled):focus-within &__label,
 	&--checked:not(&--disabled) &__label:hover {
 		background-color: var(--color-primary-element-light-hover);
+	}
+
+	&-checkbox, &-switch {
+		.checkbox-radio-switch__label {
+			padding: 4px 10px; // we use 24x24px sized MDI icons for checkbox and radiobutton -> (44px - 24 px) / 2 = 10px
+		}
 	}
 
 	// Switch specific rules


### PR DESCRIPTION
### ☑️ Resolves

We use the NcCheckboxRadioSwitch also for e.g. the files list in the FilePicker and the files app, on the table no text is used.
But even if the text is empty the element is still displayed, resulting in an oval shape of the hover state and focus visible outline.

Moreover we use 24x24px icons for checkboxes and radio, so the padding was incorrectly set as if we use 20x20px icons.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot_20230823_232518](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/72ec50fe-7cf4-45cb-99e9-d18f329c8c89) | ![Screenshot_20230823_232455](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/17cb2c37-0149-4fb4-81c0-dc4feb04ac41)
![Screenshot_20230823_232523](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/9cf85e63-8bc2-4f64-8325-8dfb77fb0653) | ![Screenshot_20230823_232503](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/2a8b50a7-5122-4d80-9126-1cd483e8afc0)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
