### PR TITLE
enh(breadcrumb): conditionally renders button when no redirection link given

### DIFF
--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -25,6 +25,7 @@
 ### General description
 
 This component is meant to be used inside a Breadcrumbs component.
+Renders a button element when given no redirection props, otherwise, renders <a/> or <router-link/> elements
 
 </docs>
 
@@ -39,18 +40,16 @@ This component is meant to be used inside a Breadcrumbs component.
 		@dragover.prevent="() => {}"
 		@dragenter="dragEnter"
 		@dragleave="dragLeave">
-		<component :is="tag"
-			v-if="(name || icon) && !$slots.default"
+		<NcButton v-if="(name || icon) && !$slots.default"
 			:title="title"
 			:aria-label="icon ? name : undefined"
 			v-bind="linkAttributes"
 			v-on="$listeners">
-			<!-- @slot Slot for passing a material design icon. Precedes the icon and name prop. -->
 			<slot name="icon">
 				<span v-if="icon" :class="icon" class="icon" />
 				<span v-else>{{ name }}</span>
 			</slot>
-		</component>
+		</NcButton>
 		<NcActions v-if="$slots.default"
 			ref="actions"
 			type="tertiary"
@@ -75,6 +74,7 @@ This component is meant to be used inside a Breadcrumbs component.
 <script>
 import NcActions from '../NcActions/index.js'
 import GenRandomId from '../../utils/GenRandomId.js'
+import NcButton from '../NcButton/NcButton.vue'
 
 import ChevronRight from 'vue-material-design-icons/ChevronRight.vue'
 
@@ -83,6 +83,7 @@ export default {
 	components: {
 		NcActions,
 		ChevronRight,
+		NcButton,
 	},
 	inheritAttrs: false,
 	props: {
@@ -180,20 +181,11 @@ export default {
 	},
 	computed: {
 		/**
-		 * Determines which element tag to use
-		 *
-		 * @return {string} the tag
-		 */
-		tag() {
-			return this.to ? 'router-link' : 'a'
-		},
-
-		/**
 		 * The attributes to pass to `router-link` or `a`
 		 */
 		linkAttributes() {
-			// If it's a router-link, we pass `to` and `exact`, otherwise only `href`
-			return this.to ? { to: this.to, exact: this.exact, ...this.$attrs } : { href: this.href, ...this.$attrs }
+			// If it's a router-link, we pass `to` and `exact`, if its an <a/> element, we pass `href`, otherwise we have a button
+			return this.to ? { to: this.to, exact: this.exact, ...this.$attrs } : (this.href ? { href: this.href, ...this.$attrs } : { type: 'tertiary', ...this.$attrs })
 		},
 	},
 	methods: {
@@ -290,45 +282,6 @@ export default {
 		// Don't show breadcrumb separator for last crumb
 		.vue-crumb__separator {
 			display: none;
-		}
-	}
-
-	// Hover and focus effect for crumbs
-	& > a:hover,
-	& > a:focus {
-		background-color: var(--color-background-dark);
-		color: var(--color-main-text);
-	}
-
-	&--hidden {
-		display: none;
-	}
-
-	&#{&}--hovered > a {
-		background-color: var(--color-background-dark);
-		color: var(--color-main-text);
-	}
-
-	&__separator {
-		padding: 0;
-		color: var(--color-text-maxcontrast);
-	}
-
-	> a {
-		overflow: hidden;
-		color: var(--color-text-maxcontrast);
-		padding: 12px;
-		min-width: $clickable-area;
-		max-width: 100%;
-		border-radius: var(--border-radius-pill);
-		align-items: center;
-		display: inline-flex;
-		justify-content: center;
-
-		> span {
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
 		}
 	}
 

--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -43,12 +43,18 @@ Renders a button element when given no redirection props, otherwise, renders <a/
 		<NcButton v-if="(name || icon) && !$slots.default"
 			:title="title"
 			:aria-label="icon ? name : undefined"
+			type="tertiary"
 			v-bind="linkAttributes"
 			v-on="$listeners">
-			<slot name="icon">
-				<span v-if="icon" :class="icon" class="icon" />
-				<span v-else>{{ name }}</span>
-			</slot>
+			<template v-if="$slots.icon || icon" #icon>
+				<!-- @slot Slot for passing a material design icon. Precedes the icon and name prop. -->
+				<slot name="icon">
+					<span :class="icon" class="icon" />
+				</slot>
+			</template>
+			<template v-else #default>
+				{{ name }}
+			</template>
 		</NcButton>
 		<NcActions v-if="$slots.default"
 			ref="actions"
@@ -185,7 +191,12 @@ export default {
 		 */
 		linkAttributes() {
 			// If it's a router-link, we pass `to` and `exact`, if its an <a/> element, we pass `href`, otherwise we have a button
-			return this.to ? { to: this.to, exact: this.exact, ...this.$attrs } : (this.href ? { href: this.href, ...this.$attrs } : { type: 'tertiary', ...this.$attrs })
+			return this.to
+				? { to: this.to, exact: this.exact, ...this.$attrs }
+				: (this.href
+					? { href: this.href, ...this.$attrs }
+					: this.$attrs
+				)
 		},
 	},
 	methods: {
@@ -276,13 +287,43 @@ export default {
 	padding: 0;
 
 	&:last-child {
-		font-weight: bold;
 		min-width: 0;
 
 		// Don't show breadcrumb separator for last crumb
 		.vue-crumb__separator {
 			display: none;
 		}
+	}
+
+	// Necessary to hide hidden crumbs
+	&--hidden {
+		display: none;
+	}
+	&__separator {
+		padding: 0;
+		color: var(--color-text-maxcontrast);
+	}
+	// Necessary for indicating hovering for drag and drop
+	&#{&}--hovered :deep(.button-vue) {
+		background-color: var(--color-background-dark);
+		color: var(--color-main-text);
+	}
+	// Adjust button style
+	&:not(:last-child) :deep() .button-vue {
+		color: var(--color-text-maxcontrast);
+
+		&:hover,
+		&:focus {
+			background-color: var(--color-background-dark);
+			color: var(--color-main-text);
+		}
+
+		&__text {
+			font-weight: normal;
+		}
+	}
+	:deep(.button-vue__text) {
+		margin: 0;
 	}
 
 	// Adjust action item appearance for crumbs with actions


### PR DESCRIPTION
### ☑️ For nextcloud/server#42624
This fixes the semantic problems when no redirection link is provided to the NcBreadcrumb component, so it renders our own NcButton. To fix the problem references, nextcloud/server#42624, we would have to update NcDialog's library version for vue
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/659438c7-f811-4203-af23-64a807a58ce3)|![firefox_SmRJdHmGO3](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/307b4694-4438-4ed5-8eb6-223b9d8e9779)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable - Not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable 
