### PR TITLE
fix(`NcRichText`) - keep newlines in rendered Markdown 

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -41,7 +41,7 @@ export default {
 
 Local IP: http://127.0.0.1/status.php should be clickable
 
-Some examples for markdown syntax: **bold text** *italic text* ~~strikethrough~~`,
+Some examples for markdown syntax: **bold text** *italic text* \`inline code\``,
 			autolink: true,
 			useMarkdown: true,
 			args: {
@@ -217,7 +217,11 @@ export default {
 					},
 					prefix: false,
 				})
-				.processSync(this.text)
+				.processSync(this.useMarkdown
+					? this.text.slice().replace(/\n{2,}/g, (match) => {
+						return '\n\u00A0'.repeat(match.length - 1) + '\n'
+					})
+					: this.text)
 				.result
 
 			return h('div', { class: 'rich-text--wrapper' }, [


### PR DESCRIPTION
### ☑️ Resolves

* Markdown eats newlines (`Enter`, `Shift+Enter`), because rendered `<span/>` element doesn't contain symbols, so it's `height === 0`
* For newline (several `\n\n` in a row) - we paste no-break space (unicode `\u00A0`) between to fill the line
* Also replaced ~~strikethrough~~ with `inline code`, as we don't support it yet

### 🖼️ Screenshots

🏚️ Before

[Screencast from 24.08.2023 14:27:11.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/8fa83492-da04-4abe-91a7-c644cedff4fe)

🏡 After

[Screencast from 24.08.2023 14:26:17.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/cb12c42c-6b0e-4071-bd42-ed1c40118249)


### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
