### PR TITLE
enh(breadcrumbs): changed aria label for voice control on a-tag

### DIFF
--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -42,6 +42,7 @@ This component is meant to be used inside a Breadcrumbs component.
 		<component :is="tag"
 			v-if="(name || icon) && !$slots.default"
 			:title="title"
+			:aria-label="icon ? name : undefined"
 			v-bind="linkAttributes"
 			v-on="$listeners">
 			<!-- @slot Slot for passing a material design icon. Precedes the icon and name prop. -->


### PR DESCRIPTION
### ☑️ Resolves nextcloud/server#42265

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/573955d1-943f-4d0c-a34a-2d2328f0f7b1) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/b4630ad2-8040-4f9c-b511-e5c4b922770d)



### 🚧 Tasks
Changed components aria label to better represent the content of the span for screen readers

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable (not applicable)
- [x] 📘 Component documentation has been extended, updated or is not applicable (not applicable)
