### PR TITLE
fix(NcAppNavigation): make toggle button not the first element for focus-trap

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -57,9 +57,6 @@ emit('toggle-navigation', {
 	<div ref="appNavigationContainer"
 		class="app-navigation"
 		:class="{'app-navigation--close':!open }">
-		<div class="app-navigation__toggle-wrapper">
-			<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
-		</div>
 		<nav id="app-navigation-vue"
 			:aria-hidden="open ? 'false' : 'true'"
 			:aria-label="ariaLabel || undefined"
@@ -76,6 +73,7 @@ emit('toggle-navigation', {
 			<!-- Footer for e.g. AppNavigationSettings -->
 			<slot name="footer" />
 		</nav>
+		<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
 	</div>
 </template>
 


### PR DESCRIPTION
### ☑️ Resolves

* Move `NcAppNavigationToggle` down the list
* Possible effect: when isMobile is active (from #4633), focus-trap grabs the first available element.
  * Before fix: toggle button
  * After fix: first element in navigation

### 🖼️ Screenshots

From Talk usecase of component:

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/3b4ad906-7f67-4086-9650-ab830617d528) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/8a66dba7-2650-4a9e-ab65-68e27ec523d6)
