### PR TITLE
feat(NcActionInput): allow to append `NcSelect` to body

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -100,6 +100,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				type="multiselect"
 				label="label"
 				track-by="id"
+				:append-to-body="true"
 				:multiple="true"
 				:options="[{label:'Apple', id: 'apple'}, {label:'Banana', id: 'banana'}, {label:'Cherry', id: 'cherry'}]">
 				<template #icon>
@@ -193,7 +194,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 							:value="value"
 							:placeholder="text"
 							:disabled="disabled"
-							:append-to-body="false"
+							:append-to-body="$attrs.appendToBody || $attrs['append-to-body'] || false"
 							:input-class="{ focusable: isFocusable }"
 							class="action-input__multi"
 							v-bind="$attrs"


### PR DESCRIPTION
### ☑️ Resolves

* This allows to append the `NcSelect` in `NcActionInput` to body. This prevents clipping the select by the action menu.

Code-wise it would be simpler to just remove `:append-to-body="false"`, but this would introduce a breaking change, as it would set `append-to-body` to `true` by default for `NcSelect`. So I decided to add a prop instead.
Also, for vue 3 this is not necessary, since `v-bind="$attrs"` overwrites the props already set on the component.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
 ![Bildschirmfoto vom 2024-01-01 12-39-14](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/34e35bf9-4b7f-4938-a086-e791c903ef51) | ![Bildschirmfoto vom 2024-01-01 12-40-09](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/9f762081-8e2a-4c12-a1f9-5bc7ce7c5295)
