### PR TITLE
fix(NcActions): Various accessibility improvements

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -96,7 +96,8 @@
 		}
 
 		// long text area
-		p {
+		&__longtext-wrapper,
+		&__longtext {
 			max-width: 220px;
 			line-height: 1.6em;
 

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -196,7 +196,8 @@ export default {
 			</slot>
 
 			<!-- long text with name -->
-			<p v-if="name">
+			<span v-if="name"
+				class="action-button__longtext-wrapper">
 				<strong class="action-button__name">
 					{{ name }}
 				</strong>
@@ -204,12 +205,12 @@ export default {
 				<!-- white space is shown on longtext, so we can't
 					put {{ text }} on a new line for code readability -->
 				<span class="action-button__longtext" v-text="text" />
-			</p>
+			</span>
 
 			<!-- long text only -->
 			<!-- white space is shown on longtext, so we can't
 				put {{ text }} on a new line for code readability -->
-			<p v-else-if="isLongText"
+			<span v-else-if="isLongText"
 				class="action-button__longtext"
 				v-text="text" />
 

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -179,7 +179,7 @@ export default {
 </docs>
 
 <template>
-	<li class="action" role="presentation" :class="{ 'action--disabled': disabled }">
+	<li class="action" :class="{ 'action--disabled': disabled }">
 		<button class="action-button"
 			:class="{ focusable: isFocusable }"
 			:aria-label="ariaLabel"

--- a/src/components/NcActionLink/NcActionLink.vue
+++ b/src/components/NcActionLink/NcActionLink.vue
@@ -98,7 +98,8 @@ export default {
 			</slot>
 
 			<!-- long text with name -->
-			<p v-if="name">
+			<span v-if="name"
+				class="action-link__longtext-wrapper">
 				<strong class="action-link__name">
 					{{ name }}
 				</strong>
@@ -106,12 +107,12 @@ export default {
 				<!-- white space is shown on longtext, so we can't
 				put {{ text }} on a new line for code readability -->
 				<span class="action-link__longtext" v-text="text" />
-			</p>
+			</span>
 
 			<!-- long text only -->
 			<!-- white space is shown on longtext, so we can't
 			put {{ text }} on a new line for code readability -->
-			<p v-else-if="isLongText"
+			<span v-else-if="isLongText"
 				class="action-link__longtext"
 				v-text="text" />
 

--- a/src/components/NcActionRouter/NcActionRouter.vue
+++ b/src/components/NcActionRouter/NcActionRouter.vue
@@ -38,7 +38,8 @@
 			</slot>
 
 			<!-- long text with name -->
-			<p v-if="name">
+			<span v-if="name"
+				class="action-router__longtext-wrapper">
 				<strong class="action-router__name">
 					{{ name }}
 				</strong>
@@ -46,12 +47,12 @@
 				<!-- white space is shown on longtext, so we can't
 				put {{ text }} on a new line for code readability -->
 				<span class="action-router__longtext" v-text="text" />
-			</p>
+			</span>
 
 			<!-- long text only -->
 			<!-- white space is shown on longtext, so we can't
 			put {{ text }} on a new line for code readability -->
-			<p v-else-if="isLongText"
+			<span v-else-if="isLongText"
 				class="action-router__longtext"
 				v-text="text" />
 

--- a/src/components/NcActionText/NcActionText.vue
+++ b/src/components/NcActionText/NcActionText.vue
@@ -35,7 +35,8 @@
 			</slot>
 
 			<!-- long text with name -->
-			<p v-if="name">
+			<span v-if="name"
+				class="action-text__longtext-wrapper">
 				<strong class="action-text__name">
 					{{ name }}
 				</strong>
@@ -43,12 +44,12 @@
 				<!-- white space is shown on longtext, so we can't
 				put {{ text }} on a new line for code readability -->
 				<span class="action-text__longtext" v-text="text" />
-			</p>
+			</span>
 
 			<!-- long text only -->
 			<!-- white space is shown on longtext, so we can't
 			put {{ text }} on a new line for code readability -->
-			<p v-else-if="isLongText"
+			<span v-else-if="isLongText"
 				class="action-text__longtext"
 				v-text="text" />
 

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1074,6 +1074,15 @@ export default {
 						},
 					})
 			)
+			const ariaExpandedForTrigger = () => {
+				if (isNav) {
+					return this.opened.toString()
+				}
+				if (this.opened) {
+					return this.opened.toString()
+				}
+				return null
+			}
 			return h('NcPopover',
 				{
 					ref: 'popover',
@@ -1120,7 +1129,7 @@ export default {
 							'aria-haspopup': isNav ? null : 'menu',
 							'aria-label': this.menuName ? null : this.ariaLabel,
 							'aria-controls': this.opened ? this.randomId : null,
-							'aria-expanded': this.opened.toString(),
+							'aria-expanded': ariaExpandedForTrigger(),
 						},
 						on: {
 							focus: this.onFocus,

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1075,13 +1075,7 @@ export default {
 					})
 			)
 			const ariaExpandedForTrigger = () => {
-				if (isNav) {
-					return this.opened.toString()
-				}
-				if (this.opened) {
-					return this.opened.toString()
-				}
-				return null
+				return (isNav || this.opened) ? this.opened.toString() : null
 			}
 			return h('NcPopover',
 				{

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -58,7 +58,7 @@ export default {
 		 */
 		ariaLabel: {
 			type: String,
-			default: '',
+			default: null,
 		},
 		/**
 		 * aria-hidden attribute for the icon slot


### PR DESCRIPTION
- For https://github.com/nextcloud/server/issues/37130

### Summary

- Remove aria-expanded when closed, https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/examples/menu-button-actions-active-descendant/
- Use span for long text
- Remove button presentation role
- Remove empty aria-label attr

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable