### PR TITLE
fix(NcAppNavigationCaption): Make color `main-text` for accessibility

### DIFF
--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -1,17 +1,19 @@
 <docs>
 ```vue
 	<template>
-		<NcAppNavigationCaption
-			name="Your caption goes here">
-			<template #actions>
-				<NcActionButton>
-					<template #icon>
-						<Plus :size="20" />
-					</template>
-					This is an action
-				</NcActionButton>
-			</template>
-		</NcAppNavigationCaption>
+		<ul>
+			<NcAppNavigationCaption
+				name="Your caption goes here">
+				<template #actions>
+					<NcActionButton>
+						<template #icon>
+							<Plus :size="20" />
+						</template>
+						This is an action
+					</NcActionButton>
+				</template>
+			</NcAppNavigationCaption>
+		</ul>
 	</template>
 	<script>
 	import Plus from 'vue-material-design-icons/Plus'
@@ -22,43 +24,51 @@
 		},
 	}
 	</script>
+	<style scoped>
+		/* mock the appnavigation */
+		ul {
+			background-color: #cce6f4;
+		}
+	</style>
 ```
 
 ### Element with a slot for custom actions icon
 ```vue
 	<template>
-		<NcAppNavigationCaption
-			name="Your caption goes here">
-			<template #actionsTriggerIcon>
-				<Plus slot="icon" :size="20" />
-			</template>
-			<template #actions>
-				<NcActionButton>
-					<template #icon>
-						<Pencil :size="20" />
-					</template>
-					Rename
-				</NcActionButton>
-				<NcActionButton>
-					<template #icon>
-						<Delete :size="20" />
-					</template>
-					Delete
-				</NcActionButton>
-				<NcActionButton>
-					<template #icon>
-						<ArrowRight :size="20" />
-					</template>
-					Validate
-				</NcActionButton>
-				<NcActionButton>
-					<template #icon>
-						<Download :size="20" />
-					</template>
-					Download
-				</NcActionButton>
-			</template>
-		</NcAppNavigationCaption>
+		<ul>
+			<NcAppNavigationCaption
+				name="Your caption goes here">
+				<template #actionsTriggerIcon>
+					<Plus slot="icon" :size="20" />
+				</template>
+				<template #actions>
+					<NcActionButton>
+						<template #icon>
+							<Pencil :size="20" />
+						</template>
+						Rename
+					</NcActionButton>
+					<NcActionButton>
+						<template #icon>
+							<Delete :size="20" />
+						</template>
+						Delete
+					</NcActionButton>
+					<NcActionButton>
+						<template #icon>
+							<ArrowRight :size="20" />
+						</template>
+						Validate
+					</NcActionButton>
+					<NcActionButton>
+						<template #icon>
+							<Download :size="20" />
+						</template>
+						Download
+					</NcActionButton>
+				</template>
+			</NcAppNavigationCaption>
+		</ul>
 	</template>
 	<script>
 		import ArrowRight from 'vue-material-design-icons/ArrowRight'
@@ -77,6 +87,12 @@
 			}
 		}
 	</script>
+	<style scoped>
+		/* mock the appnavigation */
+		ul {
+			background-color: #cce6f4;
+		}
+	</style>
 ```
 
 </docs>
@@ -146,13 +162,12 @@ export default {
 
 	&__name {
 		font-weight: bold;
-		color: var(--color-primary-element);
+		color: var(--color-main-text);
 		font-size: var(--default-font-size);
 		line-height: $clickable-area;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		opacity: $opacity_normal;
 		box-shadow: none !important;
 		flex-shrink: 0;
 		// padding to align the name with the icon of app navigation items


### PR DESCRIPTION
### ☑️ Resolves

Currently the text is not readable, especially on dark mode. So lets move to main text color instead.
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/722c9ebb-6867-47bf-b186-66df386c79ef)


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2023-11-29 at 15-58-25 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/75bda284-4c97-417a-8c11-6fc800f5150e)|![Screenshot 2023-11-29 at 15-56-55 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/22c87348-ce0e-498b-8fd3-47040c0143f0)
![Screenshot 2023-11-29 at 15-59-45 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/28af2994-4487-47ba-9632-d3a35f2f2676)|![Screenshot 2023-11-29 at 16-00-47 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/ea58461f-e4f2-441f-b138-14bd9c881e63)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
