### PR TITLE
fix: Do not depend on uncompiled vue files as dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "vue": "^2.7.14",
         "vue-color": "^2.8.1",
         "vue-frag": "^1.4.3",
-        "vue-material-design-icons": "^5.1.2",
         "vue2-datepicker": "^3.11.0"
       },
       "devDependencies": {
@@ -88,6 +87,7 @@
         "url-loader": "^4.1.1",
         "vite": "^4.3.9",
         "vue-eslint-parser": "^9.0.3",
+        "vue-material-design-icons": "^5.2.0",
         "vue-router": "^3.6.5",
         "vue-styleguidist": "~4.72.0",
         "vue-template-compiler": "^2.7.14",
@@ -27773,7 +27773,8 @@
     "node_modules/vue-material-design-icons": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.2.0.tgz",
-      "integrity": "sha512-fcdcJHQ9fQw2CAytuLAzWSELcxH138sCdMItVhvmO7Lu9afIgojB/UCWv7XHt/lURsnq/n6O+muM4AQgw8yfig=="
+      "integrity": "sha512-fcdcJHQ9fQw2CAytuLAzWSELcxH138sCdMItVhvmO7Lu9afIgojB/UCWv7XHt/lURsnq/n6O+muM4AQgw8yfig==",
+      "dev": true
     },
     "node_modules/vue-resize": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "vue": "^2.7.14",
     "vue-color": "^2.8.1",
     "vue-frag": "^1.4.3",
-    "vue-material-design-icons": "^5.1.2",
     "vue2-datepicker": "^3.11.0"
   },
   "engines": {
@@ -143,6 +142,7 @@
     "url-loader": "^4.1.1",
     "vite": "^4.3.9",
     "vue-eslint-parser": "^9.0.3",
+    "vue-material-design-icons": "^5.2.0",
     "vue-router": "^3.6.5",
     "vue-styleguidist": "~4.72.0",
     "vue-template-compiler": "^2.7.14",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -89,9 +89,12 @@ export default defineConfig((env) => {
 	const createConfig = createLibConfig(entryPoints, {
 		// Add our overrides to the config
 		config: overrides,
-		// Packages with paths imports should be added here to mark them as external as well
+		// By default all dependencies are external, but no path imports
 		nodeExternalsOptions: {
-			include: [/^vue-material-design-icons\//, /^@nextcloud\/.+\//, /^@mdi\/svg\//],
+			// Packages with paths imports should be added here to mark them as external as well
+			include: [/^@nextcloud\/.+\//, /^@mdi\/svg\//],
+			// Make sure to not provide uncompiled vue files as dependencies, this will break unit tests
+			exclude: [/\.vue(\?|$)/],
 		},
 		// For backwards compatibility we include the css within the js files
 		inlineCSS: true,


### PR DESCRIPTION
### ☑️ Resolves

We should not require any not compiled vue files as this breaks unit tests in apps, as you require the users to compile vue files first.
We had this discussion with @skjnldsv on dialogs before and decided there to bundle the vue-material-design-icons, so I would like to do the same here.
