### PR TITLE
chore(vue3): add unit test for isSlotPopulated

### DIFF
--- a/src/utils/isSlotPopulated.js
+++ b/src/utils/isSlotPopulated.js
@@ -20,19 +20,18 @@
  *
  */
 
-import { Fragment, Comment } from 'vue'
+import { Fragment, Comment, Text } from 'vue'
 
 /**
  * Checks whether a slot is populated
+ *
+ * @param {Array} vnodes The array of vnodes to check
  */
 const isSlotPopulated = function(vnodes) {
-	return vnodes?.some(child => {
-		if (child.type === Comment) {
-			return false
-		}
-		if (child.type === Fragment && !isSlotPopulated(child.children)) {
-			return false
-		}
+	return !!vnodes?.some(node => {
+		if (node.type === Comment) return false
+		if (node.type === Fragment && !isSlotPopulated(node.children)) return false
+		if (node.type === Text && !node.children.trim()) return false
 		return true
 	})
 }

--- a/tests/unit/utils/isSlotPopulated.spec.js
+++ b/tests/unit/utils/isSlotPopulated.spec.js
@@ -1,0 +1,73 @@
+import { mount } from '@vue/test-utils'
+
+import isSlotPopulated from '../../../src/utils/isSlotPopulated.js'
+
+
+const IsSlotPopulatedTest = {
+	name: 'IsSlotPopulatedTest',
+	template: '<div><slot /></div>',
+	computed : {
+		isDefaultPopulated() {
+			return isSlotPopulated(this.$slots.default?.())
+		},
+	},
+}
+
+describe('isSlotPopulated.js', () => {
+	it('is not populated when a slot contains an empty array', () => {
+		const wrapper = mount(IsSlotPopulatedTest, {
+			slots: {
+				default: [],
+			},
+		})
+		expect(wrapper.vm.isDefaultPopulated).toBe(false)
+	})
+	it('is not populated when a slot with an empty string', () => {
+		const wrapper = mount(IsSlotPopulatedTest, {
+			slots: {
+				default: '',
+			},
+		})
+		expect(wrapper.vm.isDefaultPopulated).toBe(false)
+	})
+	it('is populated when a slot contains a string', () => {
+		const wrapper = mount(IsSlotPopulatedTest, {
+			slots: {
+				default: 'Test',
+			},
+		})
+		expect(wrapper.vm.isDefaultPopulated).toBe(true)
+	})
+	it('is not populated when a slot contains a string with whitespace only', () => {
+		const wrapper = mount(IsSlotPopulatedTest, {
+			slots: {
+				default: '           ',
+			},
+		})
+		expect(wrapper.vm.isDefaultPopulated).toBe(false)
+	})
+	it('is populated when a slot contains an array containing a string', () => {
+		const wrapper = mount(IsSlotPopulatedTest, {
+			slots: {
+				default: ['Test'],
+			},
+		})
+		expect(wrapper.vm.isDefaultPopulated).toBe(true)
+	})
+	it('is populated when a slot contains a comment and a text', () => {
+		const wrapper = mount(IsSlotPopulatedTest, {
+			slots: {
+				default: '<!-- Commment -->Test',
+			},
+		})
+		expect(wrapper.vm.isDefaultPopulated).toBe(true)
+	})
+	it('is not populated when a slot contains a comment only', () => {
+		const wrapper = mount(IsSlotPopulatedTest, {
+			slots: {
+				default: '<!-- Commment -->',
+			},
+		})
+		expect(wrapper.vm.isDefaultPopulated).toBe(false)
+	})
+})


### PR DESCRIPTION
This adds a unit test for the `isSlotPopulated` util. This util is made to check whether a slot actually contains content. I also slightly changed it to check whether there is only an empty Text node.

In vue 3 the usual way used in vue 2 does not work anymore.
Both `!!this.$slots.default` and `!!this.$slots.default?.()` will basically always be `true`. 