### PR TITLE
enh(a11y): added aria-label that matches title attr on icon

### DIFF
--- a/src/components/NcSettingsSection/NcSettingsSection.vue
+++ b/src/components/NcSettingsSection/NcSettingsSection.vue
@@ -49,6 +49,7 @@ This component is to be used in the settings section of nextcloud.
 				:href="docUrl"
 				class="settings-section__info"
 				:title="docNameTranslated"
+				:aria-label="docNameTranslated"
 				target="_blank"
 				rel="noreferrer nofollow">
 				<HelpCircle :size="20" />


### PR DESCRIPTION
### ☑️ For nextcloud/server#42855
Once the nextcloud/vue8.5.0 releases a,d the server repository gets the new library update, then the servers issue will be properly fixed!

### Summary
Adds an aria label to all sections that use NcSettings Section
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/9ee76278-d0d7-48af-afdf-06c67af829bd)
Example ^ This now has an aria label. Since the icon has no text, it needs a label AND a title for accessibility
## 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable - not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable - not applicable
