### PR TITLE
[next] fix(NcBreadcrumb): correctly emit drag events

### DIFF
--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -151,8 +151,10 @@ export default {
 		},
 	},
 	emits: [
-		'update:open',
+		'dragenter',
+		'dragleave',
 		'dropped',
+		'update:open',
 	],
 	data() {
 		return {
@@ -231,6 +233,7 @@ export default {
 		 * @param {object} e The drag enter event
 		 */
 		dragEnter(e) {
+			this.$emit('dragenter', e)
 			/**
 			 * Don't do anything if dropping is disabled.
 			 */
@@ -245,6 +248,7 @@ export default {
 		 * @param {object} e The drag leave event
 		 */
 		dragLeave(e) {
+			this.$emit('dragleave', e)
 			/**
 			 * Don't do anything if dropping is disabled.
 			 */

--- a/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
+++ b/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
@@ -547,7 +547,6 @@ export default {
 				ref: 'actionsBreadcrumb',
 				key: 'actions-breadcrumb-1',
 				// Add handlers so the Actions menu opens on hover
-				onDragstart: this.dragStart,
 				onDragenter: () => { this.menuBreadcrumbProps.open = true },
 				onDragleave: this.closeActions,
 				// Make sure we keep the same open state


### PR DESCRIPTION
### ☑️ Resolves

* Fixes opening the hidden breadcrumbs menu when dragging and hovering over the menu. The `dragenter` and `dragleave` events where not emitted, so the listener in `NcBreadcrumbs` was never called, hence, the hidden crumb menu not opened. Emitting the events fixes the issue.