### PR TITLE
Pass the github token to the action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,6 +22,7 @@ jobs:
         uses: skjnldsv/check-actor-permission@e591dbfe838300c007028e1219ca82cc26e8d7c5 # v2.1
         with:
           require: admin
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
According to https://github.com/skjnldsv/check-actor-permission#input this should work

Maybe this allows releasing:
https://github.com/nextcloud-libraries/nextcloud-vue/actions/runs/5963905611