### PR TITLE
fix(NcAppSettingsDialog): issues on register/unregister sections

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -195,7 +195,7 @@ export default {
 	provide() {
 		return {
 			registerSection: this.registerSection,
-			unregisterSection: this.registerSection,
+			unregisterSection: this.unregisterSection,
 		}
 	},
 

--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -328,7 +328,7 @@ export default {
 			const newSections = [...this.sections, { id, name, icon }]
 			// Sort sections by order in slots
 			this.sections = newSections.sort(({ id: idA }, { id: idB }) => {
-				const indexOf = (id) => this.$slots.default.indexOf(vnode => vnode?.componentOptions?.propsData?.id === id)
+				const indexOf = (id) => this.$slots.default.findIndex(vnode => vnode?.componentOptions?.propsData?.id === id)
 				return indexOf(idA) - indexOf(idB)
 			})
 		},

--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -290,11 +290,6 @@ export default {
 		},
 	},
 
-	mounted() {
-		// Select first settings section
-		this.selectedSection = this.$slots.default[0].componentOptions.propsData.id
-	},
-
 	updated() {
 		// Check that the scroller element has been mounted
 		if (!this.$refs.settingsScroller) {
@@ -331,6 +326,11 @@ export default {
 				const indexOf = (id) => this.$slots.default.findIndex(vnode => vnode?.componentOptions?.propsData?.id === id)
 				return indexOf(idA) - indexOf(idB)
 			})
+
+			// Make the first registered section selected
+			if (this.sections.length === 1) {
+				this.selectedSection = this.sections[0].id
+			}
 		},
 
 		/**
@@ -339,6 +339,10 @@ export default {
 		 */
 		unregisterSection(id) {
 			this.sections = this.sections.filter(({ id: otherId }) => id !== otherId)
+			// If the selected section is removed, select the first section or none
+			if (this.selectedSection === id) {
+				this.selectedSection = this.sections[0]?.id ?? ''
+			}
 		},
 
 		/**

--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -338,7 +338,7 @@ export default {
 		 * @param {string} id The section ID
 		 */
 		unregisterSection(id) {
-			this.sections = this.sections.filter(({ id: otherId }) => id === otherId)
+			this.sections = this.sections.filter(({ id: otherId }) => id !== otherId)
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/spreed/issues/10858

Fixes a number of typos in `NcAppSettingsDialog`

### 🖼️ Screenshots

![NcAppSettingsDialog](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/93ba47d6-ba3d-4814-867e-0e89010cb4cb)


### 🚧 Tasks

- [x] Typo in provider, `registerSection` was provided as `unregisterSection`
- [x] Typo in `unregisterSection` filtered all items except the one that was supposed to be removed
- [x] Typo in sorting, `indexOf` searches for a value, not by a callback
- [x] Update `selectedSection` on `registerSection`/`unregisterSection`

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
