### PR TITLE
fix(NcAppNavigation): change h2 to span

### DIFF
--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -100,9 +100,9 @@
 <template>
 	<li class="app-navigation-caption">
 		<!-- Name of the caption -->
-		<h2 class="app-navigation-caption__name">
+		<span class="app-navigation-caption__name">
 			{{ name }}
-		</h2>
+		</span>
 
 		<!-- Actions -->
 		<div v-if="hasActions"
@@ -172,6 +172,7 @@ export default {
 		flex-shrink: 0;
 		// padding to align the name with the icon of app navigation items
 		padding: 0 calc(var(--default-grid-baseline, 4px) * 2) 0 calc(var(--default-grid-baseline, 4px) * 3);
+		margin-bottom: 12px;
 	}
 
 	&__actions {


### PR DESCRIPTION
### ☑️ Resolves

* Fix nextcloud/server#42554

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![293754098-54ff5621-bb32-40f8-bdbe-a05b764b005f](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/e1d7db0b-c701-43c1-bf4d-b1555a1f3238) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/23f1829f-a999-482f-8f37-b9b4364afc49)

### 🚧 Summary

Change the h2 element in NcAppNavigationCaption to span, as the former h2 element broke the hierarchy of headings within the user page.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable (NA)
- [x] 📘 Component documentation has been extended, updated or is not applicable (NA)
