### PR TITLE
feat(`NcRichContenteditable`) - add different output appearance in examples 

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -47,16 +47,26 @@ This component displays contenteditable div with automated `@` [at] autocompleti
 			:user-data="userData"
 			placeholder="Try mentioning user @Test01 or inserting emoji :smile"
 			@submit="onSubmit" />
-		<br>
-		<br>
+
+		<h5>Output - raw</h5>
 		{{ JSON.stringify(message) }}
+
+		<h5>Output - preformatted</h5>
+		<p class="pre-line">{{ message }}</p>
+
+		<h5>Output - in NcRichText with markdown support</h5>
+		<NcRichText :text="message" use-markdown />
 	</div>
 </template>
 <script>
+	import NcRichText from "../NcRichText/NcRichText.vue";
+
 export default {
+	components: {NcRichText},
+
 	data() {
 		return {
-			message: 'Lorem ipsum dolor sit amet.',
+			message: '**Lorem ipsum** dolor sit amet.',
 
 			// You need to provide this for the inline
 			// mention to understand what to display or not.
@@ -142,6 +152,16 @@ export default {
 	}
 }
 </script>
+<style lang="scss" scoped>
+	h5 {
+		font-weight: bold;
+		margin: 40px 0 20px 0;
+	}
+
+	.pre-line {
+		white-space: pre-line;
+	}
+</style>
 ```
 
 </docs>


### PR DESCRIPTION
### ☑️ Resolves

* Raise awareness how the component handles and transfers strings
* May help to identify some issues before they reach release
* Cover frequent usecases:
  * render as a simple message 
  * send to server with `JSON.stringify()`
  * interact with `<NcRichText />` (with markdown enabled)


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/45206bf7-0a82-4f4e-b748-6aa478a5da21) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/b0e2d28b-8ba1-41c5-9610-e23fe6001c61)



### 🚧 Tasks

- [ ] Wording suggestions?
- [ ] Another outputs?
- [ ] Visual check

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
