### PR TITLE
feat(NcIconSvgWrapper): allow to render raw svg paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@babel/preset-typescript": "^7.22.5",
         "@cypress/vue2": "^2.0.1",
         "@fontsource/roboto": "^5.0.0",
+        "@mdi/js": "^7.3.67",
         "@mdi/svg": "^7.0.96",
         "@nextcloud/babel-config": "^1.0.0",
         "@nextcloud/browserslist-config": "^3.0.0",
@@ -3162,6 +3163,12 @@
       "dependencies": {
         "unist-util-is": "^3.0.0"
       }
+    },
+    "node_modules/@mdi/js": {
+      "version": "7.3.67",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.3.67.tgz",
+      "integrity": "sha512-MnRjknFqpTC6FifhGHjZ0+QYq2bAkZFQqIj8JA2AdPZbBxUvr8QSgB2yPAJ8/ob/XkR41xlg5majDR3c1JP1hw==",
+      "dev": true
     },
     "node_modules/@mdi/svg": {
       "version": "7.3.67",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@babel/preset-typescript": "^7.22.5",
     "@cypress/vue2": "^2.0.1",
     "@fontsource/roboto": "^5.0.0",
+    "@mdi/js": "^7.3.67",
     "@mdi/svg": "^7.0.96",
     "@nextcloud/babel-config": "^1.0.0",
     "@nextcloud/browserslist-config": "^3.0.0",

--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -47,12 +47,12 @@ Render raw SVG string icons.
 		</NcButton>
 		<NcButton aria-label="Send">
 			<template #icon>
-				<NcIconSvgWrapper :svg="sendSvg" name="Send" />
+				<NcIconSvgWrapper :path="mdiSend" name="Send" />
 			</template>
 		</NcButton>
 		<NcButton aria-label="Star">
 			<template #icon>
-				<NcIconSvgWrapper :svg="starSvg" name="Star" />
+				<NcIconSvgWrapper :path="mdiStar" name="Star" />
 			</template>
 		</NcButton>
 	</div>
@@ -62,8 +62,8 @@ Render raw SVG string icons.
 import closeSvg from '@mdi/svg/svg/close.svg?raw'
 import cogSvg from '@mdi/svg/svg/cog.svg?raw'
 import plusSvg from '@mdi/svg/svg/plus.svg?raw'
-import sendSvg from '@mdi/svg/svg/send.svg?raw'
-import starSvg from '@mdi/svg/svg/star.svg?raw'
+import { mdiSend } from '@mdi/js'
+import { mdiStar } from '@mdi/js'
 
 export default {
 	data() {
@@ -71,8 +71,8 @@ export default {
 			closeSvg,
 			cogSvg,
 			plusSvg,
-			sendSvg,
-			starSvg,
+			mdiSend,
+			mdiStar,
 		}
 	},
 }
@@ -89,7 +89,17 @@ export default {
 </docs>
 
 <template>
-	<span class="icon-vue"
+	<span v-if="!cleanSvg"
+		class="icon-vue"
+		role="img"
+		:aria-hidden="!name ? true : undefined"
+		:aria-label="name || undefined">
+		<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+			<path :d="path" />
+		</svg>
+	</span>
+	<span v-else
+		class="icon-vue"
 		role="img"
 		:aria-hidden="!name ? true : undefined"
 		:aria-label="name || undefined"
@@ -119,11 +129,19 @@ export default {
 			type: String,
 			default: '',
 		},
+
+		/**
+		 * Raw SVG path to render. Takes precedence over the SVG string in the `svg` prop.
+		 */
+		path: {
+			type: String,
+			default: '',
+		},
 	},
 
 	computed: {
 		cleanSvg() {
-			if (!this.svg) {
+			if (!this.svg || this.path) {
 				return
 			}
 

--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -90,19 +90,13 @@ export default {
 
 <template>
 	<span v-if="!cleanSvg"
-		class="icon-vue"
-		role="img"
-		:aria-hidden="!name ? true : undefined"
-		:aria-label="name || undefined">
+		v-bind="attributes">
 		<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 			<path :d="path" />
 		</svg>
 	</span>
 	<span v-else
-		class="icon-vue"
-		role="img"
-		:aria-hidden="!name ? true : undefined"
-		:aria-label="name || undefined"
+		v-bind="attributes"
 		v-html="cleanSvg" /> <!-- eslint-disable-line vue/no-v-html -->
 </template>
 
@@ -159,6 +153,14 @@ export default {
 			}
 
 			return svgDocument.documentElement.outerHTML
+		},
+		attributes() {
+			return {
+				class: 'icon-vue',
+				role: 'img',
+				'aria-hidden': !this.name ? true : undefined,
+				'aria-label': this.name || undefined,
+			}
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

This allows to render raw SVG paths which prevents the overhead of having to sanitize the SVG icon for use in `v-html`.