### PR TITLE
Create scrollable content via `min-height` over sidebar and settings dialog on small screens

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -145,6 +145,7 @@ export default {
 		@update:open="handleCloseModal">
 		<template #navigation="{ isCollapsed }">
 			<ul :aria-label="settingsNavigationAriaLabel"
+				v-show="!isCollapsed"
 				:class="{ 'navigation-list': true, 'navigation-list--collapsed': isCollapsed }"
 				role="tablist">
 				<li v-for="section in sections" :key="section.id">


### PR DESCRIPTION
Create scrollable content via `min-height` over sidebar and settings dialog on small screens


### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/41542

### 🖼️ Screenshots

🏚️ Before 

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/3fe9e1e3-3b40-4f22-aaf7-4b45634c93ba)

🏡 After

![Peek 2023-11-17 10-01](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/5cf9c9c1-b064-4632-b6fd-30fb2ca5f308)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
