### PR TITLE
fix(NcActions): In case of inline actions make sure to support icon as URL

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1031,6 +1031,18 @@ export default {
 			return ['NcActionButton', 'NcActionLink', 'NcActionRouter'].includes(componentName)
 		},
 
+		/**
+		 * Check whether a icon prop value is an URL or not
+		 * @param {string} url The icon prop value
+		 */
+		isIconUrl(url) {
+			try {
+				return !!(new URL(url, url.startsWith('/') ? window.location.origin : undefined))
+			} catch (error) {
+				return false
+			}
+		},
+
 		// MENU STATE MANAGEMENT
 		openMenu(e) {
 			if (this.opened) {
@@ -1266,8 +1278,12 @@ export default {
 		 * @return {Function} the vue render function
 		 */
 		const renderInlineAction = (action) => {
-			const icon = action?.data?.scopedSlots?.icon()?.[0]
-				|| h('span', { class: ['icon', action?.componentOptions?.propsData?.icon] })
+			const iconProp = action?.componentOptions?.propsData?.icon
+			const icon = action?.data?.scopedSlots?.icon()?.[0] ?? (
+				this.isIconUrl(iconProp)
+					? h('img', { class: 'action-item__menutoggle__icon', attrs: { src: iconProp, alt: '' } })
+					: h('span', { class: ['icon', iconProp] })
+			)
 			const attrs = action?.data?.attrs || {}
 			const clickListener = action?.componentOptions?.listeners?.click
 
@@ -1540,6 +1556,12 @@ export default {
 
 	&.action-item--open .action-item__menutoggle {
 		background-color: var(--open-background-color);
+	}
+
+	&__menutoggle__icon {
+		width: 20px;
+		height: 20px;
+		object-fit: contain;
 	}
 }
 </style>

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -76,9 +76,13 @@ export default {
 	],
 
 	computed: {
+		/**
+		 * Check if icon prop is an URL
+		 * @return {boolean} Whether the icon prop is an URL
+		 */
 		isIconUrl() {
 			try {
-				return new URL(this.icon, this.icon.startsWith('/') ? window.location.origin : undefined)
+				return !!(new URL(this.icon, this.icon.startsWith('/') ? window.location.origin : undefined))
 			} catch (error) {
 				return false
 			}

--- a/tests/unit/components/NcActions/NcActions.spec.ts
+++ b/tests/unit/components/NcActions/NcActions.spec.ts
@@ -163,5 +163,24 @@ describe('NcActions.vue', () => {
 				expect(wrapper.find('.action-item__menutoggle').exists()).toBe(true)
 			})
 		})
+
+		it('supports URL for inline actions', () => {
+			const wrapper = mount(NcActions, {
+				slots: {
+					default: [
+						'<NcActionButton icon="http://example.com/image.png">Test1</NcActionButton>',
+					],
+				},
+				stubs: {
+					// used to register custom components
+					NcActionButton,
+				},
+				propsData: {
+					inline: 1,
+				},
+			})
+		
+			expect(wrapper.find('img[src="http://example.com/image.png"').exists()).toBe(true)
+		})
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

* Follow up on #4955 
* Resolves https://github.com/nextcloud-libraries/nextcloud-vue/issues/2315

The actions support the `icon` prop with class and URL, but if they are rendered as inline actions the URL was not used currently as the icon but set as class.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot_20240110_173603](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/f5e72313-3ea2-4071-85d5-d55440d3a0d6)|![Screenshot_20240110_173536](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/21b5bdd7-36f9-485a-bfad-922f05733c81)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
