### PR TITLE
fix(`NcListItem`) don't force blur action menu on tab

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -574,7 +574,6 @@ export default {
 				this.focused = false
 			} else {
 				this.displayActionsOnHoverFocus = false
-				this.$refs.actions.$refs.menuButton.$el.blur()
 			}
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix nextcloud/spreed#10341
* When current focus is on NcActions menu buton, it works fine natively, so we don't need to blur it (which triggers focus-trap to return back to the previous focused element)

### 🖼️ Screenshots

🏚️ Before

[Screencast from 24.08.2023 12:01:27.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/50ed0455-cdbc-4ba8-86f2-6a4f9f6d364d)

🏡 After

[Screencast from 24.08.2023 11:57:53.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/37fb16d5-848a-4271-8cf2-c9f22d744d26)

### 🚧 Tasks

- [ ] Visual check
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
