### PR TITLE
enh(a11y): Add nav to header menu

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -75,6 +75,7 @@ export default {
 			ref="trigger"
 			class="header-menu__trigger button-vue"
 			:aria-label="ariaLabel"
+			:aria-describedby="description ? descriptionId : null"
 			:aria-controls="`header-menu-${id}`"
 			:aria-expanded="opened.toString()"
 			@click.prevent="toggleMenu">
@@ -82,6 +83,12 @@ export default {
 				is at least 16px. Usually mdi icon works at 20px -->
 			<slot name="trigger" />
 		</button>
+
+		<span v-if="description"
+			:id="descriptionId"
+			class="header-menu__description hidden-visually">
+			{{ description }}
+		</span>
 
 		<!-- Visual triangle -->
 		<div v-show="opened" class="header-menu__carret" />
@@ -152,6 +159,15 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		/**
+		 * Additional visually hidden description text for the menu
+		 * open button
+		 */
+		description: {
+			type: String,
+			default: null,
+		},
 	},
 
 	emits: [
@@ -169,6 +185,7 @@ export default {
 			opened: this.open,
 			shortcutsDisabled: window.OCP?.Accessibility?.disableKeyboardShortcuts?.(),
 			triggerId: GenRandomId(),
+			descriptionId: GenRandomId(),
 		}
 	},
 

--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -64,12 +64,15 @@ export default {
 </docs>
 
 <template>
-	<div :id="id"
+	<component :is="wrapperTag"
+		:id="id"
 		v-click-outside="clickOutsideConfig"
+		:aria-labelledby="isNav ? triggerId : null"
 		:class="{ 'header-menu--opened': opened }"
 		class="header-menu">
 		<!-- Trigger -->
-		<button ref="trigger"
+		<button :id="triggerId"
+			ref="trigger"
 			class="header-menu__trigger button-vue"
 			:aria-label="ariaLabel"
 			:aria-controls="`header-menu-${id}`"
@@ -86,20 +89,20 @@ export default {
 		<!-- Menu opened content -->
 		<div v-show="opened"
 			:id="`header-menu-${id}`"
-			class="header-menu__wrapper"
-			role="menu">
+			class="header-menu__wrapper">
 			<div ref="content" class="header-menu__content">
 				<!-- @slot Main content -->
 				<slot />
 			</div>
 		</div>
-	</div>
+	</component>
 </template>
 
 <script>
 import { vOnClickOutside as ClickOutside } from '@vueuse/components'
 import { createFocusTrap } from 'focus-trap'
 
+import GenRandomId from '../../utils/GenRandomId.js'
 import { clickOutsideOptions } from '../../mixins/index.js'
 import { getTrapStack } from '../../utils/focusTrap.js'
 
@@ -138,6 +141,17 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		/**
+		 * Pass `true` if the header menu is used for website navigation
+		 *
+		 * The wrapper tag will be set to `nav` and its `aria-labelledby`
+		 * will be associated with the menu open button
+		 */
+		isNav: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	emits: [
@@ -154,10 +168,15 @@ export default {
 			focusTrap: null,
 			opened: this.open,
 			shortcutsDisabled: window.OCP?.Accessibility?.disableKeyboardShortcuts?.(),
+			triggerId: GenRandomId(),
 		}
 	},
 
 	computed: {
+		wrapperTag() {
+			return this.isNav ? 'nav' : 'div'
+		},
+
 		clickOutsideConfig() {
 			return [
 				this.closeMenu,
@@ -360,5 +379,4 @@ $externalMargin: 8px;
 		}
 	}
 }
-
 </style>


### PR DESCRIPTION
- For https://github.com/nextcloud/server/issues/37095

### Summary

- Add opt-in `nav`
- Remove role semantics, ref: https://inclusive-components.design/menus-menu-buttons/#themenuandmenuitemroles

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable