### PR TITLE
Correct styles for focused NcTextArea

### DIFF
--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -339,7 +339,8 @@ export default {
 		&:active:not([disabled]),
 		&:hover:not([disabled]),
 		&:focus:not([disabled]) {
-			border-color: var(--color-primary-element);
+			border-color: 2px solid var(--color-main-text) !important;
+			box-shadow: 0 0 0 2px var(--color-main-background) !important;
 		}
 
 		// Hide placeholder while not focussed -> show label instead (only if internal label is used)


### PR DESCRIPTION
### ☑️ Resolves

make same styles for focused, hovered and active NcTextArea as https://github.com/nextcloud-libraries/nextcloud-vue/pull/4718

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-11-17 15-50-06](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/d3dee1d7-b898-41d7-954a-4c54ab41cbdf) | ![Screenshot from 2023-11-17 15-49-55](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/583fab4d-0923-4dc3-8098-ec754bdcffed)



### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
