### PR TITLE
fix(NcActions): adjust keyboard navigation

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1154,8 +1154,7 @@ export default {
 		focusPreviousAction(event) {
 			if (this.opened) {
 				if (this.focusIndex === 0) {
-					// First element overflows to body-navigation (no preventDefault!) and closes Actions-menu
-					this.closeMenu()
+					this.focusLastAction(event)
 				} else {
 					this.preventIfEvent(event)
 					this.focusIndex = this.focusIndex - 1
@@ -1167,8 +1166,7 @@ export default {
 			if (this.opened) {
 				const indexLength = this.$refs.menu.querySelectorAll(focusableSelector).length - 1
 				if (this.focusIndex === indexLength) {
-					// Last element overflows to body-navigation (no preventDefault!) and closes Actions-menu
-					this.closeMenu()
+					this.focusFirstAction(event)
 				} else {
 					this.preventIfEvent(event)
 					this.focusIndex = this.focusIndex + 1

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1112,24 +1112,23 @@ export default {
 		 * @param {object} event The keydown event
 		 */
 		onKeydown(event) {
-			// Up or Shift+Tab
-			if (event.keyCode === 38 || (event.keyCode === 9 && event.shiftKey)) {
+			if (event.key === 'ArrowUp' || (event.key === 'Tab' && event.shiftKey)) {
 				this.focusPreviousAction(event)
 			}
-			// Down or Tab
-			if (event.keyCode === 40 || (event.keyCode === 9 && !event.shiftKey)) {
+
+			if (event.key === 'ArrowDown' || (event.key === 'Tab' && !event.shiftKey)) {
 				this.focusNextAction(event)
 			}
-			// Page-Up
-			if (event.keyCode === 33) {
+
+			if (event.key === 'PageUp') {
 				this.focusFirstAction(event)
 			}
-			// Page-Down
-			if (event.keyCode === 34) {
+
+			if (event.key === 'PageDown') {
 				this.focusLastAction(event)
 			}
-			// Esc
-			if (event.keyCode === 27) {
+
+			if (event.key === 'Escape') {
 				this.closeMenu()
 				event.preventDefault()
 			}

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1112,11 +1112,15 @@ export default {
 		 * @param {object} event The keydown event
 		 */
 		onKeydown(event) {
-			if (event.key === 'ArrowUp' || (event.key === 'Tab' && event.shiftKey)) {
+			if (event.key === 'Tab') {
+				this.closeMenu()
+			}
+
+			if (event.key === 'ArrowUp') {
 				this.focusPreviousAction(event)
 			}
 
-			if (event.key === 'ArrowDown' || (event.key === 'Tab' && !event.shiftKey)) {
+			if (event.key === 'ArrowDown') {
 				this.focusNextAction(event)
 			}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/41012
* https://www.w3.org/WAI/ARIA/apg/patterns/menubar/
* Briefly, **a primary keyboard navigation convention common across all platforms is:**
  * <kbd>TAB</kbd> and <kbd>SHIFT + TAB</kbd> should move focus between **components**
  * <kbd>Arrows ⬆️⬇️</kbd> should move focus between **elements inside a component**

See also: https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/

### 🚧 Tasks

- [x] Make <kbd>Arrows ⬆️⬇️</kbd> loop over elements
- [x] <kbd>TAB</kbd> and <kbd>SHIFT + TAB</kbd>:
  - [x] In **menu** and **navigation** should move to next/prev component
  - [x] In **popover like** actions with form elements should loop over elements
    - <kbd>ESC</kbd> closes actions

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
**Arrow** |
Don't loop | Loop
![arrows-before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/936b8b99-a2bb-40c4-9ee9-d34a234752f7) | ![arrows-after](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d9d81394-1a95-4087-95fb-7824cc539458)
**TAB in Menu / Navigation** | 
Between elements | Between components
![Tab-Menu-Before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/f987ec8a-9949-43b0-a25f-143b463fe317) | ![Tab-Menu](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/c645ac26-60d8-4674-8044-dcf855d91957)
**TAB in Popover-like** |
Submit is not focusable | Classic popover with focus trap
![Tab-Before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/aa17f0fb-745c-4b51-87d8-93cc21453bd4) | ![Tab-Popover](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/31342ce1-c7b8-463d-bccf-cbcf3fa45924)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
