### PR TITLE
Equalize `TextArea` styles with `TextField` styles

### DIFF
--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -365,12 +365,6 @@ export default {
 			&:focus-visible {
 				box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px
 			}
-
-			// Align label text color with border color (on hover / focus)
-			&:focus + .textarea__label,
-			&:hover:not(:placeholder-shown) + .textarea__label {
-				color: var(--color-success-text);
-			}
 		}
 
 		&--error {
@@ -378,31 +372,14 @@ export default {
 			&:focus-visible {
 				box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px
 			}
-
-			// Align label text color with border color (on hover / focus)
-			&:focus + .textarea__label,
-			&:hover:not(:placeholder-shown) + .textarea__label {
-				color: var(--color-error-text);
-			}
-		}
-
-		// Align label text color with border color (on hover / focus)
-		&:not(&--success, &--error) {
-			&:focus + .textarea__label,
-			&:hover:not(:placeholder-shown) + .textarea__label {
-				color: var(--color-primary-element);
-			}
 		}
 	}
 
 	&__label {
 		position: absolute;
 		margin-inline: 12px 0;
-		// fix height and line height to center label
-		height: 17px;
 		max-width: fit-content;
-		line-height: 1;
-		inset-block-start: 12px;
+		inset-block-start: 11px;
 		inset-inline: 0;
 		// Fix color so that users do not think the input already has content
 		color: var(--color-text-maxcontrast);
@@ -418,10 +395,11 @@ export default {
 
 	&__input:focus + &__label,
 	&__input:not(:placeholder-shown) + &__label {
-		inset-block-start: -6px;
+		inset-block-start: -10px;
 		font-size: 13px; // minimum allowed font size for accessibility
+		font-weight: 500;
+		color: var(--color-main-text);
 		background-color: var(--color-main-background);
-		height: 14px;
 		padding-inline: 4px;
 		margin-inline-start: 8px;
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/42243
* Relied on https://github.com/nextcloud-libraries/nextcloud-vue/pull/4718

### 🖼️ Screenshots

|  Before   | After                                                        |
|-------------|---------------------------------------------------------------|
| ![Screenshot from 2023-12-18 16-44-20](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/aa62d617-078f-450e-bc36-4620e033bec3) | ![Screenshot from 2023-12-18 16-25-40](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/98591f26-00fa-48d0-adac-fbb0fd105de1) |-------------|---------------------------------------------------------------|
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/c4c2d6f9-5fbe-4c67-aa83-dd9304fb476e) | ![Screenshot from 2023-12-18 16-25-26](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/641352cd-cf77-4da3-a8af-075e20f2a1cd) |-------------|---------------------------------------------------------------|
|  | ![Screenshot from 2023-12-18 16-24-50](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/8b01e4e7-6191-48bd-8679-91f57f31546f)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
