### PR TITLE
fix(NcActions): provide `aria-expanded="false"` when menu is closed instead of removing it

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1384,8 +1384,7 @@ export default {
 							'aria-haspopup': this.isSemanticMenu ? 'menu' : null,
 							'aria-label': this.menuName ? null : this.ariaLabel,
 							'aria-controls': this.opened ? this.randomId : null,
-							// Do not add aria-expanded="true" when it is closed
-							'aria-expanded': this.opened ? 'true' : undefined,
+							'aria-expanded': this.opened ? 'true' : 'false',
 						},
 						on: {
 							focus: this.onFocus,


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/41897

Example on [w3c patterns](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/examples/menu-button-actions/) says "The aria-expanded attribute is removed when the menu is closed.".

However there is an ongoing discussion about it.
For example, PR 2829 on https://github.com/w3c/aria-practices/pull/. Or another example https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/

So actually it is recommended to add `aria-expanded="false"`, not remove the attribute.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
