### PR TITLE
fix(NcSelect): make id truly uniqual

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -546,6 +546,8 @@ import NcLoadingIcon from '../NcLoadingIcon/index.js'
 
 import l10n from '../../mixins/l10n.js'
 
+import GenRandomId from '../../utils/GenRandomId.js'
+
 export default {
 	name: 'NcSelect',
 
@@ -799,6 +801,16 @@ export default {
 					},
 				}
 			},
+		},
+
+		/**
+		 * A unique identifier used to generate IDs and DOM attributes. Must be unique for every instance of the component.
+		 *
+		 * @see https://vue-select.org/api/props.html#uid
+		 */
+		uid: {
+			type: String,
+			default: () => '-' + GenRandomId(),
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/37098 (Page files)

VueSelect generates unique IDs for some elements. But it is just [auto-increment id](https://github.com/sagalbot/vue-select/blob/857753655adbebae612518aab072ed7f4a8deaa0/src/utility/uniqueId.js). For example, `#vs1-compobox`.

It works fine while only one copy of VueSelect (`@nextcloud/vue`) is used. Otherwise, there are several VueSelects with their own uid sequence. Then there are many `#vs1-compobox` elements on the page.

This PR defines a default value for [VueSelect.uid](https://vue-select.org/api/props.html#uid) with a random string.

Now nc-selects have IDs like `#vs-wxtrv-compobox`

### 🖼️ Screenshots

#### Before 

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d4c3fce6-142c-488c-b684-5226666170e3) 

#### After

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/2b30a6f2-6467-4445-b845-781d123534dc)

### 🚧 Tasks

- [x] Use random id as a default value for [VueSelect.uid](https://vue-select.org/api/props.html#uid)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
