### PR TITLE
[next] fix: unify `modelValue` naming

### DIFF
--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -28,17 +28,17 @@ All undocumented attributes will be bound to the textarea. e.g. `maxlength`
 ```
 <template>
 	<NcActions>
-		<NcActionTextEditable value="This is a textarea">
+		<NcActionTextEditable model-value="This is a textarea">
 			<template #icon>
 				<Pencil :size="20" />
 			</template>
 		</NcActionTextEditable>
-		<NcActionTextEditable :disabled="true" value="This is a disabled textarea">
+		<NcActionTextEditable :disabled="true" model-value="This is a disabled textarea">
 			<template #icon>
 				<Pencil :size="20" />
 			</template>
 		</NcActionTextEditable>
-		<NcActionTextEditable name="Please edit the text" value="This is a textarea with name">
+		<NcActionTextEditable name="Please edit the text" model-value="This is a textarea with name">
 			<template #icon>
 				<Pencil :size="20" />
 			</template>
@@ -84,7 +84,7 @@ export default {
 
 				<textarea :id="computedId"
 					:disabled="disabled"
-					:value="value"
+					:value="modelValue"
 					v-bind="$attrs"
 					:class="['action-text-editable__textarea', { focusable: isFocusable }]"
 					@input="onInput" />
@@ -133,7 +133,7 @@ export default {
 		/**
 		 * value attribute of the input field
 		 */
-		value: {
+		modelValue: {
 			type: String,
 			default: '',
 		},
@@ -141,7 +141,7 @@ export default {
 
 	emits: [
 		'input',
-		'update:value',
+		'update:modelValue',
 		'submit',
 	],
 
@@ -173,7 +173,7 @@ export default {
 			 *
 			 * @type {string|Date}
 			 */
-			this.$emit('update:value', event.target.value)
+			this.$emit('update:modelValue', event.target.value)
 		},
 		onSubmit(event) {
 			event.preventDefault()

--- a/src/components/NcAppNavigationItem/NcInputConfirmCancel.vue
+++ b/src/components/NcAppNavigationItem/NcInputConfirmCancel.vue
@@ -88,16 +88,16 @@ export default {
 			type: String,
 		},
 
-		value: {
+		modelValue: {
 			default: '',
 			type: String,
 		},
 	},
 
 	emits: [
-		'input',
-		'confirm',
 		'cancel',
+		'confirm',
+		'update:modelValue',
 	],
 
 	data() {
@@ -109,9 +109,9 @@ export default {
 
 	computed: {
 		valueModel: {
-			get() { return this.value },
+			get() { return this.modelValue },
 			set(newValue) {
-				this.$emit('input', newValue)
+				this.$emit('update:modelValue', newValue)
 			},
 		},
 	},

--- a/src/components/NcSettingsInputText/NcSettingsInputText.vue
+++ b/src/components/NcSettingsInputText/NcSettingsInputText.vue
@@ -24,7 +24,7 @@
 
 ```vue
 <NcSettingsInputText label="Label" hint="Hint" />
-<NcSettingsInputText label="Label" value="Value" hint="Hint" disabled />
+<NcSettingsInputText label="Label" model-value="Value" hint="Hint" disabled />
 ```
 
 </docs>
@@ -37,7 +37,7 @@
 			<label :for="id" class="action-input__label">{{ label }}</label>
 			<input :id="id"
 				type="text"
-				:value="value"
+				:value="modelValue"
 				:disabled="disabled"
 				@input="onInput"
 				@change="onChange">
@@ -78,7 +78,7 @@ export default {
 		/**
 		 * value of the select group input
 		 */
-		value: {
+		modelValue: {
 			type: String,
 			default: '',
 		},
@@ -102,10 +102,10 @@ export default {
 	},
 
 	emits: [
-		'update:value',
+		'change',
 		'input',
 		'submit',
-		'change',
+		'update:modelValue',
 	],
 
 	data() {
@@ -130,7 +130,7 @@ export default {
 			 *
 			 * @type {string}
 			 */
-			this.$emit('update:value', event.target.value)
+			this.$emit('update:modelValue', event.target.value)
 		},
 		onSubmit(event) {
 			if (!this.disabled) {

--- a/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
+++ b/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
@@ -191,7 +191,7 @@ export default {
 		/**
 		 * If the value is changed, check that all groups are loaded so we show the correct display name
 		 */
-		value: {
+		modelValue: {
 			handler() {
 				const loadedGroupIds = Object.keys(this.groups)
 				const missing = this.filteredValue.filter(group => !loadedGroupIds.includes(group))


### PR DESCRIPTION
### ☑️ Resolves

* This unifies the usage of `value / modelValue`. Every `value` prop got renamed to `modelValue` to align with the new usage by vue 3. For some components we did this already, so here I migrated the rest to have it consistent.