### PR TITLE
Fix unregisterSection Bug in NcAppSettingsDialog

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -338,7 +338,7 @@ export default {
 		 * @param {string} id The section ID
 		 */
 		unregisterSection(id) {
-			this.sections = this.sections.filter(({ id: otherId }) => id === otherId)
+			this.sections = this.sections.filter(({ id: otherId }) => id !== otherId)
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

Fixes "Error: Duplicate section id found: [any section id, that is used dynamically]. Settings navigation sections must have unique section ids." error, when enabling any previously disabled section using v-if.
This usage of dynamic sections is supported, but is broken since #4745, because of a very simple logic error: the unregisterSection function is supposed to filter out that particular section, that just got unregistered. Instead it currently removes any section besides of the unregistered one, leaving behind a broken component state.

### 🖼️ Screenshots

No design changes

### 🚧 Tasks

- [x] Replace "===" with "!==" :laughing: 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
