### PR TITLE
fix(NcAppSidebarTabs): override checkbox radio switch only in navigation

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -271,6 +271,26 @@ export default {
 		justify-content: stretch;
 		margin: 10px 8px 0 8px;
 		border-bottom: 1px solid var(--color-border);
+
+		// Override checkbox-radio-switch styles so that it looks like tabs
+		& :deep(.checkbox-radio-switch--button-variant) {
+			border: unset !important;
+			border-radius: 0 !important;
+			.checkbox-content {
+				padding: var(--default-grid-baseline);
+				border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0 !important;
+				margin: 0 !important;
+				border-bottom: var(--default-grid-baseline) solid transparent !important;
+				.checkbox-content__icon--checked > * {
+					color: var(--color-main-text) !important;
+				}
+			}
+			&.checkbox-radio-switch--checked .checkbox-radio-switch__content{
+				background: transparent !important;
+				color: var(--color-main-text) !important;
+				border-bottom: var(--default-grid-baseline) solid var(--color-primary-element) !important;
+			}
+		}
 	}
 
 	&__tab {
@@ -311,26 +331,6 @@ export default {
 		&--multiple > :not(section) {
 			display: none;
 		}
-	}
-}
-
-// Override checkbox-radio-switch styles so that it looks like tabs
-:deep(.checkbox-radio-switch--button-variant) {
-	border: unset !important;
-	border-radius: 0 !important;
-	.checkbox-content {
-		padding: var(--default-grid-baseline);
-		border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0 !important;
-		margin: 0 !important;
-		border-bottom: var(--default-grid-baseline) solid transparent !important;
-		.checkbox-content__icon--checked > * {
-			color: var(--color-main-text) !important;
-		}
-	}
-	&.checkbox-radio-switch--checked .checkbox-radio-switch__content{
-		background: transparent !important;
-		color: var(--color-main-text) !important;
-		border-bottom: var(--default-grid-baseline) solid var(--color-primary-element) !important;
 	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4822

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e3b0d5b9-18e0-42f3-b5a5-c25ec539aeb8) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/579eb8cd-c925-4732-986e-21abd1a3dcad)


### 🚧 Tasks

- [x] Override with `:deep` `NcCheckboxRadioSwitch` styles only inside tabslist navigation, not inside all the tab, including tab content

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
