### PR TITLE
[stable7] fix(NcAppContent): Set normal scrollbar width on resizeable NcAppContentList

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -382,6 +382,8 @@ export default {
 :deep(.splitpanes.default-theme) {
 	.app-content-list {
 		max-width: none;
+		/* Thin scrollbar is hard to catch on resizable columns */
+		scrollbar-width: auto;
 	}
 
 	.splitpanes__pane {


### PR DESCRIPTION
Manual backport of #4710 

When `NcAppContentList` is resizeable, a thin scrollbar is hard to catch with the mouse. Set scrollbar width to auto in this case.

Fixes: #4706

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
