### PR TITLE
[next] fix(NcListItemIcon): correctly use default slot in examples

### DIFF
--- a/src/components/NcListItemIcon/NcListItemIcon.vue
+++ b/src/components/NcListItemIcon/NcListItemIcon.vue
@@ -32,9 +32,7 @@ It might be used for list rendering or within the multiselect for example
 ```vue
 	<template>
 		<NcListItemIcon name="User 1" :avatar-size="44">
-			<template>
-				<Account :size="20" />
-			</template>
+			<Account :size="20" />
 		</NcListItemIcon>
 	</template>
 	<script>
@@ -52,9 +50,7 @@ It might be used for list rendering or within the multiselect for example
 ```vue
 	<template>
 		<NcListItemIcon name="Group 1" subname="13 members" :is-no-user="true">
-			<template>
-				<AccountMultiple :size="20" />
-			</template>
+			<AccountMultiple :size="20" />
 		</NcListItemIcon>
 	</template>
 	<script>
@@ -74,9 +70,7 @@ It might be used for list rendering or within the multiselect for example
 		<NcListItemIcon name="Test user 1" subname="callmetest@domain.com" search="test" />
 		<NcListItemIcon name="Testing admin" subname="testme@example.com" search="test" />
 		<NcListItemIcon name="Test group 2" subname="loremipsum@domain.com" :is-no-user="true" search="test">
-			<template>
-				<AccountMultiple :size="20" />
-			</template>
+			<AccountMultiple :size="20" />
 		</NcListItemIcon>
 	</template>
 	<script>


### PR DESCRIPTION
### ☑️ Resolves

* This brings back the icons in the `NcListItemIcon` examples. I couldn't really figure out why it doesn't work when simply using `<template>`. It only works when not wrapping the default slot content, or when using `<template #default>`.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2023-10-24 at 10-05-28 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/c83fed71-0a57-4f43-a734-0079ff4c565c) | ![Screenshot 2023-10-24 at 10-05-14 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/6844eb7b-c0ca-4820-b10a-56e40d43752e)

