### PR TITLE
fix(NcActionInput): Set default trailing button label

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -207,11 +207,9 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 							:placeholder="text"
 							:disabled="disabled"
 							:input-class="{ focusable: isFocusable }"
-							trailing-button-icon="arrowRight"
 							:show-trailing-button="showTrailingButton && !disabled"
 							v-bind="$attrs"
 							v-on="$listeners"
-							@trailing-button-click="$refs.form.requestSubmit()"
 							@input="onInput"
 							@change="onChange" />
 
@@ -247,6 +245,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 							:input-class="{ focusable: isFocusable }"
 							:type="type"
 							trailing-button-icon="arrowRight"
+							:trailing-button-label="trailingButtonLabel"
 							:show-trailing-button="showTrailingButton && !disabled"
 							v-bind="$attrs"
 							v-on="$listeners"
@@ -268,6 +267,7 @@ import NcSelect from '../NcSelect/index.js'
 import NcTextField from '../NcTextField/index.js'
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import GenRandomId from '../../utils/GenRandomId.js'
+import { t } from '../../l10n.js'
 
 export default {
 	name: 'NcActionInput',
@@ -377,11 +377,18 @@ export default {
 			default: null,
 		},
 		/**
-		 * Attribute forwarded to the underlining NcPasswordField and NcTextField
+		 * Attribute forwarded to the underlying NcPasswordField and NcTextField
 		 */
 		showTrailingButton: {
 			type: Boolean,
 			default: true,
+		},
+		/**
+		 * Trailing button label forwarded to the underlying NcTextField
+		 */
+		trailingButtonLabel: {
+			type: String,
+			default: t('Submit'),
 		},
 	},
 

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -99,7 +99,7 @@ export default {
 	<NcInputField v-bind="{...$attrs, ...$props }"
 		ref="inputField"
 		:type="isPasswordHidden ? 'password' : 'text'"
-		:show-trailing-button="showTrailingButton && true"
+		:show-trailing-button="showTrailingButton"
 		:trailing-button-label="trailingButtonLabelPassword"
 		:helper-text="computedHelperText"
 		:error="computedError"


### PR DESCRIPTION
### Summary

- Set default trailing button label to match click handler `"$refs.form.requestSubmit()"` behaviour
- Remove redundant NcPasswordField props

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable