### PR TITLE
fix(NcAppNavigation): replace custom `v-tooltip` with native `title`

### DIFF
--- a/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
+++ b/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
@@ -22,11 +22,11 @@
  -
  -->
 <template>
-	<NcButton v-tooltip.auto="label"
-		class="app-navigation-toggle"
+	<NcButton class="app-navigation-toggle"
 		type="tertiary"
 		:aria-expanded="open ? 'true' : 'false'"
 		:aria-label="label"
+		:title="label"
 		aria-controls="app-navigation-vue"
 		@click="toggleNavigation">
 		<template #icon>
@@ -38,7 +38,6 @@
 
 <script>
 import NcButton from '../NcButton/index.js'
-import Tooltip from '../../directives/Tooltip/index.js'
 import { t } from '../../l10n.js'
 
 import MenuIcon from 'vue-material-design-icons/Menu.vue'
@@ -46,10 +45,6 @@ import MenuOpenIcon from 'vue-material-design-icons/MenuOpen.vue'
 
 export default {
 	name: 'NcAppNavigationToggle',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	components: {
 		NcButton,


### PR DESCRIPTION
### ☑️ Resolves

* Continues: https://github.com/nextcloud-libraries/nextcloud-vue/issues/2503
* Fix https://github.com/nextcloud/server/issues/41862

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/54d34929-d4d9-4632-a056-0f01339666eb) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/c903f566-dc14-400e-abaf-879b3fe26a40)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
