### PR TITLE
fix(NcAppNavigation): Make the navigation toggle accessible again when closed

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -57,10 +57,11 @@ emit('toggle-navigation', {
 	<div id="app-navigation-vue"
 		class="app-navigation"
 		role="navigation"
-		:inert="!open || null"
 		:class="{'app-navigation--close':!open }">
 		<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
-		<div :aria-hidden="ariaHidden" class="app-navigation__content">
+		<div :aria-hidden="ariaHidden"
+			class="app-navigation__content"
+			:inert="!open || null">
 			<slot />
 			<!-- List for Navigation li-items -->
 			<ul class="app-navigation__list">


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4433

Make only the content of the navigation inert when closed but not the wrapper which includes the toggle

### 🖼️ Screenshots


https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/d0fabf66-49db-4963-94ff-f7a3374420ca

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
