### PR TITLE
Add header prop to NcRelatedResourcesPanel

### DIFF
--- a/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
+++ b/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
@@ -28,6 +28,7 @@ Use this component to display the related resources of a given item.
 ```
 <template>
 	<NcRelatedResourcesPanel provider-id="talk"
+							 :header="t('Related resources')"
 		:item-id="conversationId" />
 </template>
 
@@ -46,7 +47,7 @@ export default {
 <template>
 	<div v-if="appEnabled && isVisible" class="related-resources">
 		<div class="related-resources__header">
-			<h5>{{ headerTranslated }}</h5>
+			<h5>{{ header }}</h5>
 			<p>{{ description }}</p>
 		</div>
 
@@ -112,6 +113,14 @@ export default {
 			type: Object,
 			default: null,
 		},
+		/**
+		 * Make the header name dynamic
+		 */
+		header: {
+			type: String,
+			default: t('Related resources'),
+
+		},
 	},
 
 	emits: [
@@ -122,7 +131,6 @@ export default {
 	data() {
 		return {
 			appEnabled: OC?.appswebroots?.related_resources !== undefined,
-			headerTranslated: t('Related resources'),
 			loading: false,
 			error: null,
 			resources: [],


### PR DESCRIPTION
### ☑️ Resolves

* Needed for https://github.com/nextcloud/contacts/issues/3364

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A
![related_before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/12728974/12263275-7737-4976-aec0-eceefa03bc74) | ![Screenshot from 2023-10-27 14-33-16](https://github.com/nextcloud-libraries/nextcloud-vue/assets/12728974/d07e1a8a-0deb-4c22-8a22-bd965507b138)



### 🚧 Tasks

- [x] There are many ways how to do this, but for now we only need the app header to be dynamic so each one of the apps can add their own.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
