### PR TITLE
fix(NcRichcontenteditable): remove placeholder attr

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -221,7 +221,6 @@ export default {
 			'rich-contenteditable__input--disabled': disabled,
 		}"
 		:contenteditable="canEdit"
-		:placeholder="placeholder"
 		:aria-placeholder="placeholder"
 		aria-multiline="true"
 		class="rich-contenteditable__input"
@@ -824,7 +823,7 @@ export default {
 
 	// Cannot use :empty because of firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=1513303
 	&--empty:before {
-		content: attr(placeholder);
+		content: attr(aria-placeholder);
 		color: var(--color-text-maxcontrast);
 		position: absolute;
 	}

--- a/tests/unit/components/NcRichContenteditable/NcRichContenteditable.spec.js
+++ b/tests/unit/components/NcRichContenteditable/NcRichContenteditable.spec.js
@@ -126,9 +126,6 @@ describe('NcRichContenteditable', () => {
 				placeholder: PLACEHOLDER,
 			},
 		})
-		// Accessible placeholder
 		expect(wrapper.attributes('aria-placeholder')).toBe(PLACEHOLDER)
-		// Used in CSS for visible placeholder
-		expect(wrapper.attributes('placeholder')).toBe(PLACEHOLDER)
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

* A part of: https://github.com/nextcloud/server/issues/37092

This attribute is not valid on `div[richcontenteditable]` and was used only to pass value to css.

### 🖼️ Screenshots

No visual changes

### 🚧 Tasks

- [x] Remove `placeholder` and use `aria-placeholder` to pass value to CSS

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
