### PR TITLE
enh(NcAppSidebarTabs): Make tab navigation accessible

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -44,7 +44,7 @@
 				:aria-selected="String(activeTab === tab.id)"
 				:button-variant="true"
 				:checked="activeTab === tab.id"
-				:data-id="tab.id"
+				:wrapper-id="`tab-button-${tab.id}`"
 				:tabindex="activeTab === tab.id ? 0 : -1"
 				button-variant-grouped="horizontal"
 				class="app-sidebar-tabs__tab"
@@ -201,7 +201,7 @@ export default {
 		 * Focus the current active tab
 		 */
 		focusActiveTab() {
-			this.$el.querySelector(`[data-id="${this.activeTab}"]`).focus()
+			this.$el.querySelector(`#tab-button-${this.activeTab}`).focus()
 		},
 
 		/**

--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -294,7 +294,7 @@ export default {
 		}
 
 		// Override max-width to use all available space
-		:deep(.checkbox-radio-switch__label) {
+		:deep(.checkbox-radio-switch__content) {
 			max-width: unset;
 		}
 	}

--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -41,7 +41,7 @@
 			<NcCheckboxRadioSwitch v-for="tab in tabs"
 				:key="tab.id"
 				:aria-controls="`tab-${tab.id}`"
-				:aria-selected="activeTab === tab.id"
+				:aria-selected="String(activeTab === tab.id)"
 				:button-variant="true"
 				:checked="activeTab === tab.id"
 				:data-id="tab.id"

--- a/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
+++ b/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
@@ -27,7 +27,7 @@
 	<section :id="`tab-${id}`"
 		:class="{'app-sidebar__tab--active': isActive}"
 		:aria-hidden="!isActive"
-		:aria-labelledby="id"
+		:aria-labelledby="`tab-button-${id}`"
 		class="app-sidebar__tab"
 		tabindex="0"
 		role="tabpanel"

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -204,8 +204,6 @@ export default {
 	max-width: fit-content;
 
 	&__text {
-		line-height: 1.5;
-
 		&:empty {
 			// hide text if empty to ensure checkbox outline is a circle instead of oval
 			display: none;

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -1,0 +1,225 @@
+<!--
+  - @copyright 2023 Christopher Ng <chrng8@gmail.com>
+  -
+  - @author Christopher Ng <chrng8@gmail.com>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+-->
+
+<template>
+	<component :is="wrapperElement"
+		:for="!isButtonType ? id : null"
+		class="checkbox-content">
+		<span :class="['checkbox-content__icon', iconClass]"
+			:aria-hidden="true">
+			<!-- @slot The checkbox/radio icon, you can use it for adding an icon to the button variant
+					@binding {bool} checked The input checked state
+					@binding {bool} loading The loading state
+			-->
+			<slot name="icon"
+				:checked="isChecked"
+				:loading="loading">
+				<NcLoadingIcon v-if="loading" />
+				<component :is="checkboxRadioIconElement"
+					v-else-if="!buttonVariant"
+					:size="size" />
+			</slot>
+		</span>
+
+		<span :class="['checkbox-content__text', textClass]">
+			<!-- @slot The checkbox/radio label -->
+			<slot />
+		</span>
+	</component>
+</template>
+
+<script>
+import CheckboxBlankOutline from 'vue-material-design-icons/CheckboxBlankOutline.vue'
+import MinusBox from 'vue-material-design-icons/MinusBox.vue'
+import CheckboxMarked from 'vue-material-design-icons/CheckboxMarked.vue'
+import RadioboxMarked from 'vue-material-design-icons/RadioboxMarked.vue'
+import RadioboxBlank from 'vue-material-design-icons/RadioboxBlank.vue'
+import ToggleSwitchOff from 'vue-material-design-icons/ToggleSwitchOff.vue'
+import ToggleSwitch from 'vue-material-design-icons/ToggleSwitch.vue'
+
+import NcLoadingIcon from '../NcLoadingIcon/index.js'
+
+import { TYPE_BUTTON, TYPE_CHECKBOX, TYPE_RADIO, TYPE_SWITCH } from './NcCheckboxRadioSwitch.vue'
+
+export default {
+	name: 'NcCheckboxContent',
+
+	components: {
+		NcLoadingIcon,
+	},
+
+	props: {
+		/**
+		 * Unique id attribute of the input to label
+		 */
+		id: {
+			type: String,
+			default: null,
+		},
+
+		/**
+		 * Class for the icon element
+		 */
+		iconClass: {
+			type: [String, Object],
+			default: null,
+		},
+
+		/**
+		 * Class for the text element
+		 */
+		textClass: {
+			type: [String, Object],
+			default: null,
+		},
+
+		/**
+		 * Type of the input. checkbox, radio, switch, or button.
+		 *
+		 * Only use button when used in a `tablist` container and the
+		 * `tab` role is set.
+		 */
+		type: {
+			type: String,
+			default: 'checkbox',
+			validator: type => [
+				TYPE_CHECKBOX,
+				TYPE_RADIO,
+				TYPE_SWITCH,
+				TYPE_BUTTON,
+			].includes(type),
+		},
+
+		/**
+		 * Toggle the alternative button style
+		 */
+		buttonVariant: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * True if the entry is checked
+		 */
+		isChecked: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * Loading state
+		 */
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * Icon size
+		 */
+		size: {
+			type: Number,
+			default: 24,
+		},
+	},
+
+	computed: {
+		isButtonType() {
+			return this.type === TYPE_BUTTON
+		},
+
+		wrapperElement() {
+			if (this.isButtonType) {
+				return 'span'
+			}
+			return 'label'
+		},
+
+		/**
+		 * Returns the proper Material icon depending on the select case
+		 *
+		 * @return {object}
+		 */
+		checkboxRadioIconElement() {
+			if (this.type === TYPE_RADIO) {
+				if (this.isChecked) {
+					return RadioboxMarked
+				}
+				return RadioboxBlank
+			}
+
+			// Switch
+			if (this.type === TYPE_SWITCH) {
+				if (this.isChecked) {
+					return ToggleSwitch
+				}
+				return ToggleSwitchOff
+			}
+
+			// Checkbox
+			if (this.indeterminate) {
+				return MinusBox
+			}
+			if (this.isChecked) {
+				return CheckboxMarked
+			}
+			return CheckboxBlankOutline
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.checkbox-content {
+	display: flex;
+	align-items: center;
+	flex-direction: row;
+	gap: 4px;
+	user-select: none;
+	min-height: $clickable-area;
+	border-radius: $clickable-area;
+	padding: 4px $icon-margin;
+	// Set to 100% to make text overflow work on button style
+	width: 100%;
+	// but restrict to content so plain checkboxes / radio switches do not expand
+	max-width: fit-content;
+
+	&__text {
+		line-height: 1.5;
+
+		&:empty {
+			// hide text if empty to ensure checkbox outline is a circle instead of oval
+			display: none;
+		}
+	}
+
+	&__icon > * {
+		color: var(--color-primary-element);
+		width: var(--icon-size);
+		height: var(--icon-size);
+	}
+
+	&, * {
+		cursor: pointer;
+	}
+}
+</style>

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -267,50 +267,43 @@ export default {
 			'checkbox-radio-switch--button-variant': buttonVariant,
 			'checkbox-radio-switch--button-variant-v-grouped': buttonVariant && buttonVariantGrouped === 'vertical',
 			'checkbox-radio-switch--button-variant-h-grouped': buttonVariant && buttonVariantGrouped === 'horizontal',
+			'button-vue': isButtonType,
 		}"
+		class="checkbox-radio-switch"
 		:style="cssVars"
-		class="checkbox-radio-switch">
-		<input :id="id"
+		v-on="isButtonType ? listeners : null">
+		<input v-if="!isButtonType"
+			:id="id"
 			class="checkbox-radio-switch__input"
 			:disabled="disabled"
 			:type="inputType"
 			:value="value"
 			v-bind="inputProps"
-			v-on="inputListeners">
-		<label :for="id" class="checkbox-radio-switch__label">
-			<div class="checkbox-radio-switch__icon">
-				<!-- @slot The checkbox/radio icon, you can use it for adding an icon to the button variant
-						@binding {bool} checked The input checked state
-						@binding {bool} loading The loading state
-				-->
-				<slot name="icon"
-					:checked="isChecked"
-					:loading="loading">
-					<NcLoadingIcon v-if="loading" />
-					<component :is="checkboxRadioIconElement"
-						v-else-if="!buttonVariant"
-						:size="size" />
-				</slot>
-			</div>
+			v-on="listeners">
+		<NcCheckboxContent :id="id"
+			class="checkbox-radio-switch__content"
+			icon-class="checkbox-radio-switch__icon"
+			text-class="checkbox-radio-switch__text"
+			:type="type"
+			:button-variant="buttonVariant"
+			:is-checked="isChecked"
+			:loading="loading"
+			:size="size">
+			<template #icon>
+				<!-- @slot The checkbox/radio icon, you can use it for adding an icon to the button variant -->
+				<slot name="icon" />
+			</template>
 
 			<!-- @slot The checkbox/radio label -->
-			<span class="checkbox-radio-switch__label-text"><slot /></span>
-		</label>
+			<slot />
+		</NcCheckboxContent>
 	</component>
 </template>
 
 <script>
-import NcLoadingIcon from '../NcLoadingIcon/index.js'
+import NcCheckboxContent from './NcCheckboxContent.vue'
 import GenRandomId from '../../utils/GenRandomId.js'
 import l10n from '../../mixins/l10n.js'
-
-import CheckboxBlankOutline from 'vue-material-design-icons/CheckboxBlankOutline.vue'
-import MinusBox from 'vue-material-design-icons/MinusBox.vue'
-import CheckboxMarked from 'vue-material-design-icons/CheckboxMarked.vue'
-import RadioboxMarked from 'vue-material-design-icons/RadioboxMarked.vue'
-import RadioboxBlank from 'vue-material-design-icons/RadioboxBlank.vue'
-import ToggleSwitchOff from 'vue-material-design-icons/ToggleSwitchOff.vue'
-import ToggleSwitch from 'vue-material-design-icons/ToggleSwitch.vue'
 
 export const TYPE_CHECKBOX = 'checkbox'
 export const TYPE_RADIO = 'radio'
@@ -321,7 +314,7 @@ export default {
 	name: 'NcCheckboxRadioSwitch',
 
 	components: {
-		NcLoadingIcon,
+		NcCheckboxContent,
 	},
 
 	mixins: [l10n],
@@ -429,21 +422,24 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-
-		/**
-		 * Wrapping element tag
-		 */
-		wrapperElement: {
-			type: String,
-			default: 'span',
-		},
 	},
 
 	emits: ['update:checked'],
 
 	computed: {
+		isButtonType() {
+			return this.type === TYPE_BUTTON
+		},
+
+		wrapperElement() {
+			if (this.isButtonType) {
+				return 'button'
+			}
+			return 'span'
+		},
+
 		inputProps() {
-			if (this.type === TYPE_BUTTON) {
+			if (this.isButtonType) {
 				return null
 			}
 			return {
@@ -454,8 +450,8 @@ export default {
 			}
 		},
 
-		inputListeners() {
-			if (this.type === TYPE_BUTTON) {
+		listeners() {
+			if (this.isButtonType) {
 				return {
 					click: this.onToggle,
 				}
@@ -468,7 +464,7 @@ export default {
 		/**
 		 * Icon size
 		 *
-		 @return {number}
+		 * @return {number}
 		 */
 		size() {
 			return this.type === TYPE_SWITCH
@@ -520,37 +516,6 @@ export default {
 				return this.checked === this.value
 			}
 			return this.checked === true
-		},
-
-		/**
-		 * Returns the proper Material icon depending on the select case
-		 *
-		 * @return {object}
-		 */
-		checkboxRadioIconElement() {
-			if (this.type === TYPE_RADIO) {
-				if (this.isChecked) {
-					return RadioboxMarked
-				}
-				return RadioboxBlank
-			}
-
-			// Switch
-			if (this.type === TYPE_SWITCH) {
-				if (this.isChecked) {
-					return ToggleSwitch
-				}
-				return ToggleSwitchOff
-			}
-
-			// Checkbox
-			if (this.indeterminate) {
-				return MinusBox
-			}
-			if (this.isChecked) {
-				return CheckboxMarked
-			}
-			return CheckboxBlankOutline
 		},
 	},
 
@@ -619,6 +584,9 @@ export default {
 .checkbox-radio-switch {
 	display: flex;
 	align-items: center;
+	background-color: transparent;
+	font-size: var(--default-font-size);
+	padding: unset;
 
 	&__input {
 		position: absolute;
@@ -630,64 +598,34 @@ export default {
 		margin: 4px $icon-margin;
 	}
 
-	&__input:focus-visible + label {
+	&__input:focus-visible + &__content {
 		outline: 2px solid var(--color-primary-element) !important;
 	}
 
-	&__label {
-		display: flex;
-		align-items: center;
-		flex-direction: row;
-		gap: 4px;
-		user-select: none;
-		min-height: $clickable-area;
-		border-radius: $clickable-area;
-		padding: 4px $icon-margin;
-		// Set to 100% to make text overflow work on button style
-		width: 100%;
-		// but restrict to content so plain checkboxes / radio switches do not expand
-		max-width: fit-content;
-
-		&, * {
-			cursor: pointer;
-		}
-
-		&-text:empty {
-			// hide text if empty to ensure checkbox outline is a circle instead of oval
-			display: none;
-		}
-	}
-
-	&__icon > * {
-		color: var(--color-primary-element);
-		width: var(--icon-size);
-		height: var(--icon-size);
-	}
-
-	&--disabled &__label {
+	&--disabled &__content {
 		opacity: $opacity_disabled;
-		.checkbox-radio-switch__icon > * {
+		:deep(.checkbox-radio-switch__icon) > * {
 			color: var(--color-main-text)
 		}
 	}
 
-	&:not(&--disabled, &--checked):focus-within &__label,
-	&:not(&--disabled, &--checked) &__label:hover {
+	&:not(&--disabled, &--checked):focus-within &__content,
+	&:not(&--disabled, &--checked) &__content:hover {
 		background-color: var(--color-background-hover);
 	}
 
-	&--checked:not(&--disabled):focus-within &__label,
-	&--checked:not(&--disabled) &__label:hover {
+	&--checked:not(&--disabled):focus-within &__content,
+	&--checked:not(&--disabled) &__content:hover {
 		background-color: var(--color-primary-element-light-hover);
 	}
 
 	// Switch specific rules
-	&-switch:not(&--checked) &__icon > * {
+	&-switch:not(&--checked) :deep(.checkbox-radio-switch__icon) > * {
 		color: var(--color-text-maxcontrast);
 	}
 
 	// If switch is checked AND disabled, use the fade primary colour
-	&-switch.checkbox-radio-switch--disabled.checkbox-radio-switch--checked &__icon > * {
+	&-switch.checkbox-radio-switch--disabled.checkbox-radio-switch--checked :deep(.checkbox-radio-switch__icon) > * {
 		color: var(--color-primary-element-light);
 	}
 
@@ -702,14 +640,14 @@ export default {
 		&--checked {
 			font-weight: bold;
 
-			label {
+			.checkbox-radio-switch__content {
 				background-color: var(--color-primary-element-light);
 			}
 		}
 	}
 
 	// Text overflow of button style
-	&--button-variant &__label-text {
+	&--button-variant :deep(.checkbox-radio-switch__text) {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -717,22 +655,22 @@ export default {
 	}
 
 	// Set icon color for non active elements to main text color
-	&--button-variant:not(&--checked) &__icon > * {
+	&--button-variant:not(&--checked) :deep(.checkbox-radio-switch__icon) > * {
 		color: var(--color-main-text);
 	}
 
 	// Hide icon container if empty to remove virtual padding
-	&--button-variant &__icon:empty {
+	&--button-variant :deep(.checkbox-radio-switch__icon:empty) {
 		display: none;
 	}
 
 	&--button-variant:not(&--button-variant-v-grouped):not(&--button-variant-h-grouped),
-	&--button-variant &__label {
+	&--button-variant &__content {
 		border-radius: $border-radius;
 	}
 
 	/* Special rules for vertical button groups */
-	&--button-variant-v-grouped &__label {
+	&--button-variant-v-grouped &__content {
 		flex-basis: 100%;
 		// vertically grouped buttons should all have the same width
 		max-width: unset;
@@ -750,7 +688,7 @@ export default {
 		// remove borders between elements
 		&:not(:last-of-type) {
 			border-bottom: 0!important;
-			.checkbox-radio-switch__label {
+			.checkbox-radio-switch__content {
 				margin-bottom: 2px;
 			}
 		}
@@ -773,7 +711,7 @@ export default {
 		// remove borders between elements
 		&:not(:last-of-type) {
 			border-right: 0!important;
-			.checkbox-radio-switch__label {
+			.checkbox-radio-switch__content {
 				margin-right: 2px;
 			}
 		}
@@ -781,10 +719,10 @@ export default {
 			border-left: 0!important;
 		}
 	}
-	&--button-variant-h-grouped &__label-text {
+	&--button-variant-h-grouped :deep(.checkbox-radio-switch__text) {
 		text-align: center;
 	}
-	&--button-variant-h-grouped &__label {
+	&--button-variant-h-grouped &__content {
 		flex-direction: column;
 		justify-content: center;
 		width: 100%;

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -271,6 +271,7 @@ export default {
 		}"
 		class="checkbox-radio-switch"
 		:style="cssVars"
+		:type="isButtonType ? 'button' : null"
 		v-on="isButtonType ? listeners : null">
 		<input v-if="!isButtonType"
 			:id="id"

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -259,6 +259,7 @@ export default {
 
 <template>
 	<component :is="wrapperElement"
+		:id="wrapperId"
 		:class="{
 			['checkbox-radio-switch-' + type]: type,
 			'checkbox-radio-switch--checked': isChecked,
@@ -321,7 +322,6 @@ export default {
 	mixins: [l10n],
 
 	props: {
-
 		/**
 		 * Unique id attribute of the input
 		 */
@@ -329,6 +329,14 @@ export default {
 			type: String,
 			default: () => 'checkbox-radio-switch-' + GenRandomId(),
 			validator: id => id.trim() !== '',
+		},
+
+		/**
+		 * Unique id attribute of the wrapper element
+		 */
+		wrapperId: {
+			type: String,
+			default: null,
 		},
 
 		/**

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -593,9 +593,11 @@ export default {
 .checkbox-radio-switch {
 	display: flex;
 	align-items: center;
+	color: var(--color-main-text);
 	background-color: transparent;
 	font-size: var(--default-font-size);
-	padding: unset;
+	line-height: var(--default-line-height);
+	padding: 0;
 
 	&__input {
 		position: absolute;

--- a/tests/unit/components/NcAppSidebar/NcAppSidebarTabs.spec.js
+++ b/tests/unit/components/NcAppSidebar/NcAppSidebarTabs.spec.js
@@ -121,17 +121,17 @@ describe('NcAppSidebarTabs.vue', () => {
 				expect(liList.length).toEqual(3)
 			})
 			it('emit "update:active" event with the selected tab id when clicking on a tab', () => {
-				const lastLink = wrapper.find('div[role="tablist"]>.checkbox-radio-switch:last-of-type>label')
+				const lastLink = wrapper.find('div[role="tablist"]>button.checkbox-radio-switch:last-of-type')
 				lastLink.trigger('click')
 				expect(wrapper.emitted('update:active')[0]).toEqual(['last'])
 			})
 			it('emit "update:active" event with the first tab id when keydown pageup is pressed', () => {
-				const lastLink = wrapper.find('div[role="tablist"]>.checkbox-radio-switch:last-of-type>label')
+				const lastLink = wrapper.find('div[role="tablist"]>button.checkbox-radio-switch:last-of-type')
 				lastLink.trigger('keydown.pageup')
 				expect(wrapper.emitted('update:active')[0]).toEqual(['first'])
 			})
 			it('emit "update:active" event with the last tab id when keydown pagedown is pressed', () => {
-				const lastLink = wrapper.find('div[role="tablist"]>.checkbox-radio-switch:last-of-type>label')
+				const lastLink = wrapper.find('div[role="tablist"]>button.checkbox-radio-switch:last-of-type')
 				lastLink.trigger('keydown.pagedown')
 				expect(wrapper.emitted('update:active')[0]).toEqual(['last'])
 			})
@@ -141,12 +141,12 @@ describe('NcAppSidebarTabs.vue', () => {
 				})
 				it('does not emit "update:active" event when keydown left is pressed', () => {
 					expect(wrapper.emitted('update:active')).toBeFalsy()
-					const firstLink = wrapper.find('div[role="tablist"]>.checkbox-radio-switch>label')
+					const firstLink = wrapper.find('div[role="tablist"]>button.checkbox-radio-switch')
 					firstLink.trigger('keydown.left')
 					expect(wrapper.emitted('update:active')).toBeFalsy()
 				})
 				it('emit "update:active" event with the next tab id when keydown right is pressed', () => {
-					const firstLink = wrapper.find('div[role="tablist"]>.checkbox-radio-switch>label')
+					const firstLink = wrapper.find('div[role="tablist"]>button.checkbox-radio-switch')
 					firstLink.trigger('keydown.right')
 					expect(wrapper.emitted('update:active')[0]).toEqual(['second'])
 				})
@@ -156,13 +156,13 @@ describe('NcAppSidebarTabs.vue', () => {
 					wrapper.setData({ activeTab: 'last' })
 				})
 				it('emit "update:active" event with the previous tab id when keydown left is pressed', () => {
-					const lastLink = wrapper.find('div[role="tablist"]>.checkbox-radio-switch:last-of-type>label')
+					const lastLink = wrapper.find('div[role="tablist"]>button.checkbox-radio-switch:last-of-type')
 					lastLink.trigger('keydown.left')
 					expect(wrapper.emitted('update:active')[0]).toEqual(['second'])
 				})
 				it('does not emit "update:active" event when keydown right is pressed', () => {
 					expect(wrapper.emitted('update:active')).toBeFalsy()
-					const lastLink = wrapper.find('div[role="tablist"]>.checkbox-radio-switch:last-of-type>label')
+					const lastLink = wrapper.find('div[role="tablist"]>button.checkbox-radio-switch:last-of-type')
 					lastLink.trigger('keydown.right')
 					expect(wrapper.emitted('update:active')).toBeFalsy()
 				})


### PR DESCRIPTION
- For https://github.com/nextcloud/server/issues/37107

### Summary

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/24800714/c0bc8069-becf-4ab1-a4c9-bbf81a0faaca) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/24800714/5e2f4345-d02c-4785-b72b-2294a1be52a5)

- Fix glitchy <kbd>Tab</kbd> + <kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> <kbd>→</kbd> navigation, now only <kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> <kbd>→</kbd> will change tab focus
- Fix tabpanel association
- Test on server
- Test with NVDA
- Update tests

> No visual changes

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable