### PR TITLE
fix(NcListItem): adjust paddings and hover styles for list items

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -609,6 +609,12 @@ export default {
 	&.active {
 		.list-item {
 			background-color: var(--color-primary-element);
+			&:active,
+			&:hover,
+			&:focus,
+			&:focus-visible {
+				background-color: var(--color-primary-element-hover);
+			}
 		}
 
 		.line-one__name, .line-one__details {
@@ -627,7 +633,7 @@ export default {
 	position: relative;
 	flex: 0 0 auto;
 	justify-content: flex-start;
-	padding: 8px;
+	padding: 8px 10px;
 	// Fix for border-radius being too large for 3-line entries like in Mail
 	// 44px avatar size / 2 + 8px padding, and 2px for better visual quality
 	border-radius: 32px;
@@ -636,8 +642,10 @@ export default {
 	cursor: pointer;
 	transition: background-color var(--animation-quick) ease-in-out;
 	list-style: none;
+	&:active,
 	&:hover,
-	&:focus {
+	&:focus,
+	&:focus-visible {
 		background-color: var(--color-background-hover);
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4625 
  * NcListItem now has correct colors for hover states when active or not
  * Padding was adjusted for content to be inscribed in a circle and even horizontal-vertical visual paddings

### 🖼️ Screenshots
Top to bottom: `.active`, `.active:hover`, `.active:focus`, `.active:focus-visible`

![Screenshot from 2023-10-09 16-23-42](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/e47c7d13-68fc-4a6f-b54a-b0bba65476e3)


🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/1e4a199c-52da-43ed-8e09-f66b59402398) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/1492fdf9-f291-4539-90ac-cce53a173598)



### 🚧 Tasks

- [ ] Check if other components were aligned to this `<slot name="icon" />` => move also for +2px 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
