### PR TITLE
fix(NcCheckboxContent): Make sure text can wrap

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -223,6 +223,8 @@ export default {
 	max-width: fit-content;
 
 	&__text {
+		flex: 1 0;
+
 		&:empty {
 			// hide text if empty to ensure checkbox outline is a circle instead of oval
 			display: none;


### PR DESCRIPTION
### ☑️ Resolves

Ensure the text of the checkbox label does not overflow the label.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2023-11-21 at 15-26-09 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/c6f649ba-1e9f-40eb-9ecc-974ea7c4dd46)|![Screenshot 2023-11-21 at 15-26-34 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/a5578f0c-4c4d-4e05-9877-837b27b6b307)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
