### PR TITLE
feat(NcActionButton): Allow pressed state on NcActionButton - similar to NcButton

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -22,7 +22,7 @@
  */
 
 @mixin action-active {
-	li {
+	li.action {
 		&.active {
 			background-color: var(--color-background-hover);
 			border-radius: 6px;

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -397,7 +397,12 @@ export default {
 
 		/**
 		 * The buttons state if `type` is 'checkbox' or 'radio' (meaning if it is pressed / selected)
-		 * Either boolean for checkbox and toggle button behavior or `value` for radio behavior
+		 * Either boolean for checkbox and toggle button behavior or `value` for radio behavior.
+		 *
+		 *  **This is not availabe for `type='submit'` or `type='reset'`**
+		 *
+		 * If using `type='checkbox'` a `model-value` of `true` means checked, `false` means unchecked and `null` means indeterminate (tri-state)
+		 * For `type='radio'` `null` is equal to `false`
 		 */
 		modelValue: {
 			type: [Boolean, String],
@@ -457,12 +462,12 @@ export default {
 				if (this.type === 'radio') {
 					attributes.role = 'menuitemradio'
 					attributes['aria-checked'] = this.isChecked ? 'true' : 'false'
-				} else if (this.type === 'checkbox' || this.modelValue !== null) {
+				} else if (this.type === 'checkbox' || (this.nativeType === 'button' && this.modelValue !== null)) {
 					// either if checkbox behavior was set or the model value is not unset
 					attributes.role = 'menuitemcheckbox'
 					attributes['aria-checked'] = this.modelValue === null ? 'mixed' : (this.modelValue ? 'true' : 'false')
 				}
-			} else if (this.modelValue !== null) {
+			} else if (this.modelValue !== null && this.nativeType === 'button') {
 				// In case this has a modelValue it is considered a toggle button, so we need to set the aria-pressed
 				attributes['aria-pressed'] = this.modelValue ? 'true' : 'false'
 			}

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -170,13 +170,55 @@ export default {
 }
 </script>
 ```
+
+You can set an "pressed" state, for example you have a toggle button, in this example the "fullscreen" button:
+
+```vue
+<template>
+	<NcActions>
+		<NcActionButton :pressed="handRaised" @click="handRaised = !handRaised">
+			<template #icon>
+				<HandBackLeft :size="20" />
+			</template>
+			Raise hand
+		</NcActionButton>
+		<NcActionButton :pressed="fullscreen" @click="fullscreen = !fullscreen">
+			<template #icon>
+				<Fullscreen :size="20" />
+			</template>
+			Fullscreen
+		</NcActionButton>
+	</NcActions>
+</template>
+<script>
+import HandBackLeft from 'vue-material-design-icons/HandBackLeft.vue'
+import Fullscreen from 'vue-material-design-icons/Fullscreen.vue'
+
+export default {
+	components: {
+		HandBackLeft,
+		Fullscreen,
+	},
+	data() {
+		return {
+			fullscreen: true,
+			handRaised: false,
+		}
+	},
+}
+</script>
+```
 </docs>
 
 <template>
 	<li class="action" :class="{ 'action--disabled': disabled }" :role="isInSemanticMenu && 'presentation'">
 		<button class="action-button button-vue"
-			:class="{ focusable: isFocusable }"
+			:class="{
+				'action-button--active': pressed,
+				focusable: isFocusable,
+			}"
 			:aria-label="ariaLabel"
+			:aria-pressed="active"
 			:title="title"
 			:role="isInSemanticMenu && 'menuitem'"
 			type="button"
@@ -212,7 +254,9 @@ export default {
 			<span v-else class="action-button__text">{{ text }}</span>
 
 			<!-- right arrow icon when there is a sub-menu -->
-			<ChevronRightIcon v-if="isMenu" class="action-button__menu-icon" />
+			<ChevronRightIcon v-if="isMenu" :size="20" class="action-button__menu-icon" />
+			<CheckIcon v-else-if="pressed === true" :size="20" class="action-button__pressed-icon" />
+			<span v-else-if="pressed === false" class="action-button__pressed-icon material-design-icon" />
 
 			<!-- fake slot to gather inner text -->
 			<slot v-if="false" />
@@ -221,6 +265,7 @@ export default {
 </template>
 
 <script>
+import CheckIcon from 'vue-material-design-icons/Check.vue'
 import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import ActionTextMixin from '../../mixins/actionText.js'
 
@@ -231,6 +276,7 @@ export default {
 	name: 'NcActionButton',
 
 	components: {
+		CheckIcon,
 		ChevronRightIcon,
 	},
 	mixins: [ActionTextMixin],
@@ -244,21 +290,21 @@ export default {
 
 	props: {
 		/**
+		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
+		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
+		 * otherwise root element will inherit incorrect aria-hidden.
+		 */
+		 ariaHidden: {
+			type: Boolean,
+			default: null,
+		},
+
+		/**
 		 * disabled state of the action button
 		 */
 		disabled: {
 			type: Boolean,
 			default: false,
-		},
-
-		/**
-		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
-		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
-		 * otherwise root element will inherit incorrect aria-hidden.
-		 */
-		ariaHidden: {
-			type: Boolean,
-			default: null,
 		},
 
 		/**
@@ -268,6 +314,15 @@ export default {
 		isMenu: {
 			type: Boolean,
 			default: false,
+		},
+
+		/**
+		 * The pressed state of the button if it has a checked state
+		 * This will add the `aria-pressed` attribute and for the button to have a primary border in checked state.
+		 */
+		 pressed: {
+			type: Boolean,
+			default: null,
 		},
 	},
 
@@ -289,4 +344,9 @@ export default {
 @include action-active;
 @include action--disabled;
 @include action-item('button');
+
+.action-button__pressed-icon {
+	margin-left: auto;
+	margin-right: -$icon-margin;
+}
 </style>

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -209,13 +209,13 @@ This also allows tri-state behavior (`true`, `false`, `null`) in which case `ari
 ```vue
 <template>
 	<NcActions>
-		<NcActionButton :model-value.sync="handRaised" model-behavior="checkbox">
+		<NcActionButton :model-value.sync="handRaised" type="checkbox">
 			<template #icon>
 				<HandBackLeft :size="20" />
 			</template>
 			Raise hand
 		</NcActionButton>
-		<NcActionButton :model-value.sync="fullscreen" model-behavior="checkbox">
+		<NcActionButton :model-value.sync="fullscreen" type="checkbox">
 			<template #icon>
 				<Fullscreen :size="20" />
 			</template>
@@ -247,13 +247,13 @@ It is also possible to use the button with radio semantics, this is only possibl
 ```vue
 <template>
 	<NcActions>
-		<NcActionButton :model-value.sync="payment" model-behavior="radio" value="cash">
+		<NcActionButton :model-value.sync="payment" type="radio" value="cash">
 			<template #icon>
 				<Cash :size="20" />
 			</template>
 			Pay with cash
 		</NcActionButton>
-		<NcActionButton :model-value.sync="payment" model-behavior="radio" value="card">
+		<NcActionButton :model-value.sync="payment" type="radio" value="card">
 			<template #icon>
 				<CreditCard :size="20" />
 			</template>
@@ -288,7 +288,7 @@ export default {
 				focusable: isFocusable,
 			}]"
 			:title="title"
-			type="button"
+			:type="nativeType"
 			v-bind="buttonAttributes"
 			@click="handleClick">
 			<!-- @slot Manually provide icon -->
@@ -385,17 +385,18 @@ export default {
 		},
 
 		/**
-		 * The button's behavior, by default the button acts like a normal button with optional toggle button behavior if `modelValue` is `true` or `false`
+		 * The button's behavior, by default the button acts like a normal button with optional toggle button behavior if `modelValue` is `true` or `false`.
 		 * But you can also set to checkbox button behavior with tri-state or radio button like behavior.
+		 * This extends the native HTML button type attribute.
 		 */
-		modelBehavior: {
+		type: {
 			type: String,
 			default: 'button',
-			validator: (behavior) => ['checkbox', 'radio', 'button'].includes(behavior),
+			validator: (behavior) => ['button', 'checkbox', 'radio', 'reset', 'submit'].includes(behavior),
 		},
 
 		/**
-		 * The buttons state if `modelBehavior` is 'checkbox' or 'radio' (meaning if it is pressed / selected)
+		 * The buttons state if `type` is 'checkbox' or 'radio' (meaning if it is pressed / selected)
 		 * Either boolean for checkbox and toggle button behavior or `value` for radio behavior
 		 */
 		modelValue: {
@@ -427,10 +428,20 @@ export default {
 		 * The current "checked" or "pressed" state for the model behavior
 		 */
 		isChecked() {
-			if (this.modelBehavior === 'radio') {
+			if (this.type === 'radio') {
 				return this.modelValue === this.value
 			}
 			return this.modelValue
+		},
+
+		/**
+		 * The native HTML type to set on the button
+		 */
+		nativeType() {
+			if (this.type === 'submit' || this.type === 'reset') {
+				return this.type
+			}
+			return 'button'
 		},
 
 		/**
@@ -443,10 +454,10 @@ export default {
 				// By default it needs to be a menu item in semantic menus
 				attributes.role = 'menuitem'
 
-				if (this.modelBehavior === 'radio') {
+				if (this.type === 'radio') {
 					attributes.role = 'menuitemradio'
 					attributes['aria-checked'] = this.isChecked ? 'true' : 'false'
-				} else if (this.modelBehavior === 'checkbox' || this.modelValue !== null) {
+				} else if (this.type === 'checkbox' || this.modelValue !== null) {
 					// either if checkbox behavior was set or the model value is not unset
 					attributes.role = 'menuitemcheckbox'
 					attributes['aria-checked'] = this.modelValue === null ? 'mixed' : (this.modelValue ? 'true' : 'false')
@@ -467,9 +478,9 @@ export default {
 		 */
 		handleClick(event) {
 			this.onClick(event)
-			// If modelValue or modelBehavior is set (so modelValue might be null for tri-state) we need to update it
-			if (this.modelValue !== null || this.modelBehavior !== 'button') {
-				if (this.modelBehavior === 'radio') {
+			// If modelValue or type is set (so modelValue might be null for tri-state) we need to update it
+			if (this.modelValue !== null || this.type !== 'button') {
+				if (this.type === 'radio') {
 					if (!this.isChecked) {
 						this.$emit('update:modelValue', this.value)
 					}

--- a/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
+++ b/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
@@ -29,19 +29,22 @@ This should be used sparingly for accessibility.
 		<NcActions>
 			<NcActionButtonGroup name="Text alignment">
 				<NcActionButton aria-label="Align left"
-					@click="showMessage('Align left')">
+					:pressed="alignment === 'l'"
+					@click="alignment = 'l'">
 					<template #icon>
 						<AlignLeft :size="20" />
 					</template>
 				</NcActionButton>
 				<NcActionButton aria-label="Align center"
-					@click="showMessage('Align center')">
+					:pressed="alignment === 'c'"
+					@click="alignment = 'c'">
 					<template #icon>
 						<AlignCenter :size="20" />
 					</template>
 				</NcActionButton>
 				<NcActionButton aria-label="Align right"
-					@click="showMessage('Align Right')">
+					:pressed="alignment === 'r'"
+					@click="alignment = 'r'">
 					<template #icon>
 						<AlignRight :size="20" />
 					</template>
@@ -69,6 +72,9 @@ export default {
 		AlignRight,
 		AlignCenter,
 		Plus,
+	},
+	data() {
+		return { alignment: 'l' }
 	},
 	methods: {
 		showMessage(msg) {
@@ -141,6 +147,7 @@ export default defineComponent({
 
 	ul.nc-button-group-content {
 		display: flex;
+		gap: 4px; // required for the focus-visible outline
 		justify-content: space-between;
 		li {
 			flex: 1 1;
@@ -152,6 +159,20 @@ export default defineComponent({
 			width: 100%;
 			display: flex;
 			justify-content: center;
+
+			&.action-button--active {
+				background-color: var(--color-primary-element);
+				border-radius: var(--border-radius-large);
+				color: var(--color-primary-element-text);
+
+				&:hover, &:focus, &:focus-within {
+					background-color: var(--color-primary-element-hover);
+				}
+			}
+
+			.action-button__pressed-icon {
+				display: none;
+			}
 		}
 	}
 }

--- a/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
+++ b/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
@@ -29,22 +29,25 @@ This should be used sparingly for accessibility.
 		<NcActions>
 			<NcActionButtonGroup name="Text alignment">
 				<NcActionButton aria-label="Align left"
-					:pressed="alignment === 'l'"
-					@click="alignment = 'l'">
+					:model-value.sync="alignment"
+					model-behavior="radio"
+					value="l">
 					<template #icon>
 						<AlignLeft :size="20" />
 					</template>
 				</NcActionButton>
 				<NcActionButton aria-label="Align center"
-					:pressed="alignment === 'c'"
-					@click="alignment = 'c'">
+					:model-value.sync="alignment"
+					model-behavior="radio"
+					value="c">
 					<template #icon>
 						<AlignCenter :size="20" />
 					</template>
 				</NcActionButton>
 				<NcActionButton aria-label="Align right"
-					:pressed="alignment === 'r'"
-					@click="alignment = 'r'">
+					:model-value.sync="alignment"
+					model-behavior="radio"
+					value="r">
 					<template #icon>
 						<AlignRight :size="20" />
 					</template>

--- a/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
+++ b/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
@@ -30,7 +30,7 @@ This should be used sparingly for accessibility.
 			<NcActionButtonGroup name="Text alignment">
 				<NcActionButton aria-label="Align left"
 					:model-value.sync="alignment"
-					model-behavior="radio"
+					type="radio"
 					value="l">
 					<template #icon>
 						<AlignLeft :size="20" />
@@ -38,7 +38,7 @@ This should be used sparingly for accessibility.
 				</NcActionButton>
 				<NcActionButton aria-label="Align center"
 					:model-value.sync="alignment"
-					model-behavior="radio"
+					type="radio"
 					value="c">
 					<template #icon>
 						<AlignCenter :size="20" />
@@ -46,7 +46,7 @@ This should be used sparingly for accessibility.
 				</NcActionButton>
 				<NcActionButton aria-label="Align right"
 					:model-value.sync="alignment"
-					model-behavior="radio"
+					type="radio"
 					value="r">
 					<template #icon>
 						<AlignRight :size="20" />

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1304,9 +1304,10 @@ export default {
 			}
 
 			const propsToForward = { ...(action?.componentOptions?.propsData ?? {}) }
-			// not available on NcButton
+			const nativeType = ['submit', 'reset'].includes(propsToForward.type) ? propsToForward.modelValue : 'button'
+			// not available on NcButton or with different meaning
 			delete propsToForward.modelValue
-			delete propsToForward.modelBehavior
+			delete propsToForward.type
 
 			return h('NcButton',
 				{
@@ -1326,6 +1327,7 @@ export default {
 						type: this.type || (buttonText ? 'secondary' : 'tertiary'),
 						disabled: this.disabled || action?.componentOptions?.propsData?.disabled,
 						pressed: action?.componentOptions?.propsData?.modelValue,
+						nativeType,
 						...propsToForward,
 					},
 					on: {

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1303,6 +1303,11 @@ export default {
 				title = text
 			}
 
+			const propsToForward = { ...(action?.componentOptions?.propsData ?? {}) }
+			// not available on NcButton
+			delete propsToForward.modelValue
+			delete propsToForward.modelBehavior
+
 			return h('NcButton',
 				{
 					class: [
@@ -1320,11 +1325,14 @@ export default {
 						// If it has a menuName, we use a secondary button
 						type: this.type || (buttonText ? 'secondary' : 'tertiary'),
 						disabled: this.disabled || action?.componentOptions?.propsData?.disabled,
-						...action?.componentOptions?.propsData,
+						pressed: action?.componentOptions?.propsData?.modelValue,
+						...propsToForward,
 					},
 					on: {
 						focus: this.onFocus,
 						blur: this.onBlur,
+						// forward any pressed state from NcButton just like NcActionButton does
+						'update:pressed': action?.componentOptions?.listeners?.['update:modelValue'] ?? (() => {}),
 						// If we have a click listener,
 						// we bind it to execute on click and forward the click event
 						...(!!clickListener && {

--- a/tests/unit/components/NcActions/NcActions.spec.ts
+++ b/tests/unit/components/NcActions/NcActions.spec.ts
@@ -139,17 +139,16 @@ describe('NcActions.vue', () => {
 				})
 			})
 			it('shows the first action outside.', () => {
-				expect(wrapper.findAll('.action-item').length).toBe(2)
 				expect(wrapper.findAll('button.action-item').length).toBe(1)
-				expect(wrapper.find('button.action-item').exists()).toBe(true)
+				expect(wrapper.find('button.action-item[aria-label="Test1"]').exists()).toBe(true)
 			})
 			it('shows the menu toggle.', () => {
 				expect(wrapper.find('.action-item__menutoggle').exists()).toBe(true)
 			})
 			it('shows the first two action outside on prop change.', async () => {
 				await wrapper.setProps({ inline: 2 })
-				expect(wrapper.findAll('.action-item').length).toBe(3)
 				expect(wrapper.findAll('button.action-item').length).toBe(2)
+				expect(wrapper.find('.action-item__menutoggle').exists()).toBe(true)
 			})
 			it('shows all actions outside on prop change.', async () => {
 				await wrapper.setProps({ inline: 3 })


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/425

NcButton already allows a checked state so this introduces this for the NcActionButton.
In checked state the `aria-pressed` attribute will be added and a primary border will indicate it visually.

### 🖼️ Screenshots

https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/c90a7c12-e663-4cd6-8abd-5d3848088de1

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
