### PR TITLE
[WIP] feat(NcAppNavigation): add top-bar slot to save space for toggle button

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -58,7 +58,15 @@ emit('toggle-navigation', {
 		class="app-navigation"
 		role="navigation"
 		:class="{'app-navigation--close':!open }">
-		<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
+		<div v-if="hasTopBar()" class="app-navigation__top-bar">
+			<NcAppNavigationToggle class="app-navigation__toggle--in-top-bar" :open="open" @update:open="toggleNavigation" />
+			<div class="app-navigation__top-bar-content">
+				<!-- @slot The top bar of navigation for primary buttons search inputs and etc. Reserves space for the toggle button. -->
+				<slot name="top-bar" />
+			</div>
+		</div>
+		<NcAppNavigationToggle v-else :open="open" @update:open="toggleNavigation" />
+
 		<div :aria-hidden="ariaHidden"
 			class="app-navigation__content"
 			:inert="!open || null">
@@ -138,6 +146,10 @@ export default {
 		toggleNavigationByEventBus({ open }) {
 			this.toggleNavigation(open)
 		},
+
+		hasTopBar() {
+			return !!this.$slots['top-bar']
+		},
 	},
 }
 </script>
@@ -178,6 +190,26 @@ export default {
 	&--close {
 		transform: translateX(-100%);
 		position: absolute;
+	}
+
+	&__top-bar {
+		display: flex;
+		flex-direction: row;
+		gap: calc(var(--default-grid-baseline) * 2);
+		height: var(--default-clickable-area);
+
+		&-content {
+			flex-grow: 1;
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+			padding: 0 var(--app-navigation-padding);
+		}
+
+		.app-navigation__toggle--in-top-bar {
+			position: static;
+		}
 	}
 
 	//list of navigation items


### PR DESCRIPTION
### ☑️ Resolves

The toggle button outside the navigation doesn't always look good. The problem is that having this button inside the navigation may not fit any layout and requires saving space for it on every app's side.

The idea is to have an additional `top-bar` slot to allow some content in a special place at the top of navigation that reserves space for the toggle button.

This slot can be **optional**, keeping the current behavior as a default behavior to **not make a breaking change** here.

Usage example:

```vue
<NcAppNavigation>
  <template #top-bar>
    <SomeSearch />
    <!-- or -->
    <SomePrimaryButton />
  </template>
  
  <!-- Navigation items -->
</NcAppNavigation>
```

### 🖼️ Screenshots

Default | With optional top-bar slot
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/420a861f-533e-4bb8-9f4a-6034ea3ca2af) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/80298b92-489f-4e28-b7ea-03eb217a6973)

PS: Talk could be not the best example because of many items in the top already.

### 🚧 Tasks

- [ ] ...

### Alternative solution

Instead of providing a slot to render top bar in a specific position with a toggle in a specific position, we can also provide a possibility to just render `NcAppNavigaroinToggle` button wherever application wants directly. Aka

```vue
<NcAppNavigation>
  <div class="top">
    <NcAppNavigationToggle /> <!-- Just put the button where you want -->
    <!-- some other top content -->
  </div>
  <!-- Some navigation elements -->
</NcAppNavigation>
```

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
