### PR TITLE
fix(NcCheckboxRadioSwitch): fix circular import

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -58,7 +58,10 @@ import ToggleSwitch from 'vue-material-design-icons/ToggleSwitch.vue'
 
 import NcLoadingIcon from '../NcLoadingIcon/index.js'
 
-import { TYPE_BUTTON, TYPE_CHECKBOX, TYPE_RADIO, TYPE_SWITCH } from './NcCheckboxRadioSwitch.vue'
+export const TYPE_CHECKBOX = 'checkbox'
+export const TYPE_RADIO = 'radio'
+export const TYPE_SWITCH = 'switch'
+export const TYPE_BUTTON = 'button'
 
 export default {
 	name: 'NcCheckboxContent',

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -303,14 +303,9 @@ export default {
 </template>
 
 <script>
-import NcCheckboxContent from './NcCheckboxContent.vue'
+import NcCheckboxContent, { TYPE_BUTTON, TYPE_CHECKBOX, TYPE_RADIO, TYPE_SWITCH } from './NcCheckboxContent.vue'
 import GenRandomId from '../../utils/GenRandomId.js'
 import l10n from '../../mixins/l10n.js'
-
-export const TYPE_CHECKBOX = 'checkbox'
-export const TYPE_RADIO = 'radio'
-export const TYPE_SWITCH = 'switch'
-export const TYPE_BUTTON = 'button'
 
 export default {
 	name: 'NcCheckboxRadioSwitch',


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4689

This fixes the circular import of `NcCheckboxRadioSwitch` and `NcCheckboxContent`. No visual changes.