### PR TITLE
fix(NcAppNavigation): Ensure `--app-navigation-padding` is set also on app-content

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -142,7 +142,7 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
+<style lang="scss">
 .app-navigation,
 .app-content {
 	/** Distance of the app naviation toggle and the first navigation item to the top edge of the app content container */


### PR DESCRIPTION
### ☑️ Resolves
Fix regression of #4730 

We can not use scoped here because it will set a different scope than on the NcAppContent and thus the css variable will not be injected into it.
(One of the reasons I do not like scoped but prefer `module`).

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
