### PR TITLE
[next] fix(NcAvatar): don't show `false` for disabled tooltip

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -474,7 +474,7 @@ export default {
 		},
 		tooltip() {
 			if (this.disableTooltip) {
-				return false
+				return null
 			}
 			if (this.tooltipMessage) {
 				return this.tooltipMessage


### PR DESCRIPTION
### ☑️ Resolves

* Fixes showing `false` as tooltip when the tooltip was disabled with `disable-tooltip`.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-11-01 21-45-19](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/ced3189a-3ded-4844-9d4f-46ac025bf859)  | ![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/6daaa424-e72e-4c5a-a71e-7cfc782a2b85)
