### PR TITLE
fix(NcDialog): allow to close NcDialog on click outside

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -268,6 +268,7 @@ export default {
 		dialogProperties() {
 			return {
 				additionalTrapElements: this.additionalTrapElements,
+				closeOnClickOutside: true,
 				class: 'app-settings',
 				container: this.container,
 				contentClasses: 'app-settings__content',

--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -217,6 +217,15 @@ export default defineComponent({
 		},
 
 		/**
+		 * Close the dialog if the user clicked outside of the dialog
+		 * Only relevant if `canClose` is set to true.
+		 */
+		closeOnClickOutside: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
 		 * Declare if hiding the modal should be animated
 		 * @default false
 		 */
@@ -345,7 +354,7 @@ export default defineComponent({
 			show: props.open && showModal.value,
 			outTransition: props.outTransition,
 			class: 'dialog__modal',
-			closeOnClickOutside: false,
+			closeOnClickOutside: props.closeOnClickOutside,
 			enableSlideshow: false,
 			enableSwipe: false,
 		}))


### PR DESCRIPTION
### ☑️ Resolves

* Follow-up from #4550
* It feels counter-intuitive now for some dialogs (ex-modals) to not be closed with outside click. That doesn't apply to small confirmation popups, but some general things should be reverted to old behavior with this:
  * NcAppSettingsDialog
  * FilePicker
  * e.t.c.

### 🚧 Tasks

- [ ] Alternative: make `closeOnClickOutside` true by default ?

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
