### PR TITLE
Differentiate between dark and light theme for NcDateTimePickerNative

### DIFF
--- a/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
+++ b/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
@@ -385,4 +385,18 @@ export default {
 		flex: 0 0 auto;
 		padding-right: 4px;
 	}
+
+	[data-theme-light],
+	[data-themes*=light] {
+		.native-datetime-picker--input {
+			color-scheme: light;
+		}
+	}
+
+	[data-theme-dark],
+	[data-themes*=dark] {
+		.native-datetime-picker--input {
+			color-scheme: dark;
+		}
+	}
 </style>


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/42392

### 🖼️ Screenshots

No changes for the light theme.
![Screenshot from 2023-12-20 13-25-23](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/5f377e7a-c0a7-4b4e-8699-dc584f9ee547)


🏚️ Before | 🏡 After
---|---
![Screenshot from 2023-12-20 10-58-33](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/16da51c4-180e-4235-af58-a472bf7e7aea) | ![Screenshot from 2023-12-20 11-00-10](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/ed7c3937-c276-4b12-a7b0-69d537dbc9a0)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
