### PR TITLE
fix(NcCheckboxRadioSwitch): visually hidden input position

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -609,6 +609,7 @@ export default {
 	font-size: var(--default-font-size);
 	line-height: var(--default-line-height);
 	padding: 0;
+	position: relative;
 
 	&__input {
 		position: absolute;


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/4802

`<input>` in `<NcCheckboxRadioSwitch>` is visually hidden with `position: absolute`.

But when it is used in a scrollable container in another `position: relative` container, positioning is broken and is not relative to the `<NcCheckboxRadioSwitch>` position.

As a result:
- It doesn't work for accessibility having the wrong position
- Click on the input puts focus on it and scroll the container to the wrong position

### 🚧 Tasks

- [x] Add `position: relative` to the checkbox radio switch container to position input relative to the switch.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
