### PR TITLE
fix(NcActions): typo in aria-haspopup

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1381,7 +1381,7 @@ export default {
 						slot: 'trigger',
 						ref: 'menuButton',
 						attrs: {
-							'aria-haspopup': this.isSemanticMenu ? null : 'menu',
+							'aria-haspopup': this.isSemanticMenu ? 'menu' : null,
 							'aria-label': this.menuName ? null : this.ariaLabel,
 							'aria-controls': this.opened ? this.randomId : null,
 							// Do not add aria-expanded="true" when it is closed


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/41890
* Fix https://github.com/nextcloud/server/issues/41889
* Fix https://github.com/nextcloud/server/issues/41906
* Fix https://github.com/nextcloud/server/issues/41888

There was a typo, then/else is misplaced in a ternary operator.