### PR TITLE
fix(NcAppNavigationItem): Do not include `aria-expanded` attribute if there are no children

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -268,7 +268,7 @@ Just set the `pinned` prop.
 				<a v-if="!undo"
 					class="app-navigation-entry-link"
 					:aria-description="ariaDescription"
-					:aria-expanded="opened.toString()"
+					:aria-expanded="hasChildren ? opened.toString() : undefined"
 					:href="href || routerLinkHref || '#'"
 					:target="isExternal(href) ? '_blank' : undefined"
 					:title="title || name"


### PR DESCRIPTION
### ☑️ Resolves

If there are no children it can not be expanded and as such the attribute should be removed.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
