### PR TITLE
Add target prop for NcListItem

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -316,7 +316,7 @@
 			<a :id="anchorId"
 				ref="list-item"
 				:href="routerLinkHref || href"
-				:target="href === '#' ? undefined : '_blank'"
+				:target="target || (href === '#' ? undefined : '_blank')"
 				:rel="href === '#' ? undefined : 'noopener noreferrer'"
 				class="list-item"
 				:aria-label="linkAriaLabel"
@@ -470,6 +470,11 @@ export default {
 			default: '#',
 		},
 
+		target: {
+			type: String,
+			default: '',
+		},
+
 		/**
 		 * Id for the `<a>` element
 		 */
@@ -585,7 +590,6 @@ export default {
 		computedActionsAriaLabel() {
 			return this.actionsAriaLabel || t('Actions for item with name "{name}"', { name: this.name })
 		},
-
 	},
 
 	watch: {


### PR DESCRIPTION
The component user should have full control over what tab they want the link to open in, if any.

### ☑️ Resolves

* Fixes : https://github.com/nextcloud-libraries/nextcloud-vue/issues/4880

### 🚧 Tasks

- [x]  Update one know use-case at https://github.com/nextcloud/server/issues/41800

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
