### PR TITLE
fix(NcUserBubble): only forward necessary props

### DIFF
--- a/src/components/NcUserBubble/NcUserBubble.vue
+++ b/src/components/NcUserBubble/NcUserBubble.vue
@@ -99,7 +99,7 @@ export default {
 					:style="styles.avatar"
 					:disable-tooltip="true"
 					:disable-menu="true"
-					v-bind="$props"
+					:show-user-status="showUserStatus"
 					class="user-bubble__avatar" />
 
 				<!-- Name -->


### PR DESCRIPTION
### ☑️ Resolves

* This adjusts `NcUserBubble` to only forward props to `NcAvatar` that are actually used by it. E.g. the `primary` prop is currently also forwarded and lands in the markup, although `NcAvatar` makes no use of it.