### PR TITLE
fix(NcAppNavigation): add focus trap on mobile and improve a11y

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -54,15 +54,16 @@ emit('toggle-navigation', {
 </docs>
 
 <template>
-	<div id="app-navigation-vue"
-		ref="appNavigationContainer"
+	<div ref="appNavigationContainer"
 		class="app-navigation"
-		role="navigation"
 		:class="{'app-navigation--close':!open }">
 		<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
-		<div :aria-hidden="ariaHidden"
+		<nav id="app-navigation-vue"
+			:aria-hidden="open ? 'false' : 'true'"
+			:aria-label="ariaLabel || undefined"
+			:aria-labelledby="ariaLabelledby || undefined"
 			class="app-navigation__content"
-			:inert="!open || null">
+			:inert="!open || undefined">
 			<slot />
 			<!-- List for Navigation li-items -->
 			<ul class="app-navigation__list">
@@ -71,7 +72,7 @@ emit('toggle-navigation', {
 
 			<!-- Footer for e.g. AppNavigationSettings -->
 			<slot name="footer" />
-		</div>
+		</nav>
 	</div>
 </template>
 
@@ -93,16 +94,29 @@ export default {
 
 	mixins: [isMobile],
 
+	props: {
+		/**
+		 * The aria label to describe the navigation
+		 */
+		ariaLabel: {
+			type: String,
+			default: '',
+		},
+
+		/**
+		 * aria-labelledby attribute to describe the navigation
+		 */
+		ariaLabelledby: {
+			type: String,
+			default: '',
+		},
+	},
+
 	data() {
 		return {
 			open: true,
 			focusTrap: null,
 		}
-	},
-	computed: {
-		ariaHidden() {
-			return this.open ? 'false' : 'true'
-		},
 	},
 
 	watch: {
@@ -124,6 +138,7 @@ export default {
 
 		this.focusTrap = createFocusTrap(this.$refs.appNavigationContainer, {
 			allowOutsideClick: true,
+			fallbackFocus: this.$refs.appNavigationContainer,
 			trapStack: getTrapStack(),
 			escapeDeactivates: false,
 		})

--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -63,7 +63,8 @@ emit('toggle-navigation', {
 			:aria-label="ariaLabel || undefined"
 			:aria-labelledby="ariaLabelledby || undefined"
 			class="app-navigation__content"
-			:inert="!open || undefined">
+			:inert="!open || undefined"
+			@keydown.esc="handleEsc">
 			<slot />
 			<!-- List for Navigation li-items -->
 			<ul class="app-navigation__list">
@@ -180,6 +181,12 @@ export default {
 				this.focusTrap.activate()
 			} else {
 				this.focusTrap.deactivate()
+			}
+		},
+
+		handleEsc() {
+			if (this.isMobile) {
+				this.toggleNavigation(false)
 			}
 		},
 	},

--- a/tests/unit/components/NcAppNavigation/NcAppNavigation.spec.js
+++ b/tests/unit/components/NcAppNavigation/NcAppNavigation.spec.js
@@ -102,6 +102,25 @@ describe('NcAppNavigation.vue', () => {
 
 			expect(wrapper.classes(NAVIGATION_CLOSE__CLASS)).toBeFalsy()
 		})
+
+		it('closes by ESC key on mobile', async () => {
+			IsMobileState.isMobile = true
+			const wrapper = mount(NcAppNavigation)
+			const navigation = findNavigation(wrapper)
+
+			await navigation.trigger('keydown', { key: 'Escape' })
+
+			expect(wrapper.classes(NAVIGATION_CLOSE__CLASS)).toBeTruthy()
+		})
+
+		it("doesn't close by ESC key on desktop", async () => {
+			const wrapper = mount(NcAppNavigation)
+			const navigation = findNavigation(wrapper)
+
+			await navigation.trigger('keydown', { key: 'Escape' })
+
+			expect(wrapper.classes(NAVIGATION_CLOSE__CLASS)).toBeFalsy()
+		})
 	})
 
 	describe('focus trap', () => {

--- a/tests/unit/components/NcAppNavigation/NcAppNavigation.spec.js
+++ b/tests/unit/components/NcAppNavigation/NcAppNavigation.spec.js
@@ -19,33 +19,153 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
+import { describe, it, expect, afterEach } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 import { emit } from '@nextcloud/event-bus'
+import { nextTick } from 'vue'
 import NcAppNavigation from '../../../../src/components/NcAppNavigation/NcAppNavigation.vue'
+import { IsMobileState } from '../../../../src/utils/IsMobileState.js'
+
+const NAVIGATION__SELECTOR = 'nav'
+const TOGGLE_BUTTON__SELECTOR = 'button[aria-controls="app-navigation-vue"]'
+const NAVIGATION_CLOSE__CLASS = 'app-navigation--close'
+
+const findNavigation = (wrapper) => wrapper.get(NAVIGATION__SELECTOR)
+const findToggleButton = (wrapper) => wrapper.get(TOGGLE_BUTTON__SELECTOR)
 
 describe('NcAppNavigation.vue', () => {
-	'use strict'
-
 	describe('by default', () => {
 		it('is open', () => {
 			const wrapper = mount(NcAppNavigation)
-			expect(wrapper.vm.$data.open).toBe(true)
+			const navigation = findNavigation(wrapper)
+
+			expect(navigation.classes(NAVIGATION_CLOSE__CLASS)).toBeFalsy()
 		})
 	})
+
 	describe('toggle via event bus', () => {
-		it('toggle to turn it off', () => {
+		it('toggles to turn it off', async () => {
 			const wrapper = mount(NcAppNavigation)
-			emit('toggle-navigation', {open: undefined})
-			expect(wrapper.vm.$data.open).toBe(false)
+
+			emit('toggle-navigation', { open: undefined })
+			await nextTick()
+
+			expect(wrapper.classes(NAVIGATION_CLOSE__CLASS)).toBeTruthy()
 		})
 
-		it('toggle with open: false keeps it closed', () => {
+		it('toggles with open: false keeps it closed', async () => {
 			const wrapper = mount(NcAppNavigation)
-			emit('toggle-navigation', {open: false})
-			emit('toggle-navigation', {open: false})
-			expect(wrapper.vm.$data.open).toBe(false)
+
+			emit('toggle-navigation', { open: false })
+			emit('toggle-navigation', { open: false })
+			await nextTick()
+
+			expect(wrapper.classes(NAVIGATION_CLOSE__CLASS)).toBeTruthy()
+		})
+	})
+
+	describe('toggle via toggle button', () => {
+		it('opens on toggle button click in closed navigation', async () => {
+			const wrapper = mount(NcAppNavigation)
+			const togglebutton = findToggleButton(wrapper)
+
+			await togglebutton.trigger('click')
+
+			expect(wrapper.classes(NAVIGATION_CLOSE__CLASS)).toBeTruthy()
+		})
+	})
+
+	describe('toggle via mobile state', () => {
+		afterEach(() => {
+			IsMobileState.isMobile = false
 		})
 
+		it('closes on switch to mobile', async () => {
+			const wrapper = mount(NcAppNavigation)
+
+			IsMobileState.isMobile = true
+			await nextTick()
+
+			expect(wrapper.classes(NAVIGATION_CLOSE__CLASS)).toBeTruthy()
+		})
+
+		it('opens on switch to desktop', async () => {
+			IsMobileState.isMobile = true
+			const wrapper = mount(NcAppNavigation)
+			const togglebutton = findToggleButton(wrapper)
+
+			// Close
+			await togglebutton.trigger('click')
+			// Switch to desktop
+			IsMobileState.isMobile = false
+			await nextTick()
+
+			expect(wrapper.classes(NAVIGATION_CLOSE__CLASS)).toBeFalsy()
+		})
+	})
+
+	describe('focus trap', () => {
+		// TODO
+	})
+
+	describe('accessibility', () => {
+		it('has navigation role', () => {
+			const wrapper = mount(NcAppNavigation)
+			const navigation = findNavigation(wrapper)
+
+			expect(
+				navigation.attributes('role') === 'navigation'
+				|| navigation.element.tagName === 'NAV',
+			).toBeTruthy()
+		})
+
+		it('has toggle button, connected by aria-controls', () => {
+			const wrapper = mount(NcAppNavigation)
+			const navigation = findNavigation(wrapper)
+			const togglebutton = findToggleButton(wrapper)
+
+			expect(togglebutton.attributes('aria-controls')).toBe(navigation.attributes('id'))
+		})
+
+		it('has correct aria attributes and inert on open navigation', () => {
+			const wrapper = mount(NcAppNavigation)
+			const navigation = findNavigation(wrapper)
+			const togglebutton = findToggleButton(wrapper)
+
+			expect(navigation.attributes('aria-hidden')).toBe('false')
+			expect(navigation.attributes('inert')).toBeFalsy()
+			expect(togglebutton.attributes('aria-expanded')).toBe('true')
+			expect(togglebutton.attributes('aria-label')).toBe('Close navigation')
+		})
+
+		it('has correct aria attributes and inert on closed navigation', async () => {
+			const wrapper = mount(NcAppNavigation)
+			const navigation = findNavigation(wrapper)
+			const togglebutton = findToggleButton(wrapper)
+
+			// Close navigation
+			await togglebutton.trigger('click')
+
+			expect(navigation.attributes('aria-hidden')).toBe('true')
+			expect(navigation.attributes('inert')).toBeTruthy()
+			expect(togglebutton.attributes('aria-expanded')).toBe('false')
+			expect(togglebutton.attributes('aria-label')).toBe('Open navigation')
+		})
+
+		it('has aria-label from corresponding prop on navigation', () => {
+			const wrapper = mount(NcAppNavigation, {
+				propsData: { ariaLabel: 'Navigation' },
+			})
+			const navigation = findNavigation(wrapper)
+			expect(navigation.attributes('aria-label')).toBe('Navigation')
+		})
+
+		it('has aria-labelledby from corresponding prop on navigation', () => {
+			const wrapper = mount(NcAppNavigation, {
+				propsData: { ariaLabelledby: 'navHeaderId' },
+			})
+			const navigation = findNavigation(wrapper)
+			expect(navigation.attributes('aria-labelledby')).toBe('navHeaderId')
+		})
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

* A part of https://github.com/nextcloud/server/issues/36964

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![nav-before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/59f79e0f-6374-4e14-ac7c-0564e398f594) | ![nav-after](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/4efd57f4-1e08-44b3-a8df-f524776fbef4)

### 🚧 Tasks

- [x] Add focus trap, and activate it on **open** navigation on **mobile**, deactivate otherwise
- [x] Improve a11y a bit:
  - [x] Use `<nav>` instead of `role="navigation"` cc @JuliaKirschenheuter to confirm that this is fine
  - [x] Move the toggle button out from the navigation
  - [x] Add `ariaLabel` and `ariaLabelledBy` props to be set on navigation
- [x] Close navigation by <kbd>ESC</kbd> on mobile
- [x] Update tests
  - [x] Test by class instead of internal data property (testing `is closed or open` state by class also is not great, but we should not test by internal implementation as data property is not a part of the component interface). Alternative: `aria-hidden`.
  - [x] Add mobile state test
  - [x] Add a11y tests

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
