### PR TITLE
Improve relative time handling

### DIFF
--- a/src/components/NcDateTime/NcDateTime.vue
+++ b/src/components/NcDateTime/NcDateTime.vue
@@ -197,7 +197,7 @@ export default {
 					return formatter.format(Math.round(minutes), 'minute')
 				}
 				const hours = minutes / 60
-				if (Math.abs(hours) <= 72) {
+				if (Math.abs(hours) <= 24) {
 					return formatter.format(Math.round(hours), 'hour')
 				}
 				const days = hours / 24

--- a/tests/unit/components/NcDateTime/NcDateTime.spec.js
+++ b/tests/unit/components/NcDateTime/NcDateTime.spec.js
@@ -169,6 +169,20 @@ describe('NcDateTime.vue', () => {
 			expect(wrapper.element.textContent).toContain('3 hours')
 		})
 
+		it('shows days from now', () => {
+			const time = Date.UTC(2023, 5, 21, 20, 30, 30)
+			const currentTime = Date.UTC(2023, 5, 23, 17, 30, 30)
+			Date.now = jest.fn(() => new Date(currentTime).valueOf())
+			const wrapper = mount(NcDateTime, {
+				propsData: {
+					timestamp: time,
+				},
+			})
+
+			expect(wrapper.vm.currentTime).toEqual(currentTime)
+			expect(wrapper.element.textContent).toContain('2 days')
+		})
+
 		it('shows weeks from now', () => {
 			const time = Date.UTC(2023, 5, 23, 14, 30, 30)
 			const currentTime = Date.UTC(2023, 6, 13, 14, 30, 30)


### PR DESCRIPTION
### Resolve

- 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
See activity from "50 hours ago" and start dying as you are bad in math instead of knowing when a colleague did something | "2 days ago" helpfully obvious
![Bildschirmfoto vom 2023-11-16 12-16-41](https://github.com/nextcloud-libraries/nextcloud-vue/assets/213943/1f2ae33e-4d4d-4cdc-9f49-3e82c03bfe76) | ![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/213943/baa722ed-a3d8-476f-ab70-3ed67c1b5017)

### Background info

In stable27 Moment was used by the activity app, the breaking points are here:
https://github.com/moment/moment/blob/000ac1800e620f770f4eb31b5ae908f6167b0ab2/src/lib/duration/humanize.js#L4-L11

We could also go for those, but at least the 72 hours need to go.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
