### PR TITLE
fix(EmptyContent): ensure proper custom icon size

### DIFF
--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -228,8 +228,8 @@ export default {
 		background-size: 64px;
 
 		:deep(svg) {
-			width: 64px;
-			height: 64px;
+			width: 64px !important;
+			height: 64px !important;
 			max-width: 64px !important;
 			max-height: 64px !important;
 		}


### PR DESCRIPTION
Since we had to explicitly set the icon size of `NcIconSvgWrapper` in #4557 to make it work on iOS, we now have to overwrite it here to not rely on the order of the files bundling.