### PR TITLE
v7.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 # Changelog
 
+## [v7.12.7](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v7.12.7) (2023-11-07)
+
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v7.12.6...v7.12.7)
+
+### :bug: Fixed bugs
+- fix: handling of empty values in NcDateTimePickerNative by @st3iny in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4610
+- fix: invert datepicker buttons on dark mode by @raimund-schluessler in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4635
+- fix(NcAppContent): Set normal scrollbar width on resizeable NcAppContentList by @mejo- in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4747
+
+### Other Changes
+* fix(NcActionInput): Set default trailing button label by @Pytal in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4634
+
 ## [v7.12.6](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v7.12.6) (2023-09-26)
 
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v7.12.5...v7.12.6)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.12.6",
+	"version": "7.12.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/vue",
-			"version": "7.12.6",
+			"version": "7.12.7",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/vue",
-	"version": "7.12.6",
+	"version": "7.12.7",
 	"description": "Nextcloud vue components",
 	"keywords": [
 		"vuejs",


### PR DESCRIPTION
## [v7.12.7](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v7.12.7) (2023-11-07)

[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v7.12.6...v7.12.7)

### :bug: Fixed bugs
- fix: handling of empty values in NcDateTimePickerNative by @st3iny in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4610
- fix: invert datepicker buttons on dark mode by @raimund-schluessler in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4635
- fix(NcAppContent): Set normal scrollbar width on resizeable NcAppContentList by @mejo- in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4747

### Other Changes
* fix(NcActionInput): Set default trailing button label by @Pytal in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4634