### PR TITLE
fix(utils): Make `isMobileState` PURE so it can be treeshaken if not used

### DIFF
--- a/src/utils/IsMobileState.js
+++ b/src/utils/IsMobileState.js
@@ -23,7 +23,7 @@
 
 import Vue from 'vue'
 
-export const IsMobileState = new Vue({
+export const IsMobileState = /* @__PURE__ */ new Vue({
 	data() {
 		return {
 			isMobile: false,


### PR DESCRIPTION
### ☑️ Resolves

Currently it otherwise will always be imported because the treeshake algorithm can not decide if running the Vue constructor has any sideeffects.

(saves a few bytes on projects not using it)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
