### PR TITLE
[next] fix(test): correctly provide props in test

### DIFF
--- a/tests/unit/components/NcModal/modal.spec.js
+++ b/tests/unit/components/NcModal/modal.spec.js
@@ -26,7 +26,7 @@ import NcModal from '../../../../src/components/NcModal/NcModal.vue'
 
 describe('NcModal', () => {
 	it('closes on click outside with `canClose`', async () => {
-		const wrapper = mount(NcModal, { propsData: { canClose: true, title: 'modal' } })
+		const wrapper = mount(NcModal, { props: { canClose: true, title: 'modal' } })
 		expect(wrapper.html().includes('modal-wrapper')).toBe(true)
 
 		expect(wrapper.emitted('update:show')).toBe(undefined)
@@ -37,7 +37,7 @@ describe('NcModal', () => {
 	})
 
 	it('not closes on click outside when `canClose` is false', async () => {
-		const wrapper = mount(NcModal, { propsData: { canClose: false, title: 'modal' } })
+		const wrapper = mount(NcModal, { props: { canClose: false, title: 'modal' } })
 		expect(wrapper.html().includes('modal-wrapper')).toBe(true)
 
 		expect(wrapper.emitted('update:show')).toBe(undefined)
@@ -48,7 +48,7 @@ describe('NcModal', () => {
 	})
 
 	it('not closes on click outside when `canClose` is true but `closeOnClickOutside` is false', async () => {
-		const wrapper = mount(NcModal, { propsData: { canClose: true, closeOnClickOutside: false, title: 'modal' } })
+		const wrapper = mount(NcModal, { props: { canClose: true, closeOnClickOutside: false, title: 'modal' } })
 		expect(wrapper.html().includes('modal-wrapper')).toBe(true)
 
 		expect(wrapper.emitted('update:show')).toBe(undefined)


### PR DESCRIPTION
### ☑️ Resolves

* Fixes the way we provide props to the `mount` function in `modal.spec.js` for vue 3. 

@susnux Since the tests passed even though we didn't provide the props correctly, I assume the tests don't really test anything. I didn't change it here though, since it is the same in `master` and should probably be fixed there, I think.