### PR TITLE
fix(NcAppContent): Set normal scrollbar width on resizeable NcAppContentList

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -388,6 +388,8 @@ export default {
 :deep(.splitpanes.default-theme) {
 	.app-content-list {
 		max-width: none;
+		/* Thin scrollbar is hard to catch on resizable columns */
+		scrollbar-width: auto;
 	}
 
 	.splitpanes__pane {


### PR DESCRIPTION
When `NcAppContentList` is resizeable, a thin scrollbar is hard to catch with the mouse. Set scrollbar width to auto in this case.

* Fixes: #4706

### Screenshots

| Before (hover `NcAppContentList`) in Firefox/Linux | After (hover `NcAppContentList`) in Firefox/Linux |
|---|---|
| ![2023-10-31T09:32:32,543502737+01:00](https://github.com/nextcloud-libraries/nextcloud-vue/assets/3582805/fb70c2c1-b2e0-445a-9df8-82afac1bc45f) |![2023-10-31T09:31:27,365873640+01:00](https://github.com/nextcloud-libraries/nextcloud-vue/assets/3582805/514204ff-3574-45c5-92ab-1bde28a1d5b5) |

| Before (hover scrollbar of `NcAppContentList`) in Firefox/Linux | After (hover scrollbar of `NcAppContentList`) in Firefox/Linux |
|---|---|
| ![2023-10-31T09:32:38,423200946+01:00](https://github.com/nextcloud-libraries/nextcloud-vue/assets/3582805/9c2e1325-0de4-4613-b91f-f3a6e4084c29) | ![2023-10-31T09:30:52,494629227+01:00](https://github.com/nextcloud-libraries/nextcloud-vue/assets/3582805/5405c57c-67b2-4b2b-b613-abbd0cb264dd)

In Chrome there's no visible change.

Please also see the screencast of the situation without this change in issue #4706.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
