### PR TITLE
chore: Bump @nextcloud/vite-config to fix cjs require default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@nextcloud/browserslist-config": "^3.0.0",
         "@nextcloud/eslint-config": "^8.3.0-beta.0",
         "@nextcloud/stylelint-config": "^2.3.1",
-        "@nextcloud/vite-config": "^1.0.0",
+        "@nextcloud/vite-config": "^1.0.1",
         "@nextcloud/webpack-vue-config": "github:nextcloud/webpack-vue-config#master",
         "@vue/test-utils": "^1.3.0",
         "@vue/tsconfig": "^0.4.0",
@@ -3549,9 +3549,9 @@
       }
     },
     "node_modules/@nextcloud/vite-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.0.0.tgz",
-      "integrity": "sha512-C9UUNsdYKZc45S7nRk1SpMOvEdGDiOJBdCuuZIBgf3eE9y7Wxi4xWBPCtJQ+Me1pIZksmMfTIbfHR3+P7qrv0w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.0.1.tgz",
+      "integrity": "sha512-ft6x4mYN3ifIQaS3+w+9uMMFdHpHpDTICpBbelEfDCCziFqClFCz7dEecNNNf2MWwE5HfZV6x8J2WEPUNsMxpw==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-replace": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@nextcloud/browserslist-config": "^3.0.0",
     "@nextcloud/eslint-config": "^8.3.0-beta.0",
     "@nextcloud/stylelint-config": "^2.3.1",
-    "@nextcloud/vite-config": "^1.0.0",
+    "@nextcloud/vite-config": "^1.0.1",
     "@nextcloud/webpack-vue-config": "github:nextcloud/webpack-vue-config#master",
     "@vue/test-utils": "^1.3.0",
     "@vue/tsconfig": "^0.4.0",


### PR DESCRIPTION
### Summary

- Fixes Cypress + CalDavSettings CI errors in https://github.com/nextcloud/server/pull/40692

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable