### PR TITLE
fix(NcAvatar): Improve initials generation to filter out special characters

### DIFF
--- a/tests/unit/components/NcAvatar/NcAvatar.spec.ts
+++ b/tests/unit/components/NcAvatar/NcAvatar.spec.ts
@@ -20,7 +20,7 @@
  *
  */
 
-import { mount } from '@vue/test-utils'
+import { mount, shallowMount } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import NcAvatar from '../../../../src/components/NcAvatar/NcAvatar.vue'
 
@@ -86,5 +86,49 @@ describe('NcAvatar.vue', () => {
 
 		expect(wrapper.find('.avatardiv__user-status').exists()).toBe(false)
 		expect(wrapper.attributes('aria-label')).toBe('Avatar of J. Doe')
+	})
+
+	it('should display initials for user id', async () => {
+		const wrapper = shallowMount(NcAvatar, {
+			propsData: {
+				user: 'Jane Doe',
+				isNoUser: true,
+			},
+		})
+		await nextTick()
+		expect(wrapper.text()).toBe('JD')
+	})
+
+	it('should display initials for display name property over user id', async () => {
+		const wrapper = shallowMount(NcAvatar, {
+			propsData: {
+				displayName: 'No User',
+				user: 'I am a group',
+				isNoUser: true,
+			},
+		})
+		await nextTick()
+		expect(wrapper.text()).toBe('NU')
+	})
+
+	describe('Fallback initials', () => {
+		it.each`
+			displayName             | initials | case
+			${''}                   | ${'?'}   | ${'empty user'}
+			${'Jane Doe'}           | ${'JD'}  | ${'display name property'}
+			${'Jane (Doe)'}         | ${'JD'}  | ${'special characters in name'}
+			${'jane doe'}           | ${'JD'}  | ${'lower case name'}
+			${'Jane Some Name Doe'} | ${'JD'}  | ${'middle names'}
+			${'Ümit Öçal'}          | ${'ÜÖ'}  | ${'non ascii characters'}
+			${'ジェーン ドー'}        | ${'ジド'} | ${'non latin characters'}
+		`('should display initials for $case ("$displayName" -> "$initials")', async ({ displayName, initials }) => {
+			const wrapper = shallowMount(NcAvatar, {
+				propsData: {
+					displayName,
+				},
+			})
+			await nextTick()
+			expect(wrapper.text()).toBe(initials)
+		})
 	})
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,8 @@
     "strict": true,
     "noImplicitAny": false,
     "outDir": "./dist",
+  },
+  "vueCompilerOptions": {
+    "target": 2.7
   }
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/2044

1. Filter user names to only use real characters (for all languages) to generate initials and not using special characters like e.g. `(`.
2. Use first & last name for initials instead of second name (e.g. `First Second Last` should be `FL` and not `FS`).

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/e09600f8-b3d0-4dba-9b78-6fb0b469f85b)|![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/a4fabb60-2a48-4864-b247-27989371a7e1)
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/ba8494c0-d230-4fa6-b9db-a4475729f2f2)|![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/a62a1fab-1b84-478a-b836-6018e5d14cab)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
