### PR TITLE
fix(NcTimezonePicker): add missing `t` method

### DIFF
--- a/src/components/NcTimezonePicker/NcTimezonePicker.vue
+++ b/src/components/NcTimezonePicker/NcTimezonePicker.vue
@@ -130,6 +130,8 @@ export default {
 		},
 	},
 	methods: {
+		t,
+
 		change(newValue) {
 			if (!newValue) {
 				return


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/41348#issuecomment-1803538694