### PR TITLE
fix(NcRelatedResourcesPanel): t is not defined

### DIFF
--- a/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
+++ b/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
@@ -28,7 +28,7 @@ Use this component to display the related resources of a given item.
 ```
 <template>
 	<NcRelatedResourcesPanel provider-id="talk"
-							 :header="t('Related resources')"
+							 header="Related resources for talk"
 		:item-id="conversationId" />
 </template>
 
@@ -119,7 +119,6 @@ export default {
 		header: {
 			type: String,
 			default: t('Related resources'),
-
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up to #4703, fixes a `ReferenceError: t is not defined` error in the docs.