### PR TITLE
fix: remove unused vue-template-compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
         "vitest": "^0.34.6",
         "vue-eslint-parser": "^9.0.3",
         "vue-styleguidist": "~4.72.0",
-        "vue-template-compiler": "^2.7.14",
         "webpack": "^5.88.1",
         "webpack-merge": "^5.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "vitest": "^0.34.6",
     "vue-eslint-parser": "^9.0.3",
     "vue-styleguidist": "~4.72.0",
-    "vue-template-compiler": "^2.7.14",
     "webpack": "^5.88.1",
     "webpack-merge": "^5.9.0"
   },


### PR DESCRIPTION
Don't explicitly install `vue-template-compiler`. 