### PR TITLE
[stable7] fix(NcEmojiPicker): Set type to `native` for selected emoji

### DIFF
--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -169,11 +169,13 @@ This component allows the user to pick an emoji.
 				<Emoji class="emoji-selected"
 					:data="emojiIndex"
 					:emoji="selectedEmoji"
+					:native="true"
 					:size="32"
 					@click="unselect" />
 				<Emoji class="emoji-delete"
 					:data="emojiIndex"
 					emoji=":x:"
+					:native="true"
 					:size="10"
 					@click="unselect" />
 			</template>


### PR DESCRIPTION
The default is to display the emoji from a remote data source, which we don't want (and is prohibitted by our CSP anyway).

Manual backport of https://github.com/nextcloud-libraries/nextcloud-vue/pull/4575

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
