### PR TITLE
fix: missing trailing comma

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -394,7 +394,7 @@ export default {
 					// escape special symbol "<" to not treat text as HTML
 					.replace(/</gmi, '&lt;')
 					// unescape special symbol ">" to parse blockquotes
-					.replace(/&gt;/gmi, '>')
+					.replace(/&gt;/gmi, '>'),
 				)
 				.result
 


### PR DESCRIPTION
### ☑️ Resolves

Fixes a missing trailing comma. Honestly, I am not really convinced there should be a comma, but it makes `eslint` happy :man_shrugging: 