### PR TITLE
fix(NcTimezonePicker): Add correct `aria-label`

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -227,6 +227,9 @@ msgstr ""
 msgid "Search for options"
 msgstr ""
 
+msgid "Search for time zone"
+msgstr ""
+
 msgid "Search results"
 msgstr ""
 

--- a/src/components/NcTimezonePicker/NcTimezonePicker.vue
+++ b/src/components/NcTimezonePicker/NcTimezonePicker.vue
@@ -41,14 +41,15 @@ export default {
 </docs>
 
 <template>
-	<NcSelect :uid="uid"
-		:value="selectedTimezone"
-		:options="options"
-		:multiple="false"
+	<NcSelect :aria-label-combobox="t('Search for time zone')"
 		:clearable="false"
+		:filter-by="filterBy"
+		:multiple="false"
+		:options="options"
 		:placeholder="placeholder"
 		:selectable="isSelectable"
-		:filter-by="filterBy"
+		:uid="uid"
+		:value="selectedTimezone"
 		label="label"
 		@option:selected="change" />
 </template>


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/40697

Change `aria-label` to reflect that you select time zones.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
