### PR TITLE
fix(EmptyContent): svg max size

### DIFF
--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -220,8 +220,8 @@ export default {
 		:deep(svg) {
 			width: 64px;
 			height: 64px;
-			max-width: 64px;
-			max-height: 64px;
+			max-width: 64px !important;
+			max-height: 64px !important;
 		}
 	}
 


### PR DESCRIPTION
| Before | After |
|:---------:|:------:|
|![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/14975046/17993bbe-da58-4eb2-9139-0b321006e44d)|![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/14975046/336173c6-738c-45e9-9899-0997896d9288)|

## Explanations
There is a conflict when used with the `NcIconSvgWrapper`
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/14975046/e7fe2390-8503-4241-bd61-d42f8eb21c33)
