### PR TITLE
[next] fix(NcCheckboxContent): correctly check default slot

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -301,8 +301,10 @@ export default {
 				<slot name="icon" />
 			</template>
 
-			<!-- @slot The checkbox/radio label -->
-			<slot />
+			<template v-if="!!$slots.default" #default>
+				<!-- @slot The checkbox/radio label -->
+				<slot />
+			</template>
 		</NcCheckboxContent>
 	</component>
 </template>


### PR DESCRIPTION
### ☑️ Resolves

* Fixes the detection whether `NcCheckboxContent` has text. Before, it would always be `true` leading to a wrong padding right.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/86350c36-a075-4c0d-8756-3d79cdeede60) | ![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/8fdb4681-a23d-4dfc-beb9-3f3a052997ad)
