### PR TITLE
fix(NcAppNavigation): Bring back hover state for active element

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -29,6 +29,10 @@
 	&.active {
 		background-color: var(--color-primary-element) !important;
 
+		&:hover {
+			background-color: var(--color-primary-element-hover) !important;
+		}
+
 		// overwrite active text color
 		.app-navigation-entry-link, .app-navigation-entry-button {
 			color: var(--color-primary-element-text) !important;


### PR DESCRIPTION
### ☑️ Resolves

Bring back the hover state for active app navigation elements.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
