### PR TITLE
fix(NcAppNavigationSettings): remove incorrect aria-label

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -180,9 +180,6 @@ msgstr ""
 msgid "Open navigation"
 msgstr ""
 
-msgid "Open settings menu"
-msgstr ""
-
 msgid "Password is secure"
 msgstr ""
 

--- a/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
+++ b/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
@@ -29,17 +29,16 @@
 				type="button"
 				:aria-expanded="open ? 'true' : 'false'"
 				aria-controls="app-settings__content"
-				:aria-label="ariaLabel"
 				@click="toggleMenu">
 				<Cog class="settings-button__icon" :size="20" />
 				<span class="settings-button__label">{{ name }}</span>
 			</button>
 		</div>
-		<transition name="slide-up">
+		<Transition name="slide-up">
 			<div v-show="open" id="app-settings__content">
 				<slot />
 			</div>
-		</transition>
+		</Transition>
 	</div>
 </template>
 
@@ -79,9 +78,6 @@ export default {
 				this.closeMenu,
 				this.clickOutsideOptions,
 			]
-		},
-		ariaLabel() {
-			return t('Open settings menu')
 		},
 	},
 	methods: {


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/server/issues/41901
- This button has a label already from its text content
- It should not have a different `aria-label`
- "Open" action is covered by `aria-expanded`

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/97b34cba-b08e-4f06-818e-967f2b9b85b1)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
