### PR TITLE
fix: NcUserBubble properties

### DIFF
--- a/src/components/NcUserBubble/NcUserBubble.vue
+++ b/src/components/NcUserBubble/NcUserBubble.vue
@@ -123,6 +123,7 @@ export default {
 import NcUserBubbleDiv from './NcUserBubbleDiv.vue'
 import NcAvatar from '../NcAvatar/index.js'
 import NcPopover from '../NcPopover/index.js'
+import Vue from 'vue'
 
 export default {
 	name: 'NcUserBubble',
@@ -151,7 +152,7 @@ export default {
 		 */
 		displayName: {
 			type: String,
-			required: true,
+			default: undefined,
 		},
 		/**
 		 * Whether or not to display the user-status
@@ -277,6 +278,11 @@ export default {
 				},
 			}
 		},
+	},
+	mounted() {
+		if (!this.displayName && !this.user) {
+			Vue.util.warn('[NcUserBubble] At least `displayName` or `user` property should be set.')
+		}
 	},
 	methods: {
 		onOpenChange(state) {

--- a/src/components/NcUserBubble/NcUserBubble.vue
+++ b/src/components/NcUserBubble/NcUserBubble.vue
@@ -166,10 +166,10 @@ export default {
 		url: {
 			type: String,
 			default: undefined,
-			validator: url => {
+			validator: (url) => {
 				try {
-					url = new URL(url)
-					return !!url
+					url = new URL(url, url?.startsWith?.('/') ? window.location.href : undefined)
+					return true
 				} catch (error) {
 					return false
 				}

--- a/src/components/NcUserBubble/NcUserBubble.vue
+++ b/src/components/NcUserBubble/NcUserBubble.vue
@@ -36,7 +36,7 @@ This component has the following slot:
 
 ```vue
 <p>
-	Some text before <NcUserBubble user="admin" display-name="Admin Example" :url="'/test'">@admin@foreign-host.com</NcUserBubble> and after the bubble.
+	Some text before <NcUserBubble user="admin" display-name="Admin Example" url="/test">@admin@foreign-host.com</NcUserBubble> and after the bubble.
 	<NcUserBubble avatar-image="icon-group" display-name="test group xyz" :primary="true">Hey there!</NcUserBubble>
 </p>
 ```
@@ -58,7 +58,15 @@ This component has the following slot:
 	</template>
 </NcUserBubble>
 </template>
-
+<script>
+export default {
+	methods: {
+		alert() {
+			alert('Removed')
+		},
+	},
+}
+</script>
 <style>
 .icon-close {
 	display: block;

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,6 @@
+declare const PRODUCTION: boolean
+
+declare const SCOPE_VERSION: string
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const TRANSLATIONS: { locale: string, translations: any }[]


### PR DESCRIPTION
### ☑️ Resolves

* Fix #792 

1. Make `displayName` not required
    We already have a fallback so it is not required.
    But we should show a warning when user and display name are not set.
2. Fix URL prop validator to allow relative URLs
3. Fix examples
    * Examples does not need to pass computed property
    * `alert` is not defined in templates for Vue 2 (same with console)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
