### PR TITLE
Use logical style for NcHeaderMenu

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -351,7 +351,7 @@ $externalMargin: 8px;
 		position: fixed;
 		z-index: 2000;
 		top: 50px;
-		right: 0;
+		inset-inline-end: 0;
 		box-sizing: border-box;
 		margin: 0 $externalMargin;
 		padding: 8px;
@@ -366,7 +366,7 @@ $externalMargin: 8px;
 		position: absolute;
 		z-index: 2001; // Because __wrapper is 2000.
 		bottom: 0;
-		left: calc(50% - 10px);
+		inset-inline-start: calc(50% - 10px);
 		width: 0;
 		height: 0;
 		content: ' ';


### PR DESCRIPTION
### ☑️ Resolves

The current styles used in NcHeaderMenu makes it hard to make NextCloud work fine in RTL mode automatically. In order to be able to add bidirectional text support to NextCloud (server), we need to use logical styles here, so the if the layout of the dashboard is RTL, the menu automatically moved to the right.

These changes shouldn't have any visible impact in the current state of NextCloud server. To test the impact, manually set the body to use `dir="RTL"`.

There will be another PR on NextCloud server. It will depend on this PR to get merged. It will be linked to this PR as soon as it is opened.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/11241315/8c507092-9f1a-4aeb-ad45-39e850ae33a6) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/11241315/83e6118a-f2e6-47de-8938-5491fdc20a8d)


### 🚧 Tasks

Nothing remained

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
