### PR TITLE
[NcAppSettingsDialog] Allow to add icons to the navigation sections

### DIFF
--- a/src/components/NcAppSettingsSection/NcAppSettingsSection.vue
+++ b/src/components/NcAppSettingsSection/NcAppSettingsSection.vue
@@ -32,6 +32,7 @@
 <script>
 export default {
 	name: 'NcAppSettingsSection',
+	inject: ['registerSection', 'unregisterSection'],
 
 	props: {
 		name: {
@@ -53,6 +54,24 @@ export default {
 		htmlId() {
 			return 'settings-section_' + this.id
 		},
+	},
+	// Reactive changes for section navigation
+	watch: {
+		id(newId, oldId) {
+			this.unregisterSection(oldId)
+			this.registerSection(newId, this.name)
+		},
+		name(newName) {
+			this.unregisterSection(this.id)
+			this.registerSection(this.id, newName)
+		},
+	},
+	mounted() {
+		// register section for navigation
+		this.registerSection(this.id, this.name)
+	},
+	beforeDestroy() {
+		this.unregisterSection(this.id)
 	},
 }
 

--- a/src/components/NcAppSettingsSection/NcAppSettingsSection.vue
+++ b/src/components/NcAppSettingsSection/NcAppSettingsSection.vue
@@ -26,6 +26,8 @@
 			{{ name }}
 		</h3>
 		<slot />
+		<!-- @slot Optonal icon to for the secion in the navigation -->
+		<slot v-if="false" name="icon" />
 	</div>
 </template>
 
@@ -59,16 +61,16 @@ export default {
 	watch: {
 		id(newId, oldId) {
 			this.unregisterSection(oldId)
-			this.registerSection(newId, this.name)
+			this.registerSection(newId, this.name, this.$slots?.icon)
 		},
 		name(newName) {
 			this.unregisterSection(this.id)
-			this.registerSection(this.id, newName)
+			this.registerSection(this.id, newName, this.$slots?.icon)
 		},
 	},
 	mounted() {
 		// register section for navigation
-		this.registerSection(this.id, this.name)
+		this.registerSection(this.id, this.name, this.$slots?.icon)
 	},
 	beforeDestroy() {
 		this.unregisterSection(this.id)


### PR DESCRIPTION
### ☑️ Resolves

* Part of https://github.com/nextcloud-libraries/nextcloud-vue/issues/1441

This consists of 2 commits, the first one changes the way the sections are registered and the second on provides icon support.

#### Section registration
Previously the default slot content was iterated and the props of every vNode were used. This had two downsides:
1. `$slots` is not reactive -> changes will not propagate
2. We can not easily access slots of a section (like for the icon) because the slot will only be available when the vNode is mounted

So instead we now provide to functions to children:
`registerSection` and `unregisterSection` with that functions children (the sections) can register themself and update on change. Solving both issues: the reactivity and the ability to inject icons (as the registration is done after mount).

I personally also think it is easier to understand as no longer internals of vNodes need to be handled, but this is personal taste.

#### Icon support
There is a new slot `icon` on the settings section which allows to inject icons to the section name in the navigation.

### 🖼️ Screenshots
With this changes it loos like this:

without icons (looks like before) | with icons
---|---
![Screenshot_20231102_021445](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/b7c46564-1beb-4223-a14b-01c75cb121cd)|![Screenshot_20231102_021453](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/eb85faf4-16b8-4e9b-8e63-afafff5abe53)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
