### PR TITLE
[next] fix(NcBreadcrumb): fix setting class on root element

### DIFF
--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -31,7 +31,7 @@ This component is meant to be used inside a Breadcrumbs component.
 <template>
 	<li ref="crumb"
 		class="vue-crumb"
-		:class="{'vue-crumb--hovered': hovering}"
+		:class="[{'vue-crumb--hovered': hovering}, $props.class]"
 		:[crumbId]="''"
 		draggable="false"
 		@dragstart.prevent="() => {/** Prevent the breadcrumb from being draggable. */}"
@@ -148,6 +148,14 @@ export default {
 		open: {
 			type: Boolean,
 			default: false,
+		},
+
+		/**
+		 * CSS class to apply to the root element.
+		 */
+		class: {
+			type: [String, Array, Object],
+			default: '',
 		},
 	},
 	emits: [


### PR DESCRIPTION
### ☑️ Resolves

* Fix setting `class` on the root element of `NcBreadcrumb`. This is necessary to correctly set the `dropdown` class for the breadcrumb containing the hidden crumbs. This fixes a visual issue with the alignment of the three-dots icon.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/6afb4c87-8964-4477-8add-00bd54f961e3) | ![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/51921e84-733f-4ddb-a2c6-126015828fa5)

