### PR TITLE
feat(NcEmptyContent)!: make empty content centered by default instead of 20vh margin

### DIFF
--- a/src/components/NcDashboardWidget/NcDashboardWidget.vue
+++ b/src/components/NcDashboardWidget/NcDashboardWidget.vue
@@ -351,11 +351,9 @@ export default {
 <style scoped lang="scss">
 .dashboard-widget :deep(.empty-content) {
 	text-align: center;
-	margin-top: 0;
 	padding-top: 5vh;
 	&.half-screen {
 		padding-top: 0;
-		margin-top: 0;
 		margin-bottom: 1vh;
 	}
 }

--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -168,11 +168,19 @@ export default {
 	name: 'NcEmptyContent',
 
 	props: {
+		/**
+		 * A header message about an empty content shown
+		 * @example 'No comments'
+		 */
 		name: {
 			type: String,
 			default: '',
 		},
 
+		/**
+		 * Desription of the empty content
+		 * @example 'No comments yet, start the conversation!'
+		 */
 		description: {
 			type: String,
 			default: '',
@@ -198,7 +206,9 @@ export default {
 	display: flex;
 	align-items: center;
 	flex-direction: column;
-	margin-top: 20vh;
+	justify-content: center;
+	/* In case of using in a flex container - flex in advance */
+	flex-grow: 1;
 
 	.modal-wrapper & {
 		margin-top: 5vh;

--- a/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
@@ -111,11 +111,6 @@ export default {
 	display: flex;
 	flex-direction: column;
 
-	&--empty-content {
-		margin-top: auto !important;
-		margin-bottom: auto !important;
-	}
-
 	&--select {
 		width: 100%;
 

--- a/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
@@ -137,16 +137,11 @@ export default {
 		display: flex;
 	}
 
-	&--empty-content {
-		margin-top: auto !important;
-		margin-bottom: auto !important;
-
-		.provider-icon {
-			width: 150px;
-			height: 150px;
-			object-fit: contain;
-			filter: var(--background-invert-if-dark);
-		}
+	&--empty-content .provider-icon {
+		width: 150px;
+		height: 150px;
+		object-fit: contain;
+		filter: var(--background-invert-if-dark);
 	}
 
 	&--input {

--- a/src/components/NcRichText/NcReferencePicker/NcSearch.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcSearch.vue
@@ -293,11 +293,6 @@ export default {
 		min-height: 400px;
 	}
 
-	&--empty-content {
-		margin-top: auto !important;
-		margin-bottom: auto !important;
-	}
-
 	.provider-icon {
 		width: 150px;
 		height: 150px;


### PR DESCRIPTION
### ☑️ Resolves

By default `NcEmptyContent` displays the content with fixed 20vh top margin. This doesn't look good sometimes. I think that could be useful to have centered `NcEmptyContent`.

For example, by default, it looks bad in comments, where the default margin is overridden now with `!important`. 

Current `!important` override | Default styles | New `centered`
---|---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/4a93b93a-579b-4a1a-8577-50513c433c37) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/bfdeae8f-4bf0-4a07-8b02-e13f7ea22280) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d7b5db6f-f25c-4e67-923f-a8d60cb3a205)

Or in Talk.

Large screen (almost centered, but not) | Small screen (cut, but there is space)
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/2db40d3c-652d-4470-bb52-4945037010c8) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/5961e84d-a1f5-4d9d-aa84-feaa9745ae37)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a7bf5b7d-55b7-4eba-90ac-c98e8861b21f) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/4e9e15ff-f9fb-4525-96fc-af437a5c1ff3)

Also still works:

NcAppSidebar | ReferencePicker
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/bd7fa154-df2c-469f-87bb-54e540a83b8d) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a7fe31b1-64e8-42f3-99a3-d84a7a32f745)

### 🚧 Tasks

- [x] Remove `margin-top: 20vh`
- [x] Make content centered
- [x] Add `flex: 1` to make it centered by default in flex parents
- [x] Remove unnecessary styles in other components that remove margin and check that nothing it breaking
  - `NcHeaderMenu`, `NcDashboardWidget` - custom styles, nothing breaking
  - `NcAppSidebar` - works fine by default because of flex
  - `NcReferencePicker`: `NcProviderList`, `NcRawLinkInput`, `NcSearch` - remove unnecessary `margin: 0`, works fine now by default

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
