### PR TITLE
fix(NcListItem): Ensure list item does not overflow wrapper

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -738,6 +738,7 @@ export default {
 
 // NcListItem
 .list-item {
+	box-sizing: border-box;
 	display: block;
 	position: relative;
 	flex: 0 0 auto;


### PR DESCRIPTION
### ☑️ Resolves

`width` is set to 100% but if `box-sizing` is not set to `border-box` it will not include the border and the padding.
This causes the list item to overflow its parents in some cases, you can for example see this in the new unified search of Nextcloud 28 (there are even more places).

To fix this simply set `box-sizing` to `border-box` of the list item.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screen Shot 2023-12-13 at 15 09 51](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/27c581de-2bf1-40ef-89e2-6f24f439ec47)|![Screenshot 2023-12-13 at 15-09-32 Dashboard - Nextcloud](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/3502bc46-8454-4123-954a-264e1f218470)



### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
