### PR TITLE
fix(NcListItem): Add focus-visible outline state

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -754,6 +754,11 @@ export default {
 		background-color: var(--color-background-hover);
 	}
 
+	&:focus-visible {
+		outline: 2px solid var(--color-main-text);
+		border: 2px solid var(--color-main-background);
+	}
+
 	&-content__wrapper {
 		display: flex;
 		align-items: center;

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -708,6 +708,7 @@ export default {
 .list-item__wrapper {
 	position: relative;
 	width: 100%;
+	padding: 2px; // for inner focus-visible outline
 
 	&--active,
 	&:active,
@@ -738,11 +739,11 @@ export default {
 	position: relative;
 	flex: 0 0 auto;
 	justify-content: flex-start;
-	padding: 8px 10px;
+	padding: 6px 8px;
 	// Fix for border-radius being too large for 3-line entries like in Mail
 	// 44px avatar size / 2 + 8px padding, and 2px for better visual quality
 	border-radius: 32px;
-	margin: 2px 0;
+	border: 2px solid transparent; // to prevent resizing on focus-visible
 	width: 100%;
 	cursor: pointer;
 	transition: background-color var(--animation-quick) ease-in-out;
@@ -755,8 +756,8 @@ export default {
 	}
 
 	&:focus-visible {
+		border: 2px solid var(--color-main-background); // to also add contrast on active state
 		outline: 2px solid var(--color-main-text);
-		border: 2px solid var(--color-main-background);
 	}
 
 	&-content__wrapper {


### PR DESCRIPTION
### ☑️ Resolves

Add a focus-visible outline as the default one is not accessible (too low contrast).

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2023-12-01 at 17-50-47 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/4dd96329-fc6d-4330-a096-e993144d8269)|![Screenshot 2023-12-01 at 17-51-23 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/e4ea1167-2ca5-4e12-89e6-bcb139677346)
![Screenshot 2023-12-01 at 17-50-27 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/e139da09-f3c1-4271-bc70-53be87f1da66)|![Screenshot 2023-12-01 at 17-51-51 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/76bdcbe9-88a4-4529-b44d-2c0c1fa1ade1)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
