### PR TITLE
fix(NcActions): do not pass popoverBaseClass as an attr to NcPopover

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1101,7 +1101,6 @@ export default {
 						boundary: this.boundariesElement,
 						container: this.container,
 						...this.manualOpen && { triggers: [] },
-						popoverBaseClass: 'action-item__popper',
 					},
 					on: {
 						show: this.openMenu,


### PR DESCRIPTION
### ☑️ Resolves

* A part of https://github.com/nextcloud/server/issues/37092

Currently for some reason all props of `NcActions` are passed twice to `NcPopover`: as props and as attrs

https://github.com/nextcloud-libraries/nextcloud-vue/blob/d93993902c86fdc78403479b377242a17910cc50/src/components/NcActions/NcActions.vue#L1080-L1105

But `popoverBaseClass` is not a `NcPopover` prop but `NcActions` own prop. It should not be passed as an attribute. It results with an invalid `popoverbaseclass` attribute on an HTML element.

### 🖼️ Screenshots

No visual changes

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
