### PR TITLE
Align NcCheckboxRadioSwitch labels

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -669,12 +669,6 @@ export default {
 		background-color: var(--color-primary-element-light-hover);
 	}
 
-	&-checkbox, &-switch {
-		.checkbox-radio-switch__label {
-			padding: 4px 10px; // we use 24x24px sized MDI icons for checkbox and radiobutton -> (44px - 24 px) / 2 = 10px
-		}
-	}
-
 	// Switch specific rules
 	&-switch:not(&--checked) &__icon > * {
 		color: var(--color-text-maxcontrast);


### PR DESCRIPTION

🏚️ Before | 🏡 After
---|---
![Screenshot 2023-08-31 at 09-26-48 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/a2fd9ad3-6c2a-400c-a95d-4c585f4d3367) | ![Screenshot 2023-08-31 at 09-27-20 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/4dc97ffb-a5f1-4d07-8113-5ddd702954e8)

I did not align the label of `NcCheckboxRadioSwitch` `type="switch"`, because it has a wider icon and aligning it does not really work well. 