### PR TITLE
fix(vue3): Rename `NcDatetimePickerNative` to `NcDateTimePickerNative`

### DIFF
--- a/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
+++ b/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
@@ -34,7 +34,7 @@ All available types are: 'date', 'datetime-local', 'month', 'time' and 'week', p
 ```vue
 <template>
 	<span>
-		<NcDatetimePickerNative
+		<NcDateTimePickerNative
 			v-model="value"
 			:id="id"
 			:label="label"
@@ -59,7 +59,7 @@ All available types are: 'date', 'datetime-local', 'month', 'time' and 'week', p
 ```vue
 <template>
 	<span>
-		<NcDatetimePickerNative
+		<NcDateTimePickerNative
 			v-model="value"
 			:id="id"
 			:min="yesterdayDate"
@@ -88,7 +88,7 @@ All available types are: 'date', 'datetime-local', 'month', 'time' and 'week', p
 ```vue
 <template>
 	<span>
-		<NcDatetimePickerNative
+		<NcDateTimePickerNative
 			v-model="value"
 			:id="id"
 			:label="label"
@@ -113,7 +113,7 @@ All available types are: 'date', 'datetime-local', 'month', 'time' and 'week', p
 ```vue
 <template>
 	<span>
-		<NcDatetimePickerNative
+		<NcDateTimePickerNative
 			v-model="value"
 			:id="id"
 			:label="label"
@@ -156,7 +156,7 @@ All available types are: 'date', 'datetime-local', 'month', 'time' and 'week', p
 const inputDateTypes = ['date', 'datetime-local', 'month', 'time', 'week']
 
 export default {
-	name: 'NcDatetimePickerNative',
+	name: 'NcDateTimePickerNative',
 	inheritAttrs: false,
 
 	props: {
@@ -222,7 +222,7 @@ export default {
 		},
 		/**
 		 * Class to add to the input field.
-		 * Necessary to use NcDatetimePickerNative in the NcActionInput component.
+		 * Necessary to use NcDateTimePickerNative in the NcActionInput component.
 		 */
 		inputClass: {
 			type: [Object, String],

--- a/src/components/NcDateTimePickerNative/index.js
+++ b/src/components/NcDateTimePickerNative/index.js
@@ -20,9 +20,9 @@
  *
  */
 
-import NcDatetimePickerNative from './NcDatetimePickerNative.vue'
+import NcDateTimePickerNative from './NcDateTimePickerNative.vue'
 import ScopeComponent from '../../utils/ScopeComponent.js'
 
-ScopeComponent(NcDatetimePickerNative)
+ScopeComponent(NcDateTimePickerNative)
 
-export default NcDatetimePickerNative
+export default NcDateTimePickerNative

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -62,7 +62,7 @@ export { default as NcCounterBubble } from './NcCounterBubble/index.js'
 // export { default as NcDashboardWidgetItem } from './NcDashboardWidgetItem/index.js'
 export { default as NcDateTime } from './NcDateTime/index.js'
 // export { default as NcDateTimePicker } from './NcDateTimePicker/index.js'
-export { default as NcDatetimePickerNative } from './NcDatetimePickerNative/index.js'
+export { default as NcDateTimePickerNative } from './NcDateTimePickerNative/index.js'
 // Not exported on purpose
 // export { default as NcEllipsisedOption } from './NcEllipsisedOption/index.js'
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -200,7 +200,7 @@ module.exports = async () => {
 						name: 'NcPickers',
 						components: [
 							//'src/components/Nc*Picker*/*.vue',
-							'src/components/NcDatetimePickerNative*/*.vue',
+							'src/components/NcDateTimePickerNative*/*.vue',
 						],
 					},
 				// 	{


### PR DESCRIPTION
Rename `NcDatetimePickerNative` to `NcDateTimePickerNative`.
