### PR TITLE
Create scrollable content via `min-height` over sidebar and settings …

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -395,6 +395,9 @@ export default {
 
 <style lang="scss" scoped>
 .app-settings {
+	&:deep(.dialog) {
+		min-height: 256px;
+	}
 	&__navigation {
 		min-width: 200px;
 		margin-right: 20px;
@@ -409,6 +412,7 @@ export default {
 		overflow-x: hidden;
 		padding: 24px;
 		width: 100%;
+		min-height: 256px;
 	}
 }
 

--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -323,8 +323,7 @@ export default {
 
 	&__content {
 		position: relative;
-		// take full available height
-		min-height: 0;
+		min-height: 256px;
 		height: 100%;
 		// force the use of the tab component if more than one tab
 		// you can just put raw content if you don't use tabs


### PR DESCRIPTION
Create scrollable content via `min-height` over sidebar and settings dialog on small screens

### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/41504
As suggested https://github.com/nextcloud/server/issues/36965#issuecomment-1812599749

### 🖼️ Screenshots

🏚️ Before

![Peek 2023-11-15 16-57](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/427c4826-ce2d-4865-a1c6-7378160b078e)

![Peek 2023-11-15 16-56](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/05964b62-9c0c-47b6-84d0-b6af0e8a8d06)


🏡 After


![Peek 2023-11-15 16-53](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/e0247a48-ad76-4cc2-b022-8a72678ef0ba)

![Peek 2023-11-15 16-52](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/4401dbef-d27c-4907-81af-712d7d366405)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
