### PR TITLE
feat(NcActionButton): support menu styling 

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -115,7 +115,7 @@
 		&__longtext {
 			cursor: pointer;
 			// allow the use of `\n`
-			white-space: pre-wrap;
+			white-space: pre-wrap !important;
 		}
 
 		&__name {

--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -126,5 +126,13 @@
 			max-width: 100%;
 			display: inline-block;
 		}
+
+		&__menu-icon {
+			// Push to the right
+			margin-left: auto;
+			// Align with right end of the button
+			// This is the padding-right
+			margin-right: -$icon-margin;
+		}
 	}
 }

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -211,7 +211,7 @@ export default {
 			<!-- default text display -->
 			<span v-else class="action-button__text">{{ text }}</span>
 
-			<!-- default text display -->
+			<!-- right arrow icon when there is a sub-menu -->
 			<ChevronRightIcon v-if="isMenu" class="action-button__menu-icon" />
 
 			<!-- fake slot to gather inner text -->

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -26,35 +26,32 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 
 ```vue
 	<template>
-		<div style="display: flex; align-items: center;">
-			<NcActions>
-				<NcActionButton @click="showMessage('Delete')">
-					<template #icon>
-						<Delete :size="20" />
-					</template>
-					Delete
-				</NcActionButton>
-				<NcActionButton :close-after-click="true" @click="showMessage('Delete and close menu')">
-					<template #icon>
-						<Delete :size="20" />
-					</template>
-					Delete and close
-				</NcActionButton>
-				<NcActionButton :close-after-click="true" @click="focusInput">
-					<template #icon>
-						<Plus :size="20" />
-					</template>
-					Create
-				</NcActionButton>
-				<NcActionButton :disabled="true" @click="showMessage('Disabled')">
-					<template #icon>
-						<Delete :size="20" />
-					</template>
-					Disabled button
-				</NcActionButton>
-			</NcActions>
-			<input ref="input" />
-		</div>
+		<NcActions>
+			<NcActionButton @click="showMessage('Delete')">
+				<template #icon>
+					<Delete :size="20" />
+				</template>
+				Delete
+			</NcActionButton>
+			<NcActionButton :close-after-click="true" @click="showMessage('Delete and close menu')">
+				<template #icon>
+					<Delete :size="20" />
+				</template>
+				Delete and close
+			</NcActionButton>
+			<NcActionButton :is-menu="true">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
+				Create
+			</NcActionButton>
+			<NcActionButton :disabled="true" @click="showMessage('Disabled')">
+				<template #icon>
+					<Delete :size="20" />
+				</template>
+				Disabled button
+			</NcActionButton>
+		</NcActions>
 	</template>
 	<script>
 	import Delete from 'vue-material-design-icons/Delete'
@@ -68,9 +65,6 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 		methods: {
 			showMessage(msg) {
 				alert(msg)
-			},
-			focusInput() {
-				this.$nextTick(() => this.$refs.input.focus())
 			},
 		},
 	}
@@ -217,6 +211,9 @@ export default {
 			<!-- default text display -->
 			<span v-else class="action-button__text">{{ text }}</span>
 
+			<!-- default text display -->
+			<ChevronRightIcon v-if="isMenu" class="action-button__menu-icon" />
+
 			<!-- fake slot to gather inner text -->
 			<slot v-if="false" />
 		</button>
@@ -224,6 +221,7 @@ export default {
 </template>
 
 <script>
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import ActionTextMixin from '../../mixins/actionText.js'
 
 /**
@@ -232,6 +230,9 @@ import ActionTextMixin from '../../mixins/actionText.js'
 export default {
 	name: 'NcActionButton',
 
+	components: {
+		ChevronRightIcon,
+	},
 	mixins: [ActionTextMixin],
 
 	props: {
@@ -242,12 +243,22 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
 		/**
 		 * aria-hidden attribute for the icon slot
 		 */
 		ariaHidden: {
 			type: Boolean,
 			default: null,
+		},
+
+		/**
+		 * If this is a menu, a chevron icon will
+		 * be added at the end of the line
+		 */
+		isMenu: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	computed: {


### PR DESCRIPTION

![Peek 31-10-2023 11-08](https://github.com/nextcloud-libraries/nextcloud-vue/assets/14975046/ff09d5ee-7656-46ab-a971-be26a2fddb0c)


- Only for the ActionButton (see [context](https://github.com/nextcloud/server/pull/41010))
- Cleaned the [documentation](https://github.com/nextcloud-libraries/nextcloud-vue/pull/3030/#discussion_r1377287691)
- Also fix regression from [here](https://github.com/nextcloud-libraries/nextcloud-vue/pull/4648#issuecomment-1786843212) 