### PR TITLE
Bring back label outside of the input for NcActionInput

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -32,7 +32,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 ```vue
 	<template>
 		<NcActions>
-			<NcActionInput :value.sync="text">
+			<NcActionInput :value.sync="text" :label-outside="true" label="Label outside the input">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
@@ -138,7 +138,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 	<li class="action" :class="{ 'action--disabled': disabled }">
 		<span :class="{
 				'action-input-picker--disabled': disabled,
-				'action-input--visible-label': labelVisible && label,
+				'action-input--visible-label': labelOutside && label,
 			}"
 			class="action-input"
 			@mouseleave="onLeave">
@@ -157,94 +157,104 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				class="action-input__form"
 				:disabled="disabled"
 				@submit.prevent="onSubmit">
-
-				<NcDatetimePicker v-if="datePickerType"
-					ref="datetimepicker"
-					:value="value"
-					style="z-index: 99999999999;"
-					:placeholder="text"
-					:disabled="disabled"
-					:type="datePickerType"
-					:input-class="['mx-input', { focusable: isFocusable }]"
-					class="action-input__datetimepicker"
-					v-bind="$attrs"
-					@input="onInput"
-					@change="onChange" />
-
-				<NcDateTimePickerNative v-else-if="isNativePicker"
-					:id="idNativeDateTimePicker"
-					:value="value"
-					:type="nativeDatePickerType"
-					:input-class="{ focusable: isFocusable }"
-					class="action-input__datetimepicker"
-					v-bind="$attrs"
-					@input="$emit('input', $event)"
-					@change="$emit('change', $event)" />
-
-				<NcSelect v-else-if="isMultiselectType"
-					:value="value"
-					:placeholder="text"
-					:disabled="disabled"
-					:append-to-body="false"
-					:input-class="{ focusable: isFocusable }"
-					class="action-input__multi"
-					v-bind="$attrs"
-					v-on="$listeners" />
-
-				<NcPasswordField v-else-if="type==='password'"
-					:id="inputId"
-					:value="value"
-					:label="label"
-					:label-outside="!label"
-					:placeholder="text"
-					:disabled="disabled"
-					:input-class="{ focusable: isFocusable }"
-					trailing-button-icon="arrowRight"
-					:show-trailing-button="showTrailingButton && !disabled"
-					v-bind="$attrs"
-					v-on="$listeners"
-					@trailing-button-click="$refs.form.requestSubmit()"
-					@input="onInput"
-					@change="onChange" />
-
-				<div v-else-if="type === 'color'" class="action-input__container">
-					<label v-if="label && type === 'color'"
+				<div class="action-input__container">
+					<label v-if="label && labelOutside"
 						class="action-input__text-label"
-						:class="{ 'action-input__text-label--hidden': !labelVisible }"
+						:class="{ 'action-input__text-label--hidden': !labelOutside}"
 						:for="inputId">
 						{{ label }}
 					</label>
 					<div class="action-input__input-container">
-						<NcColorPicker id="inputId"
+
+						<NcDatetimePicker v-if="datePickerType"
+							ref="datetimepicker"
 							:value="value"
-							class="colorpicker__trigger"
+							style="z-index: 99999999999;"
+							:placeholder="text"
+							:disabled="disabled"
+							:type="datePickerType"
+							:input-class="['mx-input', { focusable: isFocusable }]"
+							class="action-input__datetimepicker"
+							v-bind="$attrs"
+							@input="onInput"
+							@change="onChange" />
+
+						<NcDateTimePickerNative v-else-if="isNativePicker"
+							:id="idNativeDateTimePicker"
+							:value="value"
+							:type="nativeDatePickerType"
+							:input-class="{ focusable: isFocusable }"
+							class="action-input__datetimepicker"
+							v-bind="$attrs"
+							@input="$emit('input', $event)"
+							@change="$emit('change', $event)" />
+
+						<NcSelect v-else-if="isMultiselectType"
+							:value="value"
+							:placeholder="text"
+							:disabled="disabled"
+							:append-to-body="false"
+							:input-class="{ focusable: isFocusable }"
+							class="action-input__multi"
+							v-bind="$attrs"
+							v-on="$listeners" />
+
+						<NcPasswordField v-else-if="type==='password'"
+							:id="inputId"
+							:value="value"
+							:label="label"
+							:label-outside="!label || labelOutside"
+							:placeholder="text"
+							:disabled="disabled"
+							:input-class="{ focusable: isFocusable }"
+							trailing-button-icon="arrowRight"
+							:show-trailing-button="showTrailingButton && !disabled"
 							v-bind="$attrs"
 							v-on="$listeners"
+							@trailing-button-click="$refs.form.requestSubmit()"
 							@input="onInput"
-							@submit="$refs.form.requestSubmit()">
-							<button :style="{'background-color': value}"
-								class="colorpicker__preview"
-								:class="{ focusable: isFocusable }" />
-						</NcColorPicker>
+							@change="onChange" />
+
+						<div v-else-if="type === 'color'" class="action-input__container">
+							<label v-if="label && type === 'color'"
+								class="action-input__text-label"
+								:class="{ 'action-input__text-label--hidden': !labelOutside}"
+								:for="inputId">
+								{{ label }}
+							</label>
+							<div class="action-input__input-container">
+								<NcColorPicker id="inputId"
+									:value="value"
+									class="colorpicker__trigger"
+									v-bind="$attrs"
+									v-on="$listeners"
+									@input="onInput"
+									@submit="$refs.form.requestSubmit()">
+									<button :style="{'background-color': value}"
+										class="colorpicker__preview"
+										:class="{ focusable: isFocusable }" />
+								</NcColorPicker>
+							</div>
+						</div>
+
+						<NcTextField v-else
+							:id="inputId"
+							:value="value"
+							:label="label"
+							:label-outside="!label || labelOutside"
+							:placeholder="text"
+							:disabled="disabled"
+							:input-class="{ focusable: isFocusable }"
+							:type="type"
+							trailing-button-icon="arrowRight"
+							:show-trailing-button="showTrailingButton && !disabled"
+							v-bind="$attrs"
+							v-on="$listeners"
+							@trailing-button-click="$refs.form.requestSubmit()"
+							@input="onInput"
+							@change="onChange" />
 					</div>
 				</div>
-
-				<NcTextField v-else
-					:id="inputId"
-					:value="value"
-					:label="label"
-					:label-outside="!label"
-					:placeholder="text"
-					:disabled="disabled"
-					:input-class="{ focusable: isFocusable }"
-					:type="type"
-					trailing-button-icon="arrowRight"
-					:show-trailing-button="showTrailingButton && !disabled"
-					v-bind="$attrs"
-					v-on="$listeners"
-					@trailing-button-click="$refs.form.requestSubmit()"
-					@input="onInput"
-					@change="onChange" />
 			</form>
 		</span>
 	</li>
@@ -331,10 +341,10 @@ export default {
 			default: null,
 		},
 		/**
-		 * If you want to hide the label just above the
-		 * input field, pass in `false` to this prop.
+		 * If you want to show the label just above the
+		 * input field, pass in `true` to this prop.
 		 */
-		labelVisible: {
+		labelOutside: {
 			type: Boolean,
 			default: true,
 		},


### PR DESCRIPTION
https://github.com/nextcloud-libraries/nextcloud-vue/pull/4394 introduced a change that having the label outside of the input is no longer possible with NcActionItem

    In previous versions the label was shown above the input which gives the
    text more space which might be better than the inline label from
    https://github.com/nextcloud-libraries/nextcloud-vue/pull/4394 in some
    scenarios.

    This is a breaking change as it renames the previous labelVisible
    property to a labelOutside property. The label should always be visible
    with the new NcInputField, however we can optionally decide to have the
    label outside.

Found in https://github.com/nextcloud/text/pull/4663

### 🖼️ Screenshots

#### 7.x.x with label-visible
![Screenshot 2023-08-30 at 08 35 21](https://github.com/nextcloud-libraries/nextcloud-vue/assets/3404133/5bc15130-bf8e-4247-8e8f-e87fc2907198)

#### Current 8.0.0-beta.with label-visible
![Screenshot 2023-08-30 at 08 35 37](https://github.com/nextcloud-libraries/nextcloud-vue/assets/3404133/537f0506-4368-4c03-8e6d-a5fbba24dca3)

#### This PR with label-outside

![Screenshot 2023-08-30 at 08 36 05](https://github.com/nextcloud-libraries/nextcloud-vue/assets/3404133/1c3d3db0-b9c7-482f-bdc5-c0a6a7e1111c)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
