### PR TITLE
feat(NcActions): focus the first action again if no action have a focus after render

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1175,6 +1175,18 @@ export default {
 			return renderInlineAction(inlineActions[0])
 		}
 
+		// If we completely re-render the children
+		// we need to focus the first action again
+		// Mostly used when clicking a menu item
+		this.$nextTick(() => {
+			if (this.opened && this.$refs.menu) {
+				const isAnyActive = this.$refs.menu.querySelector('li.active') || []
+				if (isAnyActive.length === 0) {
+					this.focusFirstAction()
+				}
+			}
+		})
+
 		/**
 		 * If we some inline actions to render, render them, then the menu
 		 */


### PR DESCRIPTION
From https://github.com/nextcloud/server/pull/41010#pullrequestreview-1717797692


## Testing [in preview ⬈](https://deploy-preview-4775--nextcloud-vue-components.netlify.app/)

```vue
<template>
	<NcActions>
		<template v-if="!showMenu">
			<NcActionButton @click="showMessage('Edit')">Edit</NcActionButton>
			<NcActionButton :is-menu="true" @click="showMenu = true">Show menu</NcActionButton>
		</template>
		<template v-else>
			<NcActionButton key="menu-1" @click="showMenu = false">< Back</NcActionButton>
			<NcActionButton key="menu-2" @click="showMessage('Edit')">Second entries</NcActionButton>
			<NcActionButton key="menu-3" @click="showMessage('Delete')">Second entries</NcActionButton>
		</template>
	</NcActions>
</template>
<script>
export default {
	data() {
		return {
			showMenu: false,
		}
	},
	methods: {
		showMessage(msg) {
			alert(msg)
		},
	},
}
</script>
```

