### PR TITLE
fix(NcActions): only search for items to focus on in the current menu

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1096,7 +1096,7 @@ export default {
 			}
 
 			const menuItem = event.target.closest('li')
-			if (menuItem) {
+			if (menuItem && this.$refs.menu.contains(menuItem)) {
 				const focusableItem = menuItem.querySelector(focusableSelector)
 				if (focusableItem) {
 					const focusList = this.$refs.menu.querySelectorAll(focusableSelector)


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4539

When a mouse is moved over `NcActions` it searches for a `NcAction<item>` under the cursor by searching for the **closest** `li` element.

The `closest` searches up to the document root.
So when the cursor is not on an actual `NcAction-<item>` (on `UL` itself between actions) and `NcActions` is rendered in a `container`, it finds just any `li` ancestor. In Talk, it is a message element. It results in focusing the first focusable action in this container.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![talk-before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9b5b19a6-9a0a-48bb-8b12-d335d27fc427) | ![talk-after](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a96cb6d2-70a2-4049-86cb-73dec899714a)

### 🚧 Tasks

- [x] Only search items to focus on in the current menu

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
