### PR TITLE
fix(NcEmojiPicker): Do not set padding for the search input label

### DIFF
--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -488,12 +488,7 @@ export default {
 }
 
 .search {
-	padding: 0 8px 4px 8px;
-	.input-field__label {
-		// Match styles in emoji-mart-vue-fast
-		padding: 5px 4px;
-		font-weight: 500;
-	}
+	padding: 4px 8px;
 }
 
 </style>


### PR DESCRIPTION
### ☑️ Resolves

The "hacked" padding into the label broke when we introduced the internal label, so remove the custom styles on the label.

### 🖼️ Screenshots
Focus on the search input label:

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/1d7334e2-ddb4-4bcb-bc97-ac34f1d10e65)|![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/f5c99c8e-b9e7-4d8e-9fdc-3e1889d0e3a0)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
