### PR TITLE
Increase contrast on input field for `NcRichContenteditable`

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -890,7 +890,7 @@ export default {
 		white-space: pre-wrap;
 		word-break: break-word;
 		color: var(--color-main-text);
-		border: 2px solid var(--color-border-dark);
+		border: 2px solid var(--color-border-maxcontrast);
 		border-radius: var(--border-radius-large);
 		outline: none;
 		background-color: var(--color-main-background);


### PR DESCRIPTION
### ☑️ Resolves

* For https://github.com/nextcloud/server/issues/41879
    - [ ] Input filed have to be discoverable (increase a border color)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-12-19 11-10-44](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/87d01198-43fb-450e-81bb-4a016a223cbe) | ![Screenshot from 2023-12-19 11-08-39](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/79bfbf7e-6c31-4cc5-aa42-214bf3318170)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
