### PR TITLE
fix(NcAppSidebar): add focus trap on mobile

### DIFF
--- a/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
+++ b/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
@@ -22,18 +22,20 @@
  -
  -->
 <template>
-	<NcButton class="app-navigation-toggle"
-		type="tertiary"
-		:aria-expanded="open ? 'true' : 'false'"
-		:aria-label="label"
-		:title="label"
-		aria-controls="app-navigation-vue"
-		@click="toggleNavigation">
-		<template #icon>
-			<MenuOpenIcon v-if="open" :size="20" />
-			<MenuIcon v-else :size="20" />
-		</template>
-	</NcButton>
+	<div class="app-navigation-toggle-wrapper">
+		<NcButton class="app-navigation-toggle"
+			type="tertiary"
+			:aria-expanded="open ? 'true' : 'false'"
+			:aria-label="label"
+			:title="label"
+			aria-controls="app-navigation-vue"
+			@click="toggleNavigation">
+			<template #icon>
+				<MenuOpenIcon v-if="open" :size="20" />
+				<MenuIcon v-else :size="20" />
+			</template>
+		</NcButton>
+	</div>
 </template>
 
 <script>
@@ -75,11 +77,14 @@ export default {
 </script>
 
 <style scoped lang="scss">
-button.app-navigation-toggle {
+.app-navigation-toggle-wrapper {
 	position: absolute;
 	top: var(--app-navigation-padding);
 	right: calc(0px - var(--app-navigation-padding));
 	margin-right: - $clickable-area;
+}
+
+button.app-navigation-toggle {
 	background-color: var(--color-main-background);
 }
 </style>

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -345,7 +345,10 @@ export default {
 		@after-enter="onAfterEnter"
 		@before-leave="onBeforeLeave"
 		@after-leave="onAfterLeave">
-		<aside id="app-sidebar-vue" ref="sidebar" class="app-sidebar">
+		<aside id="app-sidebar-vue"
+			ref="sidebar"
+			class="app-sidebar"
+			@keydown.esc.stop="isMobile && closeSidebar()">
 			<header :class="{
 					'app-sidebar-header--with-figure': hasFigure,
 					'app-sidebar-header--compact': compact,

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -704,6 +704,9 @@ export default {
 				this.$refs.sidebar,
 				// Nextcloud Server header navigarion
 				document.querySelector('#header'),
+				// The app navigation toggle. Navigation can be opened above the sidebar
+				// Take the parent element, because the focus-trap requires a container with elements, not the element itself
+				document.querySelector('[aria-controls="app-navigation-vue"]')?.parentElement,
 			], {
 				allowOutsideClick: true,
 				fallbackFocus: this.$refs.closeButton,


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/41839

On mobile view, the sidebar is full-screen. But it doesn't have a focus trap. So the focus may fall into the main content below the sidebar.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Focus is lost on the main content | It's a trap
![sidebar-before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/bf0cc378-7143-4106-a98b-088b2114bc9c) | ![sidebar-after](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a712dcc6-f749-42c0-a045-05da9ffe84a8)

### 🚧 Tasks

- [x] Add a focus trap on mobile
- [x] Add a header to the trap as it is fully visible

### For discussion

- [ ] Add a navigation toggle button to the trap so a user can open navigation above the focus trap
  - [ ] Alternative — hide toggle navigation button on mobile
- [ ] Close the sidebar by <kbd>ESC</kbd> on mobile

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
