### PR TITLE
feat: add `v8.x (Nextcloud 28)` as latest docs title

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -67,7 +67,7 @@ module.exports = async () => {
 				usageMode: 'hide',
 			},
 			{
-				name: 'Latest version',
+				name: 'Latest version: v8.x (Nextcloud 28)',
 				href: 'https://nextcloud-vue-components.netlify.app',
 				sections: [
 					{


### PR DESCRIPTION
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/14975046/8a7c719f-c330-46d6-b0df-7cb45b1aaf04)
