### PR TITLE
fix(NcAppNavifation): small screen support

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -57,7 +57,9 @@ emit('toggle-navigation', {
 	<div ref="appNavigationContainer"
 		class="app-navigation"
 		:class="{'app-navigation--close':!open }">
-		<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
+		<div class="app-navigation__toggle-wrapper">
+			<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
+		</div>
 		<nav id="app-navigation-vue"
 			:aria-hidden="open ? 'false' : 'true'"
 			:aria-label="ariaLabel || undefined"
@@ -206,8 +208,11 @@ export default {
 	// Set scoped variable override
 	// Using --color-text-maxcontrast as a fallback evaluates to an invalid value as it references itself in this scope instead of the variable defined higher up
 	--color-text-maxcontrast: var(--color-text-maxcontrast-background-blur, var(--color-text-maxcontrast-default));
+	// Left padding + toggle button + right padding from NcAppContent
+	--app-navigation-toggle-width: calc(var(--app-navigation-padding) + var(--default-clickable-area) + var(--default-grid-baseline));
 	transition: transform var(--animation-quick), margin var(--animation-quick);
 	width: $navigation-width;
+	max-width: calc(100vw - var(--app-navigation-toggle-width));
 	position: relative;
 	top: 0;
 	left: 0;
@@ -231,7 +236,15 @@ export default {
 		position: absolute;
 	}
 
-	//list of navigation items
+	&__toggle-wrapper {
+		position: absolute;
+		top: 0;
+		left: 100%;
+		// "app-navigation-padding (default-clickable-area) default-clickable-area" to fit AppContentHeader margin
+		width: var(--app-navigation-toggle-width);
+		height: calc(var(--app-navigation-padding) * 2 + var(--default-clickable-area));
+	}
+
 	&__content > ul,
 	&__list {
 		position: relative;
@@ -264,13 +277,11 @@ export default {
 	.app-navigation:not(.app-navigation--close) {
 		position: absolute;
 	}
-}
 
-// Put the toggle behind appsidebar on small screens
-@media only screen and (max-width: 768px) {
-	.app-navigation {
-		z-index: 1400;
+	.app-navigation__toggle-wrapper {
+		background: inherit;
+		backdrop-filter: var(--filter-background-blur, none);
+		border-radius: 0 var(--border-radius-large) var(--border-radius-large) 0;
 	}
 }
-
 </style>

--- a/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
+++ b/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
@@ -84,8 +84,7 @@ export default {
 button.app-navigation-toggle {
 	position: absolute;
 	top: var(--app-navigation-padding);
-	right: calc(0px - var(--app-navigation-padding));
-	margin-right: - $clickable-area;
+	left: var(--app-navigation-padding);
 }
 
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/40954
* Chained on https://github.com/nextcloud-libraries/nextcloud-vue/pull/4633

There are 2 issues with a small screen:
1. On a very small screen (320px) the 300px navigation is too wide, the toggle button is out of viewport
2. The toggle button doesn't look good on top of content

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before-2](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/bab4bb0a-b5f6-4c2f-9160-145e2038cab4) | ![after-2](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9188f6d3-4c7e-4f02-beea-63f08a122de0)

Toggle button on a different background:

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/64ea7b97-fc03-4462-869e-f6eb14ec6128)

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e2c3a153-ad0d-4db1-89cf-ff3eff84f2e1)

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/7588c406-4d35-4de7-a167-4c8c8e9d31e0)

### 🚧 Tasks

- [x] Add max width to make navigation smaller on a small screen
- [x] Add background to the toggle button

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
