### PR TITLE
fix(NcIconSvgWrapper): remove new keepId prop

### DIFF
--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -119,16 +119,6 @@ export default {
 			type: String,
 			default: '',
 		},
-
-		/**
-		 * By default MDI icons have an ID on the `<svg>` element. It leads to dupliated IDs on a web-page.
-		 * This component removes the ID on the received SVG.
-		 * Use this prop to disable this behavior and to not remove the ID.
-		 */
-		keepId: {
-			type: Boolean,
-			default: false,
-		},
 	},
 
 	computed: {
@@ -146,7 +136,7 @@ export default {
 				return ''
 			}
 
-			if (!this.keepId && svgDocument.documentElement.id) {
+			if (svgDocument.documentElement.id) {
 				svgDocument.documentElement.removeAttribute('id')
 			}
 

--- a/tests/unit/components/NcIconSvgWrapper/NcIconSvgWrapper.spec.js
+++ b/tests/unit/components/NcIconSvgWrapper/NcIconSvgWrapper.spec.js
@@ -41,12 +41,6 @@ describe('NcIconSvgWrapper', () => {
 		expect(svg.attributes('id')).not.toBeDefined()
 	})
 
-	it('should keep ID from rendered SVG when keepId is provided', () => {
-		const wrapper = mountNcIconSvgWrapper({ svg: SVG_ICON, keepId: true })
-		const svg = wrapper.get('svg')
-		expect(svg.attributes('id')).toBe('mdi-check')
-	})
-
 	it('should sanitize SVG', () => {
 		const svgWithXSS = `<svg xmlns="http://www.w3.org/2000/svg" id="mdi-check" viewBox="0 0 24 24">
             <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud-libraries/nextcloud-vue/pull/4607#discussion_r1346379815

This prop should not be needed because no code should use ID on SVG, they are not unique

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
