### PR TITLE
enh(NcCheckboxRadioSwitch): Allow to set `aria-label`

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -260,6 +260,7 @@ export default {
 <template>
 	<component :is="computedWrapperElement"
 		:id="wrapperId"
+		:aria-label="isButtonType && ariaLabel ? ariaLabel : undefined"
 		:class="{
 			['checkbox-radio-switch-' + type]: type,
 			'checkbox-radio-switch--checked': isChecked,
@@ -276,6 +277,7 @@ export default {
 		v-on="isButtonType ? listeners : null">
 		<input v-if="!isButtonType"
 			:id="id"
+			:aria-label="ariaLabel || undefined"
 			class="checkbox-radio-switch__input"
 			:disabled="disabled"
 			:type="inputType"
@@ -342,6 +344,15 @@ export default {
 		name: {
 			type: String,
 			default: null,
+		},
+
+		/**
+		 * Required if no text is set.
+		 * The aria-label is forwarded to the input or button.
+		 */
+		ariaLabel: {
+			type: String,
+			default: '',
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

If no text should be shown currently you have to provide the label as a `span` with `hidden-visually`, because the `aria-label` would not be forwarded correctly.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
