### PR TITLE
fix(vue3): Inherit `$attrs` to `Dropdown` in `NcPopover`

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -131,8 +131,6 @@ export default {
 		Dropdown,
 	},
 
-	inheritAttrs: false,
-
 	props: {
 		popoverBaseClass: {
 			type: String,


### PR DESCRIPTION
This fixes the `$attrs` inheritance for `NcPopover`. in #4511 I forgot to re-enable the automatic inheritance, that was explicitly disabled before. This fixes it.