### PR TITLE
fix(NcAppNavigation): closed on mobile initially

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -93,12 +93,6 @@ export default {
 		NcAppNavigationToggle,
 	},
 
-	setup() {
-		return {
-			isMobile: useIsMobile(),
-		}
-	},
-
 	props: {
 		/**
 		 * The aria label to describe the navigation
@@ -115,6 +109,12 @@ export default {
 			type: String,
 			default: '',
 		},
+	},
+
+	setup() {
+		return {
+			isMobile: useIsMobile(),
+		}
 	},
 
 	data() {

--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -119,7 +119,7 @@ export default {
 
 	data() {
 		return {
-			open: true,
+			open: !this.isMobile,
 			focusTrap: null,
 		}
 	},

--- a/tests/unit/components/NcAppNavigation/NcAppNavigation.spec.js
+++ b/tests/unit/components/NcAppNavigation/NcAppNavigation.spec.js
@@ -39,6 +39,11 @@ const findNavigation = (wrapper) => wrapper.get(NAVIGATION__SELECTOR)
 const findToggleButton = (wrapper) => wrapper.get(TOGGLE_BUTTON__SELECTOR)
 
 describe('NcAppNavigation.vue', () => {
+	beforeEach(async () => {
+		// Emulate desktop size
+		await resizeWindowWidth(1024)
+	})
+
 	describe('by default', () => {
 		it('is open', () => {
 			const wrapper = mount(NcAppNavigation)
@@ -81,10 +86,6 @@ describe('NcAppNavigation.vue', () => {
 	})
 
 	describe('toggle via mobile state', () => {
-		beforeEach(async () => {
-			await resizeWindowWidth(1024)
-		})
-
 		it('closes on switch to mobile', async () => {
 			const wrapper = mount(NcAppNavigation)
 


### PR DESCRIPTION
### ☑️ Resolves

When a window is resized to a mobile size, the app navigation closes. However, when the page was initially open on mobile, the navigation is open. It could be annoying because a user needs to close it to see the content.

See also discussion from: https://github.com/nextcloud/spreed/issues/10908#issuecomment-1822460276

### 🚧 Tasks

- [x] Make navigation closed not only after **switch to mobile**, but also **initially on mobile**

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
