### PR TITLE
fix(NcTextField): do not pass all props to InputField BY stop passing $props

### DIFF
--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -130,9 +130,10 @@ export default {
 </docs>
 
 <template>
-	<NcInputField v-bind="{...$attrs, ...$props }"
-		ref="inputField"
-		:trailing-button-label="clearTextLabel"
+	<NcInputField ref="inputField"
+		:trailing-button-label="trailingButtonLabel"
+		:type="type"
+		v-bind="$attrs"
 		v-on="$listeners"
 		@input="handleInput">
 		<!-- Default slot for the leading icon -->
@@ -171,11 +172,39 @@ export default {
 	inheritAttrs: false,
 
 	props: {
-		...NcInputField.props,
+		/**
+		 * Any NcInputField props
+		 */
+		// Not an actual prop but needed to show in vue-styleguidist docs
+		// eslint-disable-next-line
+		' ': {},
+
+		trailingButtonLabel: {
+			type: String,
+			default: t('Clear text'),
+		},
+
+		/**
+		 * The type of the input element
+		 * @type {'text'|'email'|'tel'|'url'|'search'|'number'}
+		 */
+		type: {
+			type: String,
+			default: 'text',
+			validator: (value) => [
+				'text',
+				'email',
+				'tel',
+				'url',
+				'search',
+				'number',
+			].includes(value),
+		},
 
 		/**
 		 * Specifies which material design icon should be used for the trailing
 		 * button. Value can be `close`, `arrowRight`, or `undo`.
+		 * @type {'close'|'arrowRight'|'undo'}
 		 */
 		trailingButtonIcon: {
 			type: String,
@@ -193,8 +222,6 @@ export default {
 	],
 
 	computed: {
-		clearTextLabel() {
-			return this.trailingButtonLabel || t('Clear text')
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

HTML Validation issue.

Currently `NcTextField` passes both `$attrs` and `$props` to the `NcInputField`.

```html
<NcInputField v-bind="{ ...$attrs, ...$props }">
```

While passing `$attrs` makes sense, passing `$props` is valid only when both components have **exactly** the same props. But they don't. `NcTextField` has its own prop `trailingButtonIcon` and may have more props in the future.

---

**Proposal:** same as `NcPopover`

Currently, all `NcInputField` props are defined as `NcTextField` props. But actually they are not `NcTextField` props. They are not used but `NcTextField`, it is not aware of most of them at all. It is used only for styleguidist documentation generation.

The proposal is to make component a transparent wrapper by passing attributes directly, defining only necessary props. 

**Alternative solution:** 

~~While I personally prefer this solution,~~ there is an alternative: filter out props on proxying.

See: https://github.com/nextcloud-libraries/nextcloud-vue/pull/4666

### 🖼️ Screenshots

`trailingbuttonicon` is not a valid `<input>` attribute.

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a964f791-c87a-4d9d-9842-7e391f0816d2)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
