### PR TITLE
fix(NcAppSettingsDialog): Remove navigation instead of hiding and fix styles

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -144,9 +144,9 @@ export default {
 		v-bind="dialogProperties"
 		@update:open="handleCloseModal">
 		<template #navigation="{ isCollapsed }">
-			<ul :aria-label="settingsNavigationAriaLabel"
-				v-show="!isCollapsed"
-				:class="{ 'navigation-list': true, 'navigation-list--collapsed': isCollapsed }"
+			<ul v-if="!isCollapsed"
+				:aria-label="settingsNavigationAriaLabel"
+				class="navigation-list"
 				role="tablist">
 				<li v-for="section in sections" :key="section.id">
 					<a :aria-selected="section.id === selectedSection"
@@ -405,20 +405,19 @@ export default {
 	&:deep(.dialog) {
 		min-height: 256px;
 	}
-	&__navigation {
+	:deep &__navigation {
 		min-width: 200px;
 		margin-right: 20px;
 		overflow-x: hidden;
 		overflow-y: auto;
 		position: relative;
-		height: 100%;
 	}
-	&__content {
-		max-width: 100vw;
+	:deep &__content {
+		box-sizing: border-box;
+
 		overflow-y: auto;
 		overflow-x: hidden;
-		padding: 24px;
-		width: 100%;
+		padding-inline: 20px;
 		min-height: 256px;
 	}
 }
@@ -428,12 +427,6 @@ export default {
 	box-sizing: border-box;
 	overflow-y: auto;
 	padding: 12px;
-
-	&--collapsed {
-		display: flex;
-		flex-direction: row;
-		gap: 6px;
-	}
 
 	&__link {
 		display: flex;

--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -272,7 +272,7 @@ export default defineComponent({
 		/**
 		 * We use the dialog width to decide if we collapse the navigation (flex direction row)
 		 */
-		const { width: dialogWidth } = useElementSize(wrapper)
+		const { width: dialogWidth } = useElementSize(wrapper, { width: 900 })
 
 		/**
 		 * Whether the navigation is collapsed due to dialog and window size


### PR DESCRIPTION
### ☑️ Resolves

Instead of hiding the navigation on small devices, remove it (and clean up the styles as they are not needed anymore).

Also fix dialog styles (content & navigation) which need to have the `deep` selector to be applied.
Fixed the padding which is now already (partly) included by NcDialog.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screen Shot 2023-11-21 at 20 48 05](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/86f5e42c-b26c-48e2-8562-2cfad19f56ef)|![Screen Shot 2023-11-21 at 20 47 32](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/68bc6941-1e57-41b7-bfd2-894d1ec890a3)
![Screen Shot 2023-11-21 at 20 48 00](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/72e7ab00-bac0-4a39-a357-814ae30e7246)|![Screen Shot 2023-11-21 at 20 47 43](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/6b205b2c-3514-432b-a2b7-32d207d28f99)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
