### PR TITLE
fix(NcAvatar): remove alt attr from span[role=img]

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -406,7 +406,6 @@ export default {
 			return {
 				role: 'img',
 				'aria-label': label,
-				alt: label,
 			}
 		},
 		canDisplayUserStatus() {


### PR DESCRIPTION
### ☑️ Resolves

* A part of https://github.com/nextcloud/server/issues/37092

> **Error**: Attribute `alt` not allowed on element [`span`](https://html.spec.whatwg.org/multipage/#the-span-element) at this point.

Also, there is a description with `aria-label`.

### 🖼️ Screenshots

No visual changes

### 🚧 Tasks

- [x] Remove "alt" from user status span.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
