### PR TITLE
fix(NcSelect): Update `@nextcloud/vue-select` and add translated options for `aria-labels`

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -56,6 +56,9 @@ msgstr ""
 msgid "Clear search"
 msgstr ""
 
+msgid "Clear selected"
+msgstr ""
+
 msgid "Clear text"
 msgstr ""
 
@@ -81,6 +84,9 @@ msgid "Confirm changes"
 msgstr ""
 
 msgid "Custom"
+msgstr ""
+
+msgid "Deselect {option}"
 msgstr ""
 
 msgid "do not disturb"
@@ -216,6 +222,9 @@ msgid "Search"
 msgstr ""
 
 msgid "Search emoji"
+msgstr ""
+
+msgid "Search for options"
 msgstr ""
 
 msgid "Search results"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@nextcloud/l10n": "^2.0.1",
         "@nextcloud/logger": "^2.2.1",
         "@nextcloud/router": "^2.0.0",
-        "@nextcloud/vue-select": "^3.23.0",
+        "@nextcloud/vue-select": "^3.24.0",
         "@vueuse/components": "^10.0.2",
         "@vueuse/core": "^10.1.2",
         "clone": "^2.1.2",
@@ -3933,9 +3933,9 @@
       }
     },
     "node_modules/@nextcloud/vue-select": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.23.0.tgz",
-      "integrity": "sha512-TerpWxDtbdwda32xtrLcqN8CjcQwVwCrEdHIHIAPQ2y3Ktl/dcjQxGn0onRZqk9+4ZxPGMYdX7LIWRKCHUlrmQ==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.24.0.tgz",
+      "integrity": "sha512-+TQYaqB57OcwG3XSKpUtVcbUZIkX8KHzjTCWRFAiRqwryXTuBvY/JHzB5i31BFHJ6CK+l8WyBu8LgmtQW8ktrw==",
       "peerDependencies": {
         "vue": "2.x"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@nextcloud/l10n": "^2.0.1",
     "@nextcloud/logger": "^2.2.1",
     "@nextcloud/router": "^2.0.0",
-    "@nextcloud/vue-select": "^3.23.0",
+    "@nextcloud/vue-select": "^3.24.0",
     "@vueuse/components": "^10.0.2",
     "@vueuse/core": "^10.1.2",
     "clone": "^2.1.2",

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -533,8 +533,9 @@ export default {
 </template>
 
 <script>
-import { VueSelect } from '@nextcloud/vue-select'
 import '@nextcloud/vue-select/dist/vue-select.css'
+
+import { VueSelect } from '@nextcloud/vue-select'
 import {
 	autoUpdate,
 	computePosition,
@@ -543,6 +544,7 @@ import {
 	offset,
 	shift,
 } from '@floating-ui/dom'
+import { t } from '../../l10n.js'
 
 import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import Close from 'vue-material-design-icons/Close.vue'
@@ -552,7 +554,6 @@ import NcListItemIcon from '../NcListItemIcon/index.js'
 import NcLoadingIcon from '../NcLoadingIcon/index.js'
 
 import l10n from '../../mixins/l10n.js'
-
 import GenRandomId from '../../utils/GenRandomId.js'
 
 export default {
@@ -573,6 +574,32 @@ export default {
 	props: {
 		// Add VueSelect props to $props
 		...VueSelect.props,
+
+		/**
+		 * `aria-label` for the clear input button
+		 */
+		ariaLabelClearSelected: {
+			type: String,
+			default: t('Clear selected'),
+		},
+
+		/**
+		 * `aria-label` for the search input
+		 */
+		ariaLabelCombobox: {
+			type: String,
+			default: t('Search for options'),
+		},
+
+		/**
+		 * Allows to customize the `aria-label` for the deselect-option button
+		 * The default is "Deselect " + optionLabel
+		 * @type {(optionLabel: string) => string}
+		 */
+		ariaLabelDeselectOption: {
+			type: Function,
+			default: (optionLabel) => t('Deselect {option}', { option: optionLabel }),
+		},
 
 		/**
 		 * Append the dropdown element to the end of the body


### PR DESCRIPTION
### ☑️ Resolves

* Required for https://github.com/nextcloud/server/issues/40697 to allow adjusting the `aria-label`

Also add translated variants of the default `aria-label`s

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
