### PR TITLE
refactor(NcCheckboxRadioSwitch): move comment to have a single root node

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -21,16 +21,16 @@
 -->
 
 <template>
-	<!--
-		label can't be used here because of shift+click firefox bug
-		https://bugzilla.mozilla.org/show_bug.cgi?id=559506
-	-->
-	<span :id="!isButtonType ? `${id}-label` : null"
+	<span :id="!isButtonType ? `${id}-label` : undefined"
 		class="checkbox-content"
 		:class="{
 			['checkbox-content-' + type]: true,
 			'checkbox-content--button-variant': buttonVariant,
 		}">
+		<!--
+			label can't be used here because of shift+click firefox bug
+			https://bugzilla.mozilla.org/show_bug.cgi?id=559506
+		-->
 		<span :class="{
 				'checkbox-content__icon': true,
 				'checkbox-content__icon--checked': isChecked,


### PR DESCRIPTION
Having a comment directly in a template may cause issues in `@vue/test-utils` and other tools that consider such a component to have two root nodes in a fragment: a comment node and a `span` node.

Also, replaced `null` with `undefined` to remove minor typing issue.

No visual changes.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
