### PR TITLE
chore(pkgjson): alias dev:watch to watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "vite build --mode production ",
     "dev": "vite build --mode development",
     "dev:watch": "vite build --mode development --watch",
+    "watch": "npm run dev:watch",
     "l10n:extract": "node build/extract-l10n.js",
     "lint": "eslint --ext .js,.vue src",
     "lint:fix": "eslint --ext .js,.vue src --fix",


### PR DESCRIPTION
### ☑️ Resolves

* Fix _none_

### 🖼️ Screenshots

We use `npm run watch` in most apps so it would be nice to keep the standard. I don't see any downsides to this other than one more line of json.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
