### PR TITLE
chore(lint): use valid JSDoc for literal type union

### DIFF
--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -182,7 +182,7 @@ export default defineComponent({
 		/**
 		 * Size of the underlying NcModal
 		 * @default 'small'
-		 * @values 'small', 'normal', 'large', 'full'
+		 * @type {'small'|'normal'|'large'|'full'}
 		 */
 		size: {
 			type: String,

--- a/src/components/NcDialogButton/NcDialogButton.vue
+++ b/src/components/NcDialogButton/NcDialogButton.vue
@@ -78,7 +78,7 @@ export default defineComponent({
 
 		/**
 		 * The button type, see NcButton
-		 * @values 'primary', 'secondary', 'error', 'warning', 'success'
+		 * @type {'primary'|'secondary'|'error'|'warning'|'success'}
 		 */
 		type: {
 			type: String,


### PR DESCRIPTION
`@values` is not valid in JSDoc by out ESLint rules.

`@type` with literal type union works in the `styleguidist` as well