### PR TITLE
fix(NcCheckboxRadioSwitch): use correct padding

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -30,6 +30,7 @@
 		:class="{
 			['checkbox-content-' + type]: true,
 			'checkbox-content--button-variant': buttonVariant,
+			'checkbox-content--has-text': !!$slots.default,
 		}">
 		<span :class="{
 				'checkbox-content__icon': true,
@@ -212,7 +213,7 @@ export default {
 	user-select: none;
 	min-height: $clickable-area;
 	border-radius: $clickable-area;
-	padding: 4px $icon-margin;
+	padding: 4px calc(($clickable-area - var(--icon-height)) / 2);
 	// Set to 100% to make text overflow work on button style
 	width: 100%;
 	// but restrict to content so plain checkboxes / radio switches do not expand
@@ -240,6 +241,10 @@ export default {
 		.checkbox-content__icon--checked > * {
 			color: var(--color-primary-element-text);
 		}
+	}
+
+	&--has-text {
+		padding-right: $icon-margin;
 	}
 
 	&:not(&--button-variant) {

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -511,6 +511,7 @@ export default {
 		cssVars() {
 			return {
 				'--icon-size': this.size + 'px',
+				'--icon-height': (this.type === TYPE_SWITCH ? 16 : this.size) + 'px',
 			}
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #5008.

This adjusts the left/right padding of the label to the correct / better value of `10px`. The value of `14px` calculated before does not work here, as the element is not an icon with a width of `16px` but a label with a width of `24px`.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2024-01-02 at 10-48-22 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/b83e4394-612b-472f-8e39-1beb6ecd7789) | ![Screenshot 2024-01-02 at 13-06-26 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/888aa563-e955-4c71-8d82-52388dcf544c)




