### PR TITLE
chore(vue3): Nc*Field rename default to icon slot

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -47,7 +47,7 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 				:class="[inputClass,
 					{
 						'input-field__input--trailing-icon': showTrailingButton || hasTrailingIcon,
-						'input-field__input--leading-icon': hasLeadingIcon,
+						'input-field__input--leading-icon': !!$slots.icon,
 						'input-field__input--label-outside': labelOutside,
 						'input-field__input--success': success,
 						'input-field__input--error': error,
@@ -59,16 +59,16 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 				class="input-field__label"
 				:class="[{
 					'input-field__label--trailing-icon': showTrailingButton || hasTrailingIcon,
-					'input-field__label--leading-icon': hasLeadingIcon,
+					'input-field__label--leading-icon': !!$slots.icon,
 				}]"
 				:for="computedId">
 				{{ label }}
 			</label>
 
 			<!-- Leading icon -->
-			<div v-show="hasLeadingIcon" class="input-field__icon input-field__icon--leading">
+			<div v-show="!!$slots.icon" class="input-field__icon input-field__icon--leading">
 				<!-- Leading material design icon in the text field, set the size to 18 -->
-				<slot />
+				<slot name="icon" />
 			</div>
 
 			<!-- trailing button -->
@@ -109,7 +109,6 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 <script>
 import NcButton from '../NcButton/index.js'
 import GenRandomId from '../../utils/GenRandomId.js'
-import isSlotPopulated from '../../utils/isSlotPopulated.js'
 
 import AlertCircle from 'vue-material-design-icons/AlertCircleOutline.vue'
 import Check from 'vue-material-design-icons/Check.vue'
@@ -264,10 +263,6 @@ export default {
 
 		inputName() {
 			return 'input' + GenRandomId()
-		},
-
-		hasLeadingIcon() {
-			return isSlotPopulated(this.$slots.default?.())
 		},
 
 		hasTrailingIcon() {

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -52,7 +52,11 @@ General purpose password field component.
 			label="Good new password"
 			:success="true"
 			placeholder="Min. 12 characters"
-			helper-text="Password is secure" />
+			helper-text="Password is secure">
+			<template #icon>
+				<Lock :size="20" />
+			</template>
+		</NcPasswordField>
 
 		<NcPasswordField v-model:value="text5"
 			:disabled="true"
@@ -60,6 +64,8 @@ General purpose password field component.
 	</div>
 </template>
 <script>
+import Lock from 'vue-material-design-icons/Lock'
+
 export default {
 	data() {
 		return {
@@ -69,6 +75,10 @@ export default {
 			text4: '',
 			text5: '',
 		}
+	},
+
+	components: {
+		Lock,
 	},
 }
 </script>
@@ -107,8 +117,10 @@ export default {
 		:minlength="rules.minlength"
 		@trailing-button-click="togglePasswordVisibility"
 		@input="handleInput">
-		<!-- Default slot for the leading icon -->
-		<slot />
+		<template v-if="!!$slots.icon" #icon>
+			<!-- Default slot for the leading icon -->
+			<slot name="icon" />
+		</template>
 		<template #trailing-button-icon>
 			<Eye v-if="isPasswordHidden" :size="18" />
 			<EyeOff v-else :size="18" />

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -39,7 +39,9 @@ and `minlength`.
 			trailing-button-icon="close"
 			:show-trailing-button="text1 !== ''"
 			@trailing-button-click="clearText">
-			<Magnify :size="20" />
+			<template #icon>
+				<Magnify :size="20" />
+			</template>
 		</NcTextField>
 		<NcTextField :value.sync="text4"
 			label="Internal label"
@@ -47,7 +49,9 @@ and `minlength`.
 			trailing-button-icon="close"
 			:show-trailing-button="text4 !== ''"
 			@trailing-button-click="clearText">
-			<Lock :size="20" />
+			<template #icon>
+				<Lock :size="20" />
+			</template>
 		</NcTextField>
 		<NcTextField v-model:value="text2"
 			label="Success state"
@@ -136,8 +140,10 @@ export default {
 		ref="inputField"
 		:trailing-button-label="clearTextLabel"
 		@input="handleInput">
-		<!-- Default slot for the leading icon -->
-		<slot />
+		<template v-if="!!$slots.icon" #icon>
+			<!-- Default slot for the leading icon -->
+			<slot name="icon" />
+		</template>
 
 		<!-- Trailing icon slot, except for search type input as the browser already adds a trailing close icon -->
 		<template v-if="type !== 'search'" #trailing-button-icon>


### PR DESCRIPTION
@ShGKme What do you think of this approach:

We rename the `default` slot of `NcInputField` to `icon` and then simply use `!!$slots.icon` as you proposed. This way, one anyway has to wrap the content for the `icon` slot in a `template` tag and it is easier to explain that one has to use `v-if` on the `template` when toggling the existence of an icon.
This then makes everything reactive without the need for an overkill solution, no?

And I think renaming to `icon` anyway makes sense, since it makes it clearer that it's, well, for an icon.