### PR TITLE
Enh/Make name longer when actions menu isn't visible

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -815,6 +815,10 @@ export default {
 		.app-navigation-entry__children {
 			background-color: var(--color-main-background);
 		}
+
+		.app-navigation-entry__utils {
+			display: flex;
+		}
 	}
 
 	// Show the actions on active
@@ -915,7 +919,7 @@ export default {
 
 /* counter and actions */
 .app-navigation-entry__utils {
-	display: flex;
+   	display: none;
 	min-width: $clickable-area;
 	align-items: center;
 	flex: 0 1 auto;

--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -919,7 +919,7 @@ export default {
 
 /* counter and actions */
 .app-navigation-entry__utils {
-   	display: none;
+   	display: flex;
 	min-width: $clickable-area;
 	align-items: center;
 	flex: 0 1 auto;


### PR DESCRIPTION
Make name longer when actions menu isn't visible by not displaying `app-navigation-entry__utils` when not needed

Useful for https://github.com/nextcloud/mail/issues/7171

### ☑️ Resolves

* Fix https://github.com/nextcloud/mail/issues/7171

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/76647797/43883c11-afab-432b-8e01-a11f8f79ff7d) |  ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/76647797/46a9da4f-c293-4e0e-9501-7af5e796e045)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
