### PR TITLE
Remove unneeded `tab`, `tablist` and `aria-selected` roles from navigation

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -145,19 +145,17 @@ export default {
 		@update:open="handleCloseModal">
 		<template v-if="hasNavigation" #navigation="{ isCollapsed }">
 			<ul v-if="!isCollapsed"
-				:aria-label="settingsNavigationAriaLabel"
-				class="navigation-list"
-				role="tablist">
+				class="navigation-list">
 				<li v-for="section in sections" :key="section.id">
-					<a :aria-selected="section.id === selectedSection"
+					<a :aria-current="`${section.id === selectedSection}`"
 						:class="{
 							'navigation-list__link': true,
 							'navigation-list__link--active': section.id === selectedSection,
 							'navigation-list__link--icon': hasNavigationIcons,
 						}"
-						role="tab"
+						:href="`#settings-section_${section.id}`"
 						tabindex="0"
-						@click="handleSettingsNavigationClick(section.id)"
+						@click.prevent="handleSettingsNavigationClick(section.id)"
 						@keydown.enter="handleSettingsNavigationClick(section.id)">
 						<div v-if="hasNavigationIcons" class="navigation-list__link-icon">
 							<NcVNodes v-if="section.icon" :vnodes="section.icon" />

--- a/tests/unit/components/NcAppSettingsDialog/NcAppSettingsDialog.spec.ts
+++ b/tests/unit/components/NcAppSettingsDialog/NcAppSettingsDialog.spec.ts
@@ -55,8 +55,8 @@ describe('NcAppSettingsDialog: Sections registration', () => {
 
 		await nextTick()
 
-		expect(wrapper.findAll('[role="tab"]')).toHaveLength(1)
-		expect(wrapper.find('[role="tab"]').text()).toBe('test_name')
+		expect(wrapper.findAll('nav a')).toHaveLength(1)
+		expect(wrapper.find('nav a').text()).toBe('test_name')
 	})
 
 	it('can register a new section', async () => {
@@ -70,8 +70,8 @@ describe('NcAppSettingsDialog: Sections registration', () => {
 
 		wrapper.vm.registerSection('test_id', 'test_name')
 		await nextTick()
-		expect(wrapper.findAll('[role="tab"]')).toHaveLength(1)
-		expect(wrapper.find('[role="tab"]').text()).toBe('test_name')
+		expect(wrapper.findAll('nav a')).toHaveLength(1)
+		expect(wrapper.find('nav a').text()).toBe('test_name')
 	})
 
 	it('warn on register a already registered section name', async () => {
@@ -89,13 +89,13 @@ describe('NcAppSettingsDialog: Sections registration', () => {
 		// First call should be OK
 		wrapper.vm.registerSection('test_id', 'test_name')
 		await nextTick()
-		expect(wrapper.findAll('[role="tab"]')).toHaveLength(1)
+		expect(wrapper.findAll('nav a')).toHaveLength(1)
 		expect(spy).not.toHaveBeenCalled()
 
 		// Second one should unregister first and replace with this one, but show an error
 		wrapper.vm.registerSection('test_id_2', 'test_name')
 		await nextTick()
-		expect(wrapper.findAll('[role="tab"]')).toHaveLength(2)
+		expect(wrapper.findAll('nav a')).toHaveLength(2)
 		expect(spy).toHaveBeenCalled()
 	})
 
@@ -111,12 +111,12 @@ describe('NcAppSettingsDialog: Sections registration', () => {
 		// First call should be OK
 		wrapper.vm.registerSection('test_id', 'test_name')
 		await nextTick()
-		expect(wrapper.findAll('[role="tab"]')).toHaveLength(1)
+		expect(wrapper.findAll('nav a')).toHaveLength(1)
 
 		// Second one should unregister first and replace with this one, but show an error
 		expect(() => wrapper.vm.registerSection('test_id', 'test_other_name')).toThrow()
 		await nextTick()
-		expect(wrapper.findAll('[role="tab"]')).toHaveLength(1)
+		expect(wrapper.findAll('nav a')).toHaveLength(1)
 	})
 
 	it('can unregister a section', async () => {
@@ -131,11 +131,11 @@ describe('NcAppSettingsDialog: Sections registration', () => {
 		wrapper.vm.registerSection('test_id', 'test_name')
 		wrapper.vm.registerSection('test_id2', 'test_name2')
 		await nextTick()
-		expect(wrapper.findAll('[role="tab"]')).toHaveLength(2)
+		expect(wrapper.findAll('nav a')).toHaveLength(2)
 
 		wrapper.vm.unregisterSection('test_id')
 		await nextTick()
-		expect(wrapper.findAll('[role="tab"]')).toHaveLength(1)
-		expect(wrapper.find('[role="tab"]').text()).toBe('test_name2')
+		expect(wrapper.findAll('nav a')).toHaveLength(1)
+		expect(wrapper.find('nav a').text()).toBe('test_name2')
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

* For https://github.com/nextcloud/server/issues/42599
* See https://github.com/nextcloud/server/issues/42599#issuecomment-1879050422
* Navigation example: https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html

### 🖼️ Screenshots

🏚️ Before | 🏡 After

No visual changes. Result: no errors through automatically a11y tests.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
