### PR TITLE
fix(NcSettingsSection): remove incorrect role=note on doc link

### DIFF
--- a/src/components/NcSettingsSection/NcSettingsSection.vue
+++ b/src/components/NcSettingsSection/NcSettingsSection.vue
@@ -48,8 +48,6 @@ This component is to be used in the settings section of nextcloud.
 			<a v-if="hasDocUrl"
 				:href="docUrl"
 				class="settings-section__info"
-				role="note"
-				:aria-label="docNameTranslated"
 				:title="docNameTranslated"
 				target="_blank"
 				rel="noreferrer nofollow">


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/40704

### 🖼️ Visual Changes

No visual changes

### 🔊 Audible Changes

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9bd78e82-e1fa-485d-9217-3314ff976cf6)

Before | After
---|---
`heading level 2` | `External documentation for Two-Factor Authentication visited link heading level 2`

### 🚧 Tasks

- [x] Remove `role="note"`
- [x] Remove `aria-label` that duplicates `title` (no change, no unneeded)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
