### PR TITLE
fix(NcDashboardWidgetItem): do not assign href="" with empty link

### DIFF
--- a/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
+++ b/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
@@ -31,7 +31,7 @@ This component is meant to be used inside a DashboardWidget component.
 <template>
 	<div @mouseover="hovered = true" @mouseleave="hovered = false">
 		<component :is="targetUrl ? 'a' : 'div'"
-			:href="targetUrl"
+			:href="targetUrl || undefined"
 			:target="targetUrl ? '_blank' : undefined"
 			:class="{ 'item-list__entry': true, 'item-list__entry--has-actions-menu': gotMenu }"
 			@click="onLinkClick">


### PR DESCRIPTION
### ☑️ Resolves

* A part of https://github.com/nextcloud/server/issues/37092

When `NcDashboardWidgetItem` has empty `targetUrl`, it is rendered as `div`, but still has `href=""` which is not a valid HTML

### 🖼️ Screenshots

No visual changes

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
