### PR TITLE
Create outline for `focus-within` on RadioSwitch

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -620,8 +620,11 @@ export default {
 		margin: 4px $icon-margin;
 	}
 
-	&__input:focus-visible + &__content {
-		outline: 2px solid var(--color-primary-element) !important;
+	&__input:focus-visible + &__content,
+	&__input:focus-visible {
+		outline: 2px solid var(--color-main-text);
+		border-color: var(--color-main-background);
+		outline-offset: -2px;
 	}
 
 	&--disabled &__content {


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/40706

- [x] Equalize styles for focused state: keyboard as well as mouse click
- [x] Apply styles for unchecked state

### 🖼️ Screenshots

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/cd3e7894-c001-48cb-9d60-d60146d56e02) | ![Screenshot from 2023-10-26 13-28-29](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/6d87cae4-4876-4311-a5e2-f86136720aee) |-------------|---------------------------------------------------------------|
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/319eb332-dc5e-4304-aa09-22ad2fa55887) | ![Screenshot from 2023-10-26 13-26-04](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/dac48b08-0a05-418c-ba47-0382201cccf6) |-------------|---------------------------------------------------------------|
| ![Screenshot from 2023-10-26 13-34-43](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/1dfe3ca4-b0f2-4cec-9f02-e3b910888be0) | ![Screenshot from 2023-10-26 13-29-24](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/f1023bf0-a03d-431d-8062-b26cad8c50e9) |-------------|---------------------------------------------------------------|
|  | |-------------|---------------------------------------------------------------|
| ![Screenshot from 2023-10-26 13-35-20](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/1e33e689-8bcf-42c6-aa74-0e0d68be8ce8) | ![Screenshot from 2023-10-26 13-29-14](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/c1c0d143-ea4b-487c-9a64-a4ce603437e2)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
