### PR TITLE
enh(aria): changed check color to adhere to 3:1 ratio

### DIFF
--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -173,7 +173,7 @@ export default {
 						:style="{ backgroundColor: color }"
 						class="color-picker__simple-color-circle"
 						:class="{ 'color-picker__simple-color-circle--active' : color === currentColor }">
-						<Check v-if="color === currentColor" :size="20" />
+						<Check v-if="color === currentColor" :size="20" :fill-color="contrastColor" />
 						<input type="radio"
 							class="hidden-visually"
 							:aria-label="name"
@@ -323,6 +323,11 @@ export default {
 		uid() {
 			return GenRandomId()
 		},
+		contrastColor() {
+			const black = '#000000'
+			const white = '#FFFFFF'
+			return (this.calculateLuma(this.currentColor) > 0.5) ? black : white
+		},
 	},
 
 	watch: {
@@ -385,6 +390,28 @@ export default {
 			 */
 			this.$emit('input', color)
 
+		},
+
+		/**
+		 * Calculate luminance of provided hex color
+		 *
+		 * @param {string} color the hex color
+		 */
+		 calculateLuma(color) {
+			const [red, green, blue] = this.hexToRGB(color)
+			return (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255
+		},
+
+		/**
+		 * Convert hex color to RGB
+		 *
+		 * @param {string} hex the hex color
+		 */
+		 hexToRGB(hex) {
+			const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+			return result
+				? [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16)]
+				: null
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves nextcloud/server#41861

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/c82b877e-7ed6-416f-bdd1-d5754f3460a1) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/a0eca23c-48e6-4e61-acd5-dbda862f8482)

### 🚧 Summary
Changes the check color depending on the background color chosen to either be white or black to achieve the 3:1 contrast ratio for ARIA - radio input button still has white border, so up to reviewers to decide if that should change

### 🏁 Checklist

- [X] ⛑️ Tests are included or are not applicable (N/A)
- [X] 📘 Component documentation has been extended, updated or is not applicable (N/A)
