### PR TITLE
fix: Remove unused id from trigger

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -71,7 +71,7 @@ export default {
 		:class="{ 'header-menu--opened': opened }"
 		class="header-menu">
 		<!-- Trigger -->
-		<button :id="triggerId"
+		<button :id="isNav ? triggerId : null"
 			ref="trigger"
 			class="header-menu__trigger button-vue"
 			:aria-label="ariaLabel"


### PR DESCRIPTION
### Summary

Remove id from header menu trigger button when unused

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable