### PR TITLE
Set double outline to active action menu

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1264,6 +1264,8 @@ export default {
 
 	&.action-item--open .action-item__menutoggle {
 		background-color: var(--open-background-color);
+		outline: 2px solid var(--color-main-text);
+		box-shadow: 0 0 0 4px var(--color-main-background);
 	}
 }
 </style>

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1265,7 +1265,9 @@ export default {
 	&.action-item--open .action-item__menutoggle {
 		background-color: var(--open-background-color);
 		outline: 2px solid var(--color-main-text);
-		box-shadow: 0 0 0 4px var(--color-main-background);
+		outline-offset: -4px;
+		border: 2px solid var(--color-main-background);
+		height: 44px;
 	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Part of https://github.com/nextcloud/server/issues/36966

See general requirements here: https://github.com/nextcloud-libraries/nextcloud-vue/issues/4193

Draft PR because in a moment i can't link NcVue and Server.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-09-26 13-26-09](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/94654b98-f166-4e4f-8589-325b11f065a9) | ![Screenshot from 2023-09-26 13-25-20](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/c0f4732b-5e47-4a87-a477-bc47ed6c2ce6)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
