### PR TITLE
fix(package): specify exports for composables

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
     "./dist/Mixins/*.js": {
       "import": "./dist/Mixins/*.mjs",
       "require": "./dist/Mixins/*.cjs"
+    },
+    "./dist/Composables/*.js": {
+      "import": "./dist/Composables/*.mjs",
+      "require": "./dist/Composables/*.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
### ☑️ Resolves

* See: https://github.com/nextcloud/spreed/issues/10927
