### PR TITLE
fix(Nc*Field): do not pass all props to InputField BY filtering $props

### DIFF
--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -128,6 +128,21 @@ import { generateOcsUrl } from '@nextcloud/router'
 import { t } from '../../l10n.js'
 import logger from '../../utils/logger.js'
 
+/**
+ * @typedef PasswordPolicy
+ * @property {object} api - The URLs to the password_policy app methods
+ * @property {string} api.generate - The URL to the password generator
+ * @property {string} api.validate - The URL to the password validator
+ * @property {boolean} enforceNonCommonPassword - Whether to enforce non common passwords
+ * @property {boolean} enforceNumericCharacters - Whether to enforce numeric characters
+ * @property {boolean} enforceSpecialCharacters - Whether to enforce special characters
+ * @property {boolean} enforceUpperLowerCase - Whether to enforce upper and lower case
+ * @property {number} minLength - The minimum length of the password
+ */
+
+/** @type {PasswordPolicy|null} */
+const passwordPolicy = loadState('core', 'capabilities', {}).password_policy || null
+
 const NcInputFieldProps = new Set(Object.keys(NcInputField.props))
 
 export default {
@@ -210,7 +225,6 @@ export default {
 		return {
 			isPasswordHidden: true,
 			internalHelpMessage: '',
-			passwordPolicy: loadState('core', 'capabilities', {}).password_policy || null,
 			isValid: null,
 		}
 	},
@@ -230,7 +244,7 @@ export default {
 		},
 
 		rules() {
-			const { minlength, passwordPolicy } = this
+			const { minlength } = this
 			return {
 				minlength: minlength ?? passwordPolicy?.minLength,
 			}
@@ -255,12 +269,10 @@ export default {
 	watch: {
 		value(newValue) {
 			if (this.checkPasswordStrength) {
-				if (this.passwordPolicy === null) {
+				if (passwordPolicy === null) {
 					return
 				}
-				if (this.passwordPolicy) {
-					this.checkPassword(newValue)
-				}
+				this.checkPassword(newValue)
 			}
 		},
 	},

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -96,10 +96,9 @@ export default {
 </docs>
 
 <template>
-	<NcInputField v-bind="{...$attrs, ...$props }"
+	<NcInputField v-bind="propsAndAttrsToForward"
 		ref="inputField"
 		:type="isPasswordHidden ? 'password' : 'text'"
-		:show-trailing-button="showTrailingButton"
 		:trailing-button-label="trailingButtonLabelPassword"
 		:helper-text="computedHelperText"
 		:error="computedError"
@@ -129,6 +128,8 @@ import { generateOcsUrl } from '@nextcloud/router'
 import { t } from '../../l10n.js'
 import logger from '../../utils/logger.js'
 
+const NcInputFieldProps = new Set(Object.keys(NcInputField.props))
+
 export default {
 	name: 'NcPasswordField',
 
@@ -142,17 +143,31 @@ export default {
 	inheritAttrs: false,
 
 	props: {
+		/**
+		 * Any [NcInputField](#/Components/NcFields?id=ncinputfield) props
+		 */
+		// Not an actual prop but needed to show in vue-styleguidist docs
+		// eslint-disable-next-line
+		' ': {},
+
+		// Reuse all the props from NcInputField for better typing and documentation
 		...NcInputField.props,
 
+		// Redefined props
+
 		/**
-		 * Additional error message
-		 *
-		 * This will be displayed beneath the input field
+		 * Controls whether to display the trailing button.
 		 */
-		helperText: {
-			type: String,
-			default: '',
+		 showTrailingButton: {
+			type: Boolean,
+			default: true,
 		},
+
+		// Removed NcInputField props, defined only by this component
+
+		trailingButtonLabel: undefined,
+
+		// Custom props
 
 		/**
 		 * Check if the user entered a valid password using the password_policy
@@ -182,14 +197,6 @@ export default {
 		maxlength: {
 			type: Number,
 			default: null,
-		},
-
-		/**
-		 * Controls whether to display the trailing button.
-		 */
-		showTrailingButton: {
-			type: Boolean,
-			default: true,
 		},
 	},
 
@@ -231,6 +238,17 @@ export default {
 
 		trailingButtonLabelPassword() {
 			return this.isPasswordHidden ? t('Show password') : t('Hide password')
+		},
+
+		propsAndAttrsToForward() {
+			return {
+				// Proxy all the HTML attributes
+				...this.$attrs,
+				// Proxy original NcInputField's props
+				...Object.fromEntries(
+					Object.entries(this.$props).filter(([key]) => NcInputFieldProps.has(key)),
+				),
+			}
 		},
 	},
 

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -130,9 +130,8 @@ export default {
 </docs>
 
 <template>
-	<NcInputField v-bind="{...$attrs, ...$props }"
+	<NcInputField v-bind="propsAndAttrsToForward"
 		ref="inputField"
-		:trailing-button-label="clearTextLabel"
 		v-on="$listeners"
 		@input="handleInput">
 		<!-- Default slot for the leading icon -->
@@ -157,6 +156,8 @@ import Undo from 'vue-material-design-icons/UndoVariant.vue'
 
 import { t } from '../../l10n.js'
 
+const NcInputFieldProps = new Set(Object.keys(NcInputField.props))
+
 export default {
 	name: 'NcTextField',
 
@@ -171,11 +172,32 @@ export default {
 	inheritAttrs: false,
 
 	props: {
+		/**
+		 * Any [NcInputField](#/Components/NcFields?id=ncinputfield) props
+		 */
+		// Not an actual prop but needed to show in vue-styleguidist docs
+		// eslint-disable-next-line
+		' ': {},
+
+		// Reuse all the props from NcInputField for better typing and documentation
 		...NcInputField.props,
+
+		// Redefined props
+
+		/**
+		 * Label of the trailing button
+		 */
+		trailingButtonLabel: {
+			type: String,
+			default: t('Clear text'),
+		},
+
+		// Custom props
 
 		/**
 		 * Specifies which material design icon should be used for the trailing
-		 * button. Value can be `close`, `arrowRight`, or `undo`.
+		 * button.
+		 * @type {'close'|'arrowRight'|'undo'}
 		 */
 		trailingButtonIcon: {
 			type: String,
@@ -193,8 +215,15 @@ export default {
 	],
 
 	computed: {
-		clearTextLabel() {
-			return this.trailingButtonLabel || t('Clear text')
+		propsAndAttrsToForward() {
+			return {
+				// Proxy all the HTML attributes
+				...this.$attrs,
+				// Proxy original NcInputField's props
+				...Object.fromEntries(
+					Object.entries(this.$props).filter(([key]) => NcInputFieldProps.has(key)),
+				),
+			}
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

HTML Validation issue.

Currently `NcTextField` passes both `$attrs` and `$props` to the `NcInputField`.

```html
<NcInputField v-bind="{ ...$attrs, ...$props }">
```

While passing `$attrs` makes sense, passing `$props` is valid only when both components have **exactly** the same props. But they don't. `NcTextField` has its own prop `trailingButtonIcon` and may have more props in the future.

**Proposal:** same as `NcSelect`.

Filter props to proxy only original `NcInputField` props.

**Alternative solution:** do not use props for proxying.

See: https://github.com/nextcloud-libraries/nextcloud-vue/pull/4665

### 🖼️ Screenshots

`trailingbuttonicon` is not a valid `<input>` attribute.

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a964f791-c87a-4d9d-9842-7e391f0816d2)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
