### PR TITLE
feat(NcRichContenteditable): put caret in the end when focus input

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -232,6 +232,7 @@ export default {
 			role="textbox"
 			v-bind="$attrs"
 			v-on="listeners"
+			@focus="moveCursorToEnd"
 			@input="onInput"
 			@compositionstart="isComposing = true"
 			@compositionend="isComposing = false"
@@ -645,6 +646,17 @@ export default {
 			const range = document.createRange()
 			range.setEndAfter(element)
 			range.collapse()
+			const selection = window.getSelection()
+			selection.removeAllRanges()
+			selection.addRange(range)
+		},
+		moveCursorToEnd() {
+			if (!document.createRange) {
+				return
+			}
+			const range = document.createRange()
+			range.selectNodeContents(this.$refs.contenteditable)
+			range.collapse(false)
 			const selection = window.getSelection()
 			selection.removeAllRanges()
 			selection.addRange(range)


### PR DESCRIPTION
### ☑️ Resolves

* Put caret to the end of inputted text when focus it, instead of start

### 🖼️ Screenshots

Casted some tests (with mouse clicks, range selections, keyboard tabbing)

[Screencast - focus tests](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/88b89afe-b91c-4aeb-aa7b-29a144155bc3)


### 🚧 Tasks

- [ ] Manual tests:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
- [ ] TODO
  - [ ] Check if code could be reused:

https://github.com/nextcloud-libraries/nextcloud-vue/blob/9dcd33b3810293a23e9dd964d60814f97639c8e2/src/components/NcRichContenteditable/NcRichContenteditable.vue#L700-L705

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable