### PR TITLE
chore(vue3): Migrate Focus directive, globally import Tooltip in docs

### DIFF
--- a/src/directives/Focus/index.js
+++ b/src/directives/Focus/index.js
@@ -21,7 +21,7 @@
  */
 
 export const directive = {
-	inserted(el) {
+	mounted(el) {
 		el.focus()
 	},
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export * from './components/index.js'
 
 // Not yet adjusted for vue3
 // export * from './functions/index.js'
-// export * from './directives/index.js'
+export * from './directives/index.js'
 // export * from './mixins/index.js'
 
 export { NextcloudVuePlugin } from './plugin.ts'

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -59,6 +59,8 @@ module.exports = async () => {
 			return `import ${name} from '@nextcloud/vue/dist/Components/${name}'`
 		},
 
+		enhancePreviewApp: path.resolve(__dirname, 'styleguide/preview.js'),
+
 		sections: [
 			{
 				name: 'Introduction',
@@ -84,10 +86,10 @@ module.exports = async () => {
 					},
 				],
 			},
-			// {
-			// 	name: 'Directives',
-			// 	content: 'docs/directives.md',
-			// },
+			{
+				name: 'Directives',
+				content: 'docs/directives.md',
+			},
 			{
 				name: 'Components',
 				content: 'docs/components.md',

--- a/styleguide/preview.js
+++ b/styleguide/preview.js
@@ -1,0 +1,8 @@
+import { Tooltip } from '../src/directives/index.js'
+
+// The export here MUST be default or module.export
+// this is what is imported by the styleguide
+export default (app) => {
+  app.directive('tooltip', Tooltip)
+}
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,14 +33,13 @@ webpackConfig.entry = {
 		return acc
 	}, {}),
 
-	// Temporarily exclude not yet migrated vue2 components
-	// ...globSync('src/directives/*/index.js').reduce((acc, item) => {
-	// 	const name = item
-	// 		.replace('/index.js', '')
-	// 		.replace('src/directives/', 'Directives/')
-	// 	acc[name] = path.join(__dirname, item)
-	// 	return acc
-	// }, {}),
+	...globSync('src/directives/*/index.js').reduce((acc, item) => {
+		const name = item
+			.replace('/index.js', '')
+			.replace('src/directives/', 'Directives/')
+		acc[name] = path.join(__dirname, item)
+		return acc
+	}, {}),
 
 	// ...globSync('src/functions/*/index.js').reduce((acc, item) => {
 	// 	const name = item


### PR DESCRIPTION
This migrates the `Focus` directive to vue 3.