### PR TITLE
fix: Avoid closing all modals on escape if multiple are present

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -668,6 +668,11 @@ export default {
 		 */
 		handleKeydown(event) {
 			if (event.key === 'Escape') {
+				const trapStack = getTrapStack()
+				// Only close the most recent focus trap modal
+				if (trapStack.length > 0 && trapStack[trapStack.length - 1] !== this.focusTrap) {
+					return
+				}
 				return this.close(event)
 			}
 


### PR DESCRIPTION
### ☑️ Resolves

Do not close all modals if escape is pressed while multiple layered modals are open, e.g. viewer and help dialog or filepicker from text

Steps to reprocuce:
- Open a markdown file in viewer
- Open the formatting help through the menu bar
- Press Escape

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
