### PR TITLE
fix: If a aria-selected button is present we focus on this one instead of the first entry

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -932,7 +932,11 @@ export default {
 		focusFirstAction(event) {
 			if (this.opened) {
 				this.preventIfEvent(event)
-				this.focusIndex = 0
+				// In case a button is considered aria-selected we will use this one as a initial focus
+				const firstSelectedIndex = [...this.$refs.menu.querySelectorAll(focusableSelector)].findIndex((button) => {
+					return button.parentElement.getAttribute('aria-selected')
+				})
+				this.focusIndex = firstSelectedIndex > -1 ? firstSelectedIndex : 0
 				this.focusAction()
 			}
 		},


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>

### ☑️ Resolves

Fixes https://github.com/nextcloud/text/issues/3864

I checked and it seems we cannot easily or nicely change the initial focus of the NcActions entires. (unless we consider using setTimeout an option) within text. Now we don't have a real active state in the NcAction* components which we could use to pick the initial focus element, however since this initial focus handling is mostly bound to accessibility I decided to make a change of the initial focus depending on if any NcAction* entry is indicating a selected state with `aria-selected`.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
