### PR TITLE
Fix height of `label` and `input` on NcInputField

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -436,7 +436,7 @@ export default {
 		position: absolute;
 		margin-inline: 12px 0;
 		// fix height and line height to center label
-		height: 17px;
+		height: 25px;
 		max-width: fit-content;
 		line-height: 1;
 		inset-block-start: 12px;
@@ -468,7 +468,7 @@ export default {
 		inset-block-start: -6px;
 		font-size: 13px; // minimum allowed font size for accessibility
 		background-color: var(--color-main-background);
-		height: 14px;
+		height: 18px;
 		padding-inline: 4px;
 		margin-inline-start: 8px;
 


### PR DESCRIPTION
### ☑️ Resolves

* https://github.com/nextcloud/server/issues/36977

Fix height for text spacing requirements. Checked with ARCToolkit.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-10-09 17-12-08](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/bf37b4f1-7e9f-453f-a1a6-ccb9c35ac3f1) | ![Screenshot from 2023-10-09 17-11-01](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/a8cf2f8a-18e7-406c-bb59-15cd381894e8)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
