### PR TITLE
fix(NcAvatar): make it a span phrasing element

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -108,7 +108,7 @@ export default {
 
 </docs>
 <template>
-	<div ref="main"
+	<span ref="main"
 		v-click-outside="closeMenu"
 		:class="{
 			'avatardiv--unknown': userDoesNotExist,
@@ -128,7 +128,7 @@ export default {
 		<!-- @slot Icon slot -->
 		<slot name="icon">
 			<!-- Avatar icon or image -->
-			<div v-if="iconClass" :class="iconClass" class="avatar-class-icon" />
+			<span v-if="iconClass" :class="iconClass" class="avatar-class-icon" />
 			<img v-else-if="isAvatarLoaded && !userDoesNotExist"
 				:src="avatarUrlLoaded"
 				:srcset="avatarSrcSetLoaded"
@@ -164,23 +164,23 @@ export default {
 		</NcActions>
 
 		<!-- Avatar status -->
-		<div v-if="showUserStatusIconOnAvatar" class="avatardiv__user-status avatardiv__user-status--icon">
+		<span v-if="showUserStatusIconOnAvatar" class="avatardiv__user-status avatardiv__user-status--icon">
 			{{ userStatus.icon }}
-		</div>
-		<div v-else-if="canDisplayUserStatus"
+		</span>
+		<span v-else-if="canDisplayUserStatus"
 			class="avatardiv__user-status"
 			:class="'avatardiv__user-status--' + userStatus.status"
 			v-bind="userStatusRole" />
 
 		<!-- Show the letter if no avatar nor icon class -->
-		<div v-if="userDoesNotExist && !(iconClass || $slots.icon)"
+		<span v-if="userDoesNotExist && !(iconClass || $slots.icon)"
 			:style="initialsWrapperStyle"
 			class="avatardiv__initials-wrapper">
-			<div :style="initialsStyle" class="unknown">
+			<span :style="initialsStyle" class="unknown">
 				{{ initials }}
-			</div>
-		</div>
-	</div>
+			</span>
+		</span>
+	</span>
 </template>
 
 <script>
@@ -395,7 +395,7 @@ export default {
 		},
 		/**
 		 * If the avatar has no menu no aria-label is assigned, but for accessibility we still need the status to be accessible
-		 * So this sets `role=img` on the status indicator (div with background) and the required `alt` and `aria-label` attributes.
+		 * So this sets `role=img` on the status indicator (span with background) and the required `alt` and `aria-label` attributes.
 		 */
 		userStatusRole() {
 			// only needed if non-interactive, otherwise the aria-label is set
@@ -777,6 +777,7 @@ export default {
 	}
 
 	.avatardiv__initials-wrapper {
+		display: block;
 		height: var(--size);
 		width: var(--size);
 		background-color: var(--color-main-background);
@@ -855,6 +856,7 @@ export default {
 }
 
 .avatar-class-icon {
+	display: block;
 	border-radius: 50%;
 	background-color: var(--color-background-darker);
 	height: 100%;


### PR DESCRIPTION
It is required to allow using avatar as a phrasing content, for example, as a button content.

### ☑️ Resolves

> **Error: Element [`div`](https://html.spec.whatwg.org/multipage/#the-div-element) not allowed as child of element [`button`](https://html.spec.whatwg.org/multipage/#the-button-element) in this context. (Suppressing further errors from this subtree.)**

* A part of https://github.com/nextcloud/server/issues/37092

Sometimes we use `NcAvatar` as a button content, for example, as a Popover trigger on the main UserMenu.

HTML does not allow this. Button should have only so-called phrasing (aca inline text) content.

This PR makes `NcAvatar` a `span` instead of a `div`. 

For some places it doesn't change anything in the layout, because it has `display: inline-block`, or `position: absolute`. In other places `display: block;` was implicitly added.

**Alternative solution:** make `NcHeaderItem` not a `<button>` but a `div[role=button]`.

https://github.com/nextcloud-libraries/nextcloud-vue/pull/4675

### 🖼️ Screenshots

No visual changes

User Menu | Comments | Sharing | Talk
---|---|---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e796b889-e063-4f2a-a9cc-397017c259ac) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/99f9fd7e-b9e1-4b66-bfbb-39cd5099d0b1) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9b076d0f-b272-4da8-970d-2c5e6d7f3f5f) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/50ea3a5d-059e-4dd0-8252-98d55ce5723a)


### 🚧 Tasks

- [x] Replace all `div` with a `span`
- [x] Update styles, add `display: block;` where it is required.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
