### PR TITLE
fix(NcModal): Some modal improvments

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -288,9 +288,6 @@ export default {
 						<NcButton v-show="hasPrevious"
 							type="tertiary-no-background"
 							class="prev"
-							:class="{
-								invisible: !hasPrevious
-							}"
 							:aria-label="prevButtonAriaLabel"
 							@click="previous">
 							<template #icon>
@@ -322,9 +319,6 @@ export default {
 						<NcButton v-show="hasNext"
 							type="tertiary-no-background"
 							class="next"
-							:class="{
-								invisible: !hasNext
-							}"
 							:aria-label="nextButtonAriaLabel"
 							@click="next">
 							<template #icon>
@@ -826,14 +820,7 @@ export default {
 	width: 100%;
 	height: $header-height;
 	overflow: hidden;
-	transition: opacity 250ms,
-		visibility 250ms;
-
-	// replace display by visibility
-	&.invisible[style*='display:none'],
-	&.invisible[style*='display: none'] {
-		visibility: hidden;
-	}
+	transition: opacity 250ms, visibility 250ms;
 
 	.modal-name {
 		overflow-x: hidden;
@@ -946,13 +933,10 @@ export default {
 	.prev,
 	.next {
 		z-index: 10000;
-		// ignore display: none
-		display: flex !important;
 		height: 35vh;
 		min-height: 300px;
 		position: absolute;
-		transition: opacity 250ms,
-			visibility 250ms;
+		transition: opacity 250ms;
 		// hover the mask
 		color: white;
 
@@ -961,16 +945,8 @@ export default {
 			box-shadow: 0 0 0 2px var(--color-primary-element-text);
 			background-color: var(--color-box-shadow);
 		}
-
-		// we want to keep the elements on page
-		// even if hidden to avoid having a unbalanced
-		// centered content
-		// replace display by visibility
-		&.invisible[style*='display:none'],
-		&.invisible[style*='display: none'] {
-			visibility: hidden;
-		}
 	}
+
 	.prev {
 		left: 2px;
 	}

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -966,6 +966,8 @@ export default {
 		box-shadow: 0 0 40px rgba(0, 0, 0, .2);
 
 		&__close {
+			// Ensure the close button is always ontop of the content
+			z-index: 1;
 			position: absolute;
 			top: 4px;
 			right: 4px;
@@ -973,13 +975,14 @@ export default {
 
 		&__content {
 			width: 100%;
+			min-height: 52px; // At least the close button shall fit in
 			overflow: auto; // avoids unecessary hacks if the content should be bigger than the modal
 		}
 	}
 
 	// We allow 90% max-height, but we need to ensure the header does not overlap the modal
 	// as the modal is centered, we need the space on top and bottom
-	$max-modal-height: min(90%, calc(100% - 2 * var(--header-height)));
+	$max-modal-height: min(90%, calc(100% - 2 * $header-height));
 
 	// Sizing
 	&--small {

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -977,26 +977,30 @@ export default {
 		}
 	}
 
+	// We allow 90% max-height, but we need to ensure the header does not overlap the modal
+	// as the modal is centered, we need the space on top and bottom
+	$max-modal-height: min(90%, calc(100% - 2 * var(--header-height)));
+
 	// Sizing
 	&--small {
 		.modal-container {
 			width: 400px;
 			max-width: 90%;
-			max-height: 90%;
+			max-height: $max-modal-height;
 		}
 	}
 	&--normal {
 		.modal-container {
 			max-width: 90%;
 			width: 600px;
-			max-height: 90%;
+			max-height: $max-modal-height;
 		}
 	}
 	&--large {
 		.modal-container {
 			max-width: 90%;
 			width: 900px;
-			max-height: 90%;
+			max-height: $max-modal-height;
 		}
 	}
 	&--full {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4627 
* Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/3117

1. Revert hack to make unused buttons invisible instead of setting `display: none`
    The buttons are placed absolute, therefor they do not interact with the modal container and content.
    Meaning even if only on button is shown the modal is centered correctly.
2. Ensure the modal header does not overflow the modal content
    The modal height is max. 90%, but if the window is not that tall or the modal is tall, then the header might overlap the content. So fix this by setting the modal max. height to 100% - 2*modal-header (because of the centered placement).
3. Ensure the close button is always clickable and not covert by content. (simply setting a z-index on it).

### 🖼️ Screenshots
You can see the header no longer overflows the content. And the button is on top of the modal content even if the default content margin of 50px is overridden.

🏚️ Before | 🏡 After
---|---
![Screenshot_20231013_171853](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/041bc52e-67fc-44a4-a336-17f3d74dd0ee) | ![Screenshot_20231013_171949](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/4147061a-e71b-4a11-80cc-d75b3c3be1ec)

And for the revert of the visibility hack, here is a "after" screenshot with only on button, you can see it is still centered perfectly:
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/8b62f611-2dd2-4fc8-babb-825f8139c602)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
