### PR TITLE
fix(NcSelect): Ensure selected option has enough contrast when the menu is opened

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1143,6 +1143,9 @@ body {
 			.vs__selected {
 				// Fix `max-width` for `position: absolute`
 				max-width: 100%;
+				// Fix color to be accessible
+				opacity: 1;
+				color: var(--color-text-maxcontrast);
 			}
 		}
 		.vs__selected-options {


### PR DESCRIPTION
### ☑️ Resolves

* Part of https://github.com/nextcloud/server/issues/40697

Make sure the currently active option has still enough contrast when the menu is opened, by dropping the opacity property but using max contrast color.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/a5e57612-a5e4-4c9e-96cb-389363e2d689)|![after](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/f8d01a40-3d84-4d77-89ec-8f7dfa070ce6)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
