### PR TITLE
fix(NcActions): fix role and aria attributes

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -173,12 +173,12 @@ export default {
 </docs>
 
 <template>
-	<li class="action" :class="{ 'action--disabled': disabled }">
+	<li class="action" :class="{ 'action--disabled': disabled }" :role="isInSemanticMenu && 'presentation'">
 		<button class="action-button"
 			:class="{ focusable: isFocusable }"
 			:aria-label="ariaLabel"
 			:title="title"
-			role="menuitem"
+			:role="isInSemanticMenu && 'menuitem'"
 			type="button"
 			@click="onClick">
 			<!-- @slot Manually provide icon -->
@@ -235,6 +235,13 @@ export default {
 	},
 	mixins: [ActionTextMixin],
 
+	inject: {
+		isInSemanticMenu: {
+			from: 'NcActions:isSemanticMenu',
+			default: false,
+		},
+	},
+
 	props: {
 		/**
 		 * disabled state of the action button
@@ -263,6 +270,7 @@ export default {
 			default: false,
 		},
 	},
+
 	computed: {
 		/**
 		 * determines if the action is focusable

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -185,7 +185,7 @@ export default {
 			<slot name="icon">
 				<span :class="[isIconUrl ? 'action-button__icon--url' : icon]"
 					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
-					:aria-hidden="ariaHidden"
+					aria-hidden="true"
 					class="action-button__icon" />
 			</slot>
 
@@ -245,7 +245,9 @@ export default {
 		},
 
 		/**
-		 * aria-hidden attribute for the icon slot
+		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
+		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
+		 * otherwise root element will inherit incorrect aria-hidden.
 		 */
 		ariaHidden: {
 			type: Boolean,

--- a/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
+++ b/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
@@ -82,10 +82,10 @@ export default {
 
 <template>
 	<li class="nc-button-group-base">
-		<div v-if="name">
+		<div v-if="name" :id="labelId">
 			{{ name }}
 		</div>
-		<ul class="nc-button-group-content">
+		<ul class="nc-button-group-content" role="group" :aria-labelledby="name ? labelId : undefined">
 			<slot />
 		</ul>
 	</li>
@@ -93,6 +93,7 @@ export default {
 
 <script>
 import { defineComponent } from 'vue'
+import GenRandomId from '../../utils/GenRandomId.js'
 
 /**
  * A wrapper for allowing inlining NcAction components within the action menu
@@ -107,6 +108,12 @@ export default defineComponent({
 			required: false,
 			default: undefined,
 			type: String,
+		},
+	},
+
+	computed: {
+		labelId() {
+			return `nc-action-button-group-${GenRandomId()}`
 		},
 	},
 })

--- a/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
+++ b/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
@@ -81,7 +81,7 @@ export default {
 </docs>
 
 <template>
-	<li class="nc-button-group-base">
+	<li class="nc-button-group-base" :role="isInSemanticMenu && 'presentation'">
 		<div v-if="name" :id="labelId">
 			{{ name }}
 		</div>
@@ -100,6 +100,14 @@ import GenRandomId from '../../utils/GenRandomId.js'
  */
 export default defineComponent({
 	name: 'NcActionButtonGroup',
+
+	inject: {
+		isInSemanticMenu: {
+			from: 'NcActions:isSemanticMenu',
+			default: false,
+		},
+	},
+
 	props: {
 		/**
 		 * Optional text shown below the button group

--- a/src/components/NcActionCaption/NcActionCaption.vue
+++ b/src/components/NcActionCaption/NcActionCaption.vue
@@ -30,7 +30,7 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 </docs>
 
 <template>
-	<li class="app-navigation-caption">
+	<li class="app-navigation-caption" :role="isInSemanticMenu && 'presentation'">
 		{{ name }}
 	</li>
 </template>
@@ -38,6 +38,14 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 <script>
 export default {
 	name: 'NcActionCaption',
+
+	inject: {
+		isInSemanticMenu: {
+			from: 'NcActions:isSemanticMenu',
+			default: false,
+		},
+	},
+
 	props: {
 		/**
 		 * The caption's text

--- a/src/components/NcActionCheckbox/NcActionCheckbox.vue
+++ b/src/components/NcActionCheckbox/NcActionCheckbox.vue
@@ -35,8 +35,8 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 </docs>
 
 <template>
-	<li class="action" :class="{ 'action--disabled': disabled }">
-		<span class="action-checkbox">
+	<li class="action" :class="{ 'action--disabled': disabled }" :role="isInSemanticMenu && 'presentation'">
+		<span class="action-checkbox" :role="isInSemanticMenu && 'menuitemcheckbox'" :aria-checked="ariaChecked">
 			<input :id="id"
 				ref="checkbox"
 				:disabled="disabled"
@@ -63,6 +63,13 @@ export default {
 	name: 'NcActionCheckbox',
 
 	mixins: [ActionGlobalMixin],
+
+	inject: {
+		isInSemanticMenu: {
+			from: 'NcActions:isSemanticMenu',
+			default: false,
+		},
+	},
 
 	props: {
 		/**
@@ -114,6 +121,18 @@ export default {
 		 */
 		isFocusable() {
 			return !this.disabled
+		},
+
+		/**
+		 * aria-checked attribute for role="menuitemcheckbox"
+		 *
+		 * @return {'true'|'false'|undefined} aria-checked value if needed
+		 */
+		ariaChecked() {
+			if (this.isInSemanticMenu) {
+				return this.checked ? 'true' : 'false'
+			}
+			return undefined
 		},
 	},
 

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -147,7 +147,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				<slot name="icon">
 					<span :class="[isIconUrl ? 'action-input__icon--url' : icon]"
 						:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
-						:aria-hidden="ariaHidden"
+						aria-hidden="true"
 						class="action-input__icon" />
 				</slot>
 			</span>
@@ -370,7 +370,9 @@ export default {
 			default: '',
 		},
 		/**
-		 * aria-hidden attribute for the icon slot
+		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
+		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
+		 * otherwise root element will inherit incorrect aria-hidden.
 		 */
 		ariaHidden: {
 			type: Boolean,

--- a/src/components/NcActionLink/NcActionLink.vue
+++ b/src/components/NcActionLink/NcActionLink.vue
@@ -93,7 +93,7 @@ export default {
 			<slot name="icon">
 				<span :class="[isIconUrl ? 'action-link__icon--url' : icon]"
 					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
-					:aria-hidden="ariaHidden"
+					aria-hidden="true"
 					class="action-link__icon" />
 			</slot>
 
@@ -175,7 +175,9 @@ export default {
 			default: null,
 		},
 		/**
-		 * aria-hidden attribute for the icon slot
+		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
+		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
+		 * otherwise root element will inherit incorrect aria-hidden.
 		 */
 		ariaHidden: {
 			type: Boolean,

--- a/src/components/NcActionLink/NcActionLink.vue
+++ b/src/components/NcActionLink/NcActionLink.vue
@@ -78,7 +78,7 @@ export default {
 </docs>
 
 <template>
-	<li class="action">
+	<li class="action" :role="isInSemanticMenu && 'presentation'">
 		<a :download="download"
 			:href="href"
 			:aria-label="ariaLabel"
@@ -86,7 +86,7 @@ export default {
 			:title="title"
 			class="action-link focusable"
 			rel="nofollow noreferrer noopener"
-			role="menuitem"
+			:role="isInSemanticMenu && 'menuitem'"
 			@click="onClick">
 
 			<!-- @slot Manually provide icon -->
@@ -132,6 +132,13 @@ export default {
 	name: 'NcActionLink',
 
 	mixins: [ActionTextMixin],
+
+	inject: {
+		isInSemanticMenu: {
+			from: 'NcActions:isSemanticMenu',
+			default: false,
+		},
+	},
 
 	props: {
 		/**

--- a/src/components/NcActionRadio/NcActionRadio.vue
+++ b/src/components/NcActionRadio/NcActionRadio.vue
@@ -37,8 +37,8 @@ So that only one of each name set can be selected at the same time.
 </docs>
 
 <template>
-	<li class="action" :class="{ 'action--disabled': disabled }">
-		<span class="action-radio">
+	<li class="action" :class="{ 'action--disabled': disabled }" :role="isInSemanticMenu && 'presentation'">
+		<span class="action-radio" role="menuitemradio" :aria-checked="ariaChecked">
 			<input :id="id"
 				ref="radio"
 				:disabled="disabled"
@@ -66,6 +66,13 @@ export default {
 	name: 'NcActionRadio',
 
 	mixins: [ActionGlobalMixin],
+
+	inject: {
+		isInSemanticMenu: {
+			from: 'NcActions:isSemanticMenu',
+			default: false,
+		},
+	},
 
 	props: {
 		/**
@@ -125,6 +132,18 @@ export default {
 		 */
 		isFocusable() {
 			return !this.disabled
+		},
+
+		/**
+		 * aria-checked attribute for role="menuitemcheckbox"
+		 *
+		 * @return {'true'|'false'|undefined} aria-checked value if needed
+		 */
+		 ariaChecked() {
+			if (this.isInSemanticMenu) {
+				return this.checked ? 'true' : 'false'
+			}
+			return undefined
 		},
 	},
 

--- a/src/components/NcActionRouter/NcActionRouter.vue
+++ b/src/components/NcActionRouter/NcActionRouter.vue
@@ -34,7 +34,8 @@
 			<slot name="icon">
 				<span :class="[isIconUrl ? 'action-router__icon--url' : icon]"
 					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
-					class="action-router__icon" />
+					class="action-router__icon"
+					aria-hidden="true" />
 			</slot>
 
 			<!-- long text with name -->

--- a/src/components/NcActionRouter/NcActionRouter.vue
+++ b/src/components/NcActionRouter/NcActionRouter.vue
@@ -22,13 +22,14 @@
   -->
 
 <template>
-	<li class="action">
-		<router-link :to="to"
+	<li class="action" :role="isInSemanticMenu && 'presentation'">
+		<RouterLink :to="to"
 			:aria-label="ariaLabel"
 			:exact="exact"
 			:title="title"
 			class="action-router focusable"
 			rel="nofollow noreferrer noopener"
+			:role="isInSemanticMenu && 'menuitem'"
 			@click.native="onClick">
 			<!-- @slot Manually provide icon -->
 			<slot name="icon">
@@ -62,7 +63,7 @@
 
 			<!-- fake slot to gather inner text -->
 			<slot v-if="false" />
-		</router-link>
+		</RouterLink>
 	</li>
 </template>
 
@@ -73,6 +74,13 @@ export default {
 	name: 'NcActionRouter',
 
 	mixins: [ActionTextMixin],
+
+	inject: {
+		isInSemanticMenu: {
+			from: 'NcActions:isSemanticMenu',
+			default: false,
+		},
+	},
 
 	props: {
 		/**

--- a/src/components/NcActionSeparator/NcActionSeparator.vue
+++ b/src/components/NcActionSeparator/NcActionSeparator.vue
@@ -24,7 +24,7 @@
   -->
 
 <template>
-	<li class="action action-separator action--disabled" />
+	<li class="action action-separator action--disabled" role="separator" />
 </template>
 
 <script>

--- a/src/components/NcActionText/NcActionText.vue
+++ b/src/components/NcActionText/NcActionText.vue
@@ -29,7 +29,7 @@
 			<slot name="icon">
 				<span v-if="icon !== ''"
 					:class="[isIconUrl ? 'action-text__icon--url' : icon]"
-					:aria-hidden="ariaHidden"
+					aria-hidden="true"
 					:style="{ backgroundImage: isIconUrl ? `url(${icon})` : null }"
 					class="action-text__icon" />
 			</slot>

--- a/src/components/NcActionText/NcActionText.vue
+++ b/src/components/NcActionText/NcActionText.vue
@@ -22,7 +22,7 @@
   -->
 
 <template>
-	<li class="action">
+	<li class="action" :role="isInSemanticMenu && 'presentation'">
 		<span class="action-text"
 			@click="onClick">
 			<!-- @slot Manually provide icon -->
@@ -70,6 +70,12 @@ export default {
 
 	mixins: [ActionTextMixin],
 
+	inject: {
+		isInSemanticMenu: {
+			from: 'NcActions:isSemanticMenu',
+			default: false,
+		},
+	},
 }
 </script>
 

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -564,6 +564,236 @@ export default {
 </script>
 ```
 
+### Use cases
+
+```vue
+<template>
+	<div>
+		<h2>Application menu</h2>
+		Uses buttons, button groups, links and router links, separators, text. May have checkboxes and radio buttons.
+		<p>
+			<NcActions aria-label="Email menu" type="tertiary">
+				<NcActionButtonGroup>
+					<NcActionButton>
+						<template #icon>
+							<StarOutline :size="20" />
+						</template>
+						Favorite
+					</NcActionButton>
+					<NcActionButton>
+						<template #icon>
+							<EmailUnread :size="20" />
+						</template>
+						Unread
+					</NcActionButton>
+					<NcActionButton>
+						<template #icon>
+							<Bookmark :size="20" />
+						</template>
+						Important
+					</NcActionButton>
+				</NcActionButtonGroup>
+				<NcActionText>
+					<template #icon>
+						<ClockOutlineIcon :size="20" />
+					</template>
+					{{ new Date().toLocaleDateString('en-US') }}
+				</NcActionText>
+				<NcActionSeparator />
+				<NcActionButton>
+					<template #icon>
+						<AlertOctagonIcon :size="20" />
+					</template>
+					Mark as spam
+				</NcActionButton>
+				<NcActionCheckbox :checked.sync="selected">
+					Select
+				</NcActionCheckbox>
+				<NcActionButton>
+					<template #icon>
+						<OpenInNewIcon :size="20" />
+					</template>
+					Move thread
+				</NcActionButton>
+				<NcActionLink href="#">
+					<template #icon>
+						<DownloadIcon :size="20" />
+					</template>
+					Download message
+				</NcActionLink>
+			</NcActions>
+		</p>
+
+		<h2>Menu in menubar</h2>
+		Same as application menu. Separator can be used to make groups of radio buttons as well.
+		<p>
+			<NcActions aria-label="Text settings" type="tertiary">
+				<template #icon>
+					<FormatTitle :size="20" />
+				</template>
+				<NcActionButtonGroup name="Allignment">
+					<NcActionButton aria-label="Left">
+						<template #icon>
+							<FormatAlignLeft :size="20" />
+						</template>
+					</NcActionButton>
+					<NcActionButton aria-label="Center">
+						<template #icon>
+							<FormatAlignCenter :size="20" />
+						</template>
+					</NcActionButton>
+					<NcActionButton aria-label="Right">
+						<template #icon>
+							<FormatAlignRight :size="20" />
+						</template>
+					</NcActionButton>
+				</NcActionButtonGroup>
+				<NcActionSeparator />
+				<NcActionCheckbox :checked.sync="checked.bold" value="bold">
+					<template #icon>
+						<FormatBold :size="20" />
+					</template>
+					Bold
+				</NcActionCheckbox>
+				<NcActionCheckbox :checked.sync="checked.italic" value="italic">
+					<template #icon>
+						<FormatItalic :size="20" />
+					</template>
+					Italic
+				</NcActionCheckbox>
+				<NcActionCheckbox :checked.sync="checked.underline" value="underline">
+					<template #icon>
+						<FormatUnderline :size="20" />
+					</template>
+					Underline
+				</NcActionCheckbox>
+				<NcActionSeparator />
+				<NcActionRadio name="color" :checked.sync="color.black" value="Black">Black</NcActionRadio>
+				<NcActionRadio name="color" :checked.sync="color.blue" value="Blue">Blue</NcActionRadio>
+				<NcActionRadio name="color" :checked.sync="color.red" value="Red">Red</NcActionRadio>
+				<NcActionRadio name="color" :checked.sync="color.green" value="Green">Green</NcActionRadio>
+			</NcActions>
+		</p>
+
+		<h2>Navigation</h2>
+		Uses links or router links. May use text elements, captions and separators.
+		<p>
+			<NcActions aria-label="Applications navigation" :inline="2" type="tertiary">
+				<NcActionLink href="/apps/dashboard" icon="icon-category-dashboard-white">
+					Dashboard
+				</NcActionLink>
+				<NcActionLink href="/apps/files" icon="icon-files-white">
+					Files
+				</NcActionLink>
+				<NcActionLink href="/apps/spreed" icon="icon-talk-white">
+					Talk
+				</NcActionLink>
+				<NcActionLink href="/apps/contacts" icon="icon-contacts-white">
+					Contacts
+				</NcActionLink>
+				<NcActionLink href="/apps/spreed" icon="icon-circles-white">
+					Circles
+				</NcActionLink>
+			</NcActions>
+		</p>
+
+		<h2>Popover</h2>
+		Has any elements, including text input element, or no buttons.
+		<p>
+			<NcActions aria-label="Group management">
+				<NcActionInput trailing-button-label="Submit" label="Rename group">
+					<template #icon>
+						<Pencil :size="20" />
+					</template>
+				</NcActionInput>
+				<NcActionButton>
+					<template #icon>
+						<Delete :size="20" />
+					</template>
+					Remove group
+				</NcActionButton>
+			</NcActions>
+		</p>
+	</div>
+</template>
+
+<script>
+// Common icons
+import Pencil from 'vue-material-design-icons/Pencil'
+import Delete from 'vue-material-design-icons/Delete'
+
+// Email icons
+import StarOutline from 'vue-material-design-icons/StarOutline'
+import EmailUnread from 'vue-material-design-icons/Email'
+import Bookmark from 'vue-material-design-icons/Bookmark'
+import ClockOutlineIcon from 'vue-material-design-icons/ClockOutline'
+import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagon'
+import CheckIcon from 'vue-material-design-icons/Check'
+import OpenInNewIcon from 'vue-material-design-icons/OpenInNew'
+import DownloadIcon from 'vue-material-design-icons/Download'
+
+// Formating icons
+import FormatTitle from 'vue-material-design-icons/FormatTitle.vue'
+import FormatAlignLeft from 'vue-material-design-icons/FormatAlignLeft.vue'
+import FormatAlignCenter from 'vue-material-design-icons/FormatAlignCenter.vue'
+import FormatAlignRight from 'vue-material-design-icons/FormatAlignRight.vue'
+import FormatBold from 'vue-material-design-icons/FormatBold.vue'
+import FormatItalic from 'vue-material-design-icons/FormatItalic.vue'
+import FormatUnderline from 'vue-material-design-icons/FormatUnderline.vue'
+
+export default {
+	components: {
+		// Common icons
+		Pencil,
+		Delete,
+
+		// Email icons
+		StarOutline,
+		EmailUnread,
+		Bookmark,
+		ClockOutlineIcon,
+		AlertOctagonIcon,
+		CheckIcon,
+		OpenInNewIcon,
+		DownloadIcon,
+
+		// Formating icons
+		FormatTitle,
+		FormatAlignLeft,
+		FormatAlignCenter,
+		FormatAlignRight,
+		FormatBold,
+		FormatItalic,
+		FormatUnderline,
+	},
+
+	data() {
+		return {
+			selected: false,
+			// Formating
+			checked: {
+				bold: true,
+				italic: false,
+				underline: false,
+			},
+			color: {
+				black: true,
+				blue: false,
+				red: false,
+				green: false,
+			},
+		}
+	},
+}
+</script>
+
+<style scoped>
+p {
+	margin: 1rem 0;
+}
+</style>
+```
+
 </docs>
 
 <script>

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -912,7 +912,9 @@ export default {
 		},
 
 		/**
-		 * aria-hidden attribute for the icon slot
+		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
+		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
+		 * otherwise root element will inherit incorrect aria-hidden.
 		 */
 		ariaHidden: {
 			type: Boolean,
@@ -1272,7 +1274,6 @@ export default {
 						// If it has a menuName, we use a secondary button
 						type: this.type || (buttonText ? 'secondary' : 'tertiary'),
 						disabled: this.disabled || action?.componentOptions?.propsData?.disabled,
-						ariaHidden: this.ariaHidden,
 						...action?.componentOptions?.propsData,
 					},
 					on: {
@@ -1352,7 +1353,6 @@ export default {
 						props: {
 							type: this.triggerBtnType,
 							disabled: this.disabled,
-							ariaHidden: this.ariaHidden,
 						},
 						slot: 'trigger',
 						ref: 'menuButton',

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -539,7 +539,9 @@ export default {
 			default: false,
 		},
 		/**
-		 * aria-hidden attribute for the icon slot
+		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
+		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
+		 * otherwise root element will inherit incorrect aria-hidden.
 		 */
 		ariaHidden: {
 			type: Boolean,
@@ -663,7 +665,7 @@ export default {
 						? h('span', {
 							class: 'button-vue__icon',
 							attrs: {
-								'aria-hidden': this.ariaHidden,
+								'aria-hidden': 'true',
 							},
 						},
 						[this.$slots.icon],

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -61,7 +61,9 @@ export default {
 			default: null,
 		},
 		/**
-		 * aria-hidden attribute for the icon slot
+		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
+		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
+		 * otherwise root element will inherit incorrect aria-hidden.
 		 */
 		ariaHidden: {
 			type: Boolean,


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/37099

`NcActions` and `NcAction*` items should have correct menu roles only when it represents a menu.

See detailed requirement in the comment here: https://github.com/nextcloud/server/issues/37099#issuecomment-1803927925

### 🖼️ Screenshots

Example | Before | After
---|---|---
**Application menus** | | +group, +presentation, +label, +checkbox/radio
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/de3dcdb3-985c-49f7-a937-953a229984ce) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/1136527b-bb28-4cbd-b96c-3ddfc953a86a) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/ebd6b8a9-484c-450b-81fa-bc083cffc724)
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/bda2b703-beac-4861-bd7c-0e340c1c40da) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/b846c124-f35b-4b16-a72e-54122c1da0e4) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/76a37d86-5c59-41d5-82a3-9e414b31a17b)
**Navigation** | ✅ | No changes
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/f7d3415e-7b65-4c2d-abea-afae9ece43e8) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d42cc1b7-0d7c-4f40-8611-72a9210588c6) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9da9df0d-bb66-465c-8319-830882a3f031)
**Popovers** | | no wrong roles
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/b9552a72-518b-4b23-a108-e272b09e7c5f) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/65d14dcc-f2e1-4eb8-9fb1-8f5e050bed25) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/58b3a043-8cb1-4825-9d3a-55e18cfed9e9)

### 🚧 Tasks

- [x] Add more examples with use cases to docs
- [x] `NcActionSeparator`: add `role="separator"`
- [x] `NcActionButtonGroup`: add `role="group"` and `aria-labelledby`
- [x] `NcActionsButton` and `NcButton`:
      - Always set `aria-hidden="true"` on `span.icon` in default `#icon`
      - ⚠️ **Deprecate `ariaHidden` props. Developers don't need to set it manually, it is always needed by default** ⚠️
- [x] `NcActions`:
      - Change rule to determine when actions has `role="menu"`
      - Provide `NcActions:inSemanticMenu`, to `NcAction*` may know if they are in `role="menu"`
      - Only in a menu:
        - `LI` has `role="presentation"`
        - `BUTTON` has `role="menuitem"`
        - In `NcActionCheckbox/NcActionRadio`:
          - `span` has `role="menuitemcheckbox"` or `role="menuitemradio"`
          - `span` has correct `aria-checked`

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
