### PR TITLE
chore: do not show NcCheckboxContent in docs

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -102,6 +102,7 @@ module.exports = async () => {
 					'src/components/NcAppSettings*/*.vue',
 					'src/components/NcAppSidebar*/*.vue',
 					'src/components/NcBreadcrumb*/*.vue',
+					'src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue',
 					'src/components/NcContent/*.vue',
 					'src/components/NcDashboard*/*.vue',
 					'src/components/NcDialog*/*.vue',


### PR DESCRIPTION
### ☑️ Resolves

This simply hides `NcCheckboxContent` from the docs as this component is only internally used and not exported.