### PR TITLE
fix(NcDialog): Add slighly more padding on the bottom and fix example button order

### DIFF
--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -45,15 +45,15 @@ export default {
 			lastResponse: 'None',
 			buttons: [
 				{
+					label: 'Cancel',
+					icon: IconCancel,
+					callback: () => { this.lastResponse = 'Pressed "Cancel"' },
+				},
+				{
 					label: 'Ok',
 					type: 'primary',
 					icon: IconCheck,
 					callback: () => { this.lastResponse = 'Pressed "Ok"' },
-				},
-				{
-					label: 'Cancel',
-					icon: IconCancel,
-					callback: () => { this.lastResponse = 'Pressed "Cancel"' },
 				}
 			]
 		}
@@ -106,7 +106,9 @@ export default {
 				<!-- Main dialog content -->
 				<div class="dialog__content" :class="contentClasses">
 					<slot>
-						<p>{{ message }}</p>
+						<p class="dialog__text">
+							{{ message }}
+						</p>
 					</slot>
 				</div>
 			</div>
@@ -440,6 +442,12 @@ export default defineComponent({
 		flex: 1;
 		min-height: 0;
 		overflow: auto;
+	}
+
+	// In case only text content is show
+	&__text {
+		// Also add padding to the bottom to make it more readable
+		padding-block-end: 6px;
 	}
 
 	&__actions {


### PR DESCRIPTION
### ☑️ Resolves

On the OCDialogs.confirm and everywhere else we use
left: secondary action
right: primary action

So I adjusted the example for this.

And also add slightly more padding on the bottom in case there is only text shown, so that the padding on the left / right and bottom is the same.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2023-11-28 at 21-19-50 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/35eac328-3234-43e0-b898-53cc30f89bea)|![Screenshot 2023-11-28 at 21-19-24 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/76993d33-6551-4317-9876-d4b8e01a0b0d)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
