### PR TITLE
feat(NcActionInput): allow to prevent open on hover

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -100,6 +100,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				type="multiselect"
 				label="label"
 				track-by="id"
+				:open-on-hover="false"
 				:multiple="true"
 				:options="[{label:'Apple', id: 'apple'}, {label:'Banana', id: 'banana'}, {label:'Cherry', id: 'cherry'}]">
 				<template #icon>
@@ -173,7 +174,8 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 							:placeholder="text"
 							:disabled="disabled"
 							:type="datePickerType"
-							:input-class="['mx-input', { focusable: isFocusable }]"
+							:class="{ focusable: isFocusable && !openOnHover}"
+							:input-class="['mx-input', { focusable: isFocusable && openOnHover }]"
 							class="action-input__datetimepicker"
 							v-bind="$attrs"
 							@input="onInput"
@@ -183,7 +185,8 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 							:id="idNativeDateTimePicker"
 							:value="value"
 							:type="nativeDatePickerType"
-							:input-class="{ focusable: isFocusable }"
+							:class="{ focusable: isFocusable && !openOnHover}"
+							:input-class="{ focusable: isFocusable && openOnHover }"
 							class="action-input__datetimepicker"
 							v-bind="$attrs"
 							@input="$emit('input', $event)"
@@ -194,7 +197,8 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 							:placeholder="text"
 							:disabled="disabled"
 							:append-to-body="false"
-							:input-class="{ focusable: isFocusable }"
+							:class="{ focusable: isFocusable && !openOnHover}"
+							:input-class="{ focusable: isFocusable && openOnHover }"
 							class="action-input__multi"
 							v-bind="$attrs"
 							v-on="$listeners" />
@@ -391,6 +395,13 @@ export default {
 		trailingButtonLabel: {
 			type: String,
 			default: t('Submit'),
+		},
+		/**
+		 * Whether to open / focus the NcDatePicker and NcSelect components on hover.
+		 */
+		openOnHover: {
+			type: Boolean,
+			default: true,
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Allow to prevent opening the datepicker and select components in `NcActionInput` on hover.

While working on https://github.com/nextcloud/tasks/pull/2427 I realized that opening the `NcSelect` in `NcActionInput` on hover is quite disturbing, as it is unexpected and in many cases also undesired. E.g. when clicking a `NcActionButton` below the `NcActionInput`, the open `NcActionInput` blocks the view. Also, the select is open by default if it is the first element in the `NcActions` menu. This also looks weird. Furthermore, all other usages of `NcDateTimePicker` and `NcSelect` do not open on hover.

This PR adds a prop `openOnHover` that allows to disable this behaviour. By default it is still enabled to not introduce a breaking change.

### 🖼️ Screenshots

🏚️ Before:

[Bildschirmaufzeichnung vom 2024-01-01, 10-38-37.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/95c20eb1-29cb-4d9e-a686-d7cf0877da77)

🏡 After:

[Bildschirmaufzeichnung vom 2024-01-01, 10-33-30.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/a44d46c5-0d31-4e8e-937e-6fef3dfdf98c)

