### PR TITLE
[next] fix(NcCheckboxRadioSwitch): fix v-on with no argument expects an object value

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -273,7 +273,7 @@ export default {
 		class="checkbox-radio-switch"
 		:style="cssVars"
 		:type="isButtonType ? 'button' : null"
-		v-on="isButtonType ? listeners : null">
+		v-on="isButtonType ? listeners : {}">
 		<input v-if="!isButtonType"
 			:id="id"
 			class="checkbox-radio-switch__input"


### PR DESCRIPTION
### ☑️ Resolves

* Fix `[Vue warn]: v-on with no argument expects an object value. ` for `NcCheckboxRadioSwitch`.