### PR TITLE
chore(docs): correct list types values for styleguidist in NcCheckboxRadioSwitch

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -113,6 +113,8 @@ export default {
 		 *
 		 * Only use button when used in a `tablist` container and the
 		 * `tab` role is set.
+		 *
+		 * @type {'checkbox'|'radio'|'switch'|'button'}
 		 */
 		type: {
 			type: String,

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -360,6 +360,8 @@ export default {
 		 *
 		 * Only use button when used in a `tablist` container and the
 		 * `tab` role is set.
+		 *
+		 * @type {'checkbox'|'radio'|'switch'|'button'}
 		 */
 		type: {
 			type: String,
@@ -383,7 +385,8 @@ export default {
 		/**
 		 * Are the elements are all direct siblings?
 		 * If so they will be grouped horizontally or vertically
-		 * Possible values are `no`, `horizontal`, `vertical`.
+		 *
+		 * @type {'no'|'horizontal'|'vertical'}
 		 */
 		buttonVariantGrouped: {
 			type: String,


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4661

Vue-Styleguidist tries to parse the values list from `validator`, but crashes when it is an array of not values itself but constants.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e060afec-5675-4a37-986c-7931353f1b4c) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/825c36d3-793f-4fba-8e82-db3585f15132)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
