### PR TITLE
enh(NcAppNavigationSettings): added aria label prop

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -208,6 +208,9 @@ msgstr ""
 msgid "Open navigation"
 msgstr ""
 
+msgid "Open settings menu"
+msgstr ""
+
 msgid "Password is secure"
 msgstr ""
 

--- a/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
+++ b/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
@@ -29,6 +29,7 @@
 				type="button"
 				:aria-expanded="open ? 'true' : 'false'"
 				aria-controls="app-settings__content"
+				:aria-label="inputAriaLabel"
 				@click="toggleMenu">
 				<Cog class="settings-button__icon" :size="20" />
 				<span class="settings-button__label">{{ name }}</span>
@@ -66,6 +67,11 @@ export default {
 			required: false,
 			default: t('Settings'),
 		},
+		inputAriaLabel: {
+			type: String,
+			required: false,
+			default: t('Open settings menu'),
+		}
 	},
 	data() {
 		return {


### PR DESCRIPTION
### ☑️ This is part of a change for nextcloud/server#42235 - with a chained PR referenced in the comments!

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/3a43f589-dd30-4ed6-822b-85848c2879d2) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/c38cd4ab-df2f-4d23-83b1-af2c2ee6aceb)



### 🚧 Tasks / Summary
Added a prop (with a default value) so that we have better control for aria labels within the NcAppNavigationSetting component

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable (Not Applicable)
- [ ] 📘 Component documentation has been extended, updated or is not applicable (Updating / Updated)
