### PR TITLE
fix(NcDateTimePicker): Use ISO week numbers if `showWeekNumber` is set

### DIFF
--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -127,7 +127,7 @@ export default {
 		:append-to-body="appendToBody"
 		:clearable="clearable"
 		:format="format ? format : formatTypeMap"
-		:formatter="formatter"
+		:formatter="internalFormatter"
 		:lang="lang ? lang : defaultLang"
 		:minute-step="minuteStep"
 		:placeholder="placeholder ? placeholder : defaultPlaceholder"
@@ -352,6 +352,32 @@ export default {
 		 */
 		formatTypeMap() {
 			return formatMap[this.type] ?? formatMap.date
+		},
+
+		/**
+		 * The formatter used for the vue-datepicker to fix nextcloud-libraries/nextcloud-vue#5044
+		 */
+		internalFormatter() {
+			/**
+			 * Get the ISO week number of the date
+			 * @param {Date} date The date to format
+			 */
+			const getWeek = (date) => {
+				// Adjust to nearest Thursday
+				const firstThursday = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
+				firstThursday.setUTCDate(firstThursday.getUTCDate() + 4 - (firstThursday.getUTCDay() || 7))
+
+				const yearStart = new Date(Date.UTC(firstThursday.getUTCFullYear(), 0, 1))
+
+				// Full weeks to nearest Thursday
+				return Math.ceil((((firstThursday - yearStart) / 86400000) + 1) / 7)
+			}
+
+			return {
+				getWeek,
+				// allow to override it by users using the `formatter` prop
+				...(this.formatter ?? {}),
+			}
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #5044 

Use ISO week numbers by default, but still allow users to override it using the `formatter`  prop.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot_20240109_135501](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/843fdc0b-cdf0-4177-a3f6-f3c23895b6f9)|![Screenshot_20240109_135514](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/b6f67821-cd41-4732-bc7d-d002c55e014d)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
