### PR TITLE
Harmonize focus-visible styles for vue-navigation item with none-vue navigation item

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -111,6 +111,12 @@
 			width: calc(100% - #{$clickable-area});
 			margin: auto;
 		}
+
+		&:focus-visible {
+			box-shadow: 0 0 0 4px var(--color-main-background);
+			outline: 2px solid var(--color-main-text);
+			border-radius: var(--border-radius-pill);
+		}
 	}
 }
 /* Second level nesting for lists */


### PR DESCRIPTION
### ☑️ Resolves

* For https://github.com/nextcloud/server/issues/41699

**Before 
Vue-navigation** 

![Peek 2024-01-03 15-44](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/2b97a9ed-8793-4430-9ca3-277b9d1ef7ad)

**Unchanged non-vue navigation**

![Peek 2024-01-03 15-31](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/7421a80f-5fa6-4862-a11f-c71ac9fee021)

**After
Vue-navigation** 

![Peek 2024-01-03 15-30](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/631531c9-a85e-4b85-a57a-3f2666b788b9)

Vue-navigation | Unchanged non-vue navigation
---|---
![Screenshot from 2024-01-03 15-31-17](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/13efb49d-2b2f-43f4-9557-44017c4e0780) | ![Screenshot from 2024-01-03 15-31-12](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/bd931913-2bd0-4872-a0b5-0e76ba1b4d89)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
