### PR TITLE
Fix NcBreadcrumbs styles to wrap buttons

### DIFF
--- a/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
+++ b/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
@@ -653,12 +653,7 @@ export default {
 
 	nav {
 		flex-shrink: 1;
-		max-width: 100%;
-		/**
-		 * This value is given by the min-width of the last crumb (100px) plus
-		 * two times the width of a crumb with an icon (first crumb and hidden crumbs actions).
-		 */
-		min-width: 228px;
+		min-width: 0;
 	}
 
 	& #{&}__crumbs {


### PR DESCRIPTION
### ☑️ Resolves

* Part of https://github.com/nextcloud/server/issues/36965
* Fixes "Add" button is far away

### 🖼️ Screenshots


|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/e01ae8db-5881-4c4d-b2bd-aa5baf0c619d) | ![Screenshot from 2023-10-18 16-15-54](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/c992734a-3a58-4591-b31b-cddc0e7ada95) 

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
