### PR TITLE
fix(NcEmptyContent): Fix regression that changed the color of the description text

### DIFF
--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -28,8 +28,8 @@ Providing an icon, name, and a description is strongly advised.
 
 ```
 <template>
-	<NcEmptyContent
-		name="No comments">
+	<NcEmptyContent name="No comments"
+		description="Start writing comments and they will appear here.">
 		<template #icon>
 			<Comment />
 		</template>
@@ -150,7 +150,7 @@ export default {
 				{{ name }}
 			</span>
 		</slot>
-		<p v-if="hasDescription">
+		<p v-if="hasDescription" class="empty-content__description">
 			<!-- @slot Optional formatted description rendered inside a paragraph -->
 			<slot name="description">
 				{{ description }}
@@ -241,6 +241,10 @@ export default {
 		font-weight: bold;
 		font-size: 20px;
 		line-height: 30px;
+	}
+
+	&__description {
+		color: var(--color-text-maxcontrast);
 	}
 
 	&__action {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #3133 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2023-11-01 at 17-06-10 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/68a05706-4cc6-434b-8070-0062b7a06f9b)|![Screenshot 2023-11-01 at 17-05-52 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/8d972c98-e450-48ec-81fb-1c84d10421db)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
