### PR TITLE
fix: remove empty attributes values

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -270,7 +270,7 @@ Just set the `pinned` prop.
 					:aria-description="ariaDescription"
 					:aria-expanded="opened.toString()"
 					:href="href || routerLinkHref || '#'"
-					:target="isExternal(href) ? '_blank' : ''"
+					:target="isExternal(href) ? '_blank' : undefined"
 					:title="title || name"
 					@blur="handleBlur"
 					@click="onClick($event, navigate, routerLinkHref)"

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -279,7 +279,7 @@ export default {
 				<div v-show="showModal"
 					:class="[
 						`modal-wrapper--${size}`,
-						spreadNavigation ? 'modal-wrapper--spread-navigation' : ''
+						{ 'modal-wrapper--spread-navigation': spreadNavigation },
 					]"
 					class="modal-wrapper"
 					@mousedown.self="handleClickModalWrapper">

--- a/src/components/NcNoteCard/NcNoteCard.vue
+++ b/src/components/NcNoteCard/NcNoteCard.vue
@@ -53,7 +53,7 @@ When using an error type,
 <template>
 	<div class="notecard"
 		:class="`notecard--${type}`"
-		:role="shouldShowAlert ? 'alert' : ''">
+		:role="shouldShowAlert ? 'alert' : 'note'">
 		<component :is="icon"
 			class="notecard__icon"
 			:class="{'notecard__icon--heading': heading}"

--- a/src/components/NcUserBubble/NcUserBubble.vue
+++ b/src/components/NcUserBubble/NcUserBubble.vue
@@ -80,7 +80,7 @@ This component has the following slot:
 				class="user-bubble__content"
 				:style="styles.content"
 				:href="hasUrl ? url : null"
-				:class="primary ? 'user-bubble__content--primary' : ''"
+				:class="{ 'user-bubble__content--primary': primary }"
 				@click="onClick">
 				<!-- NcAvatar -->
 				<NcAvatar :url="isCustomAvatar && isAvatarUrl ? avatarImage : undefined"


### PR DESCRIPTION
### ☑️ Resolves

* A part of https://github.com/nextcloud/server/issues/37092

> **Error: Bad value `' '` for attribute `target` on element [`a`](https://html.spec.whatwg.org/multipage/#the-a-element): Browsing context name must be at least one character long.**

### 🖼️ Screenshots

No visual changes

### 🚧 Tasks

- [x] `NcAppNavigationItem`: remove empty string `target`
- [x] `NcNoteCard`: use [`role="note"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/roles/note_role) for non-alert card instead of empty `role=""`
- [x] Some components: refactor ternary with empty string `else` with Vue object class bingings

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
