### PR TITLE
feat(NcDialog): add navigationAriaLabel and navigationAriaLabelledBy props

### DIFF
--- a/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
+++ b/src/components/NcAppSettingsDialog/NcAppSettingsDialog.vue
@@ -141,6 +141,7 @@ export default {
 
 <template>
 	<NcDialog v-if="open"
+		:navigation-aria-label="settingsNavigationAriaLabel"
 		v-bind="dialogProperties"
 		@update:open="handleCloseModal">
 		<template v-if="hasNavigation" #navigation="{ isCollapsed }">

--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -103,7 +103,8 @@ export default {
 				<nav v-if="hasNavigation"
 					class="dialog__navigation"
 					:class="navigationClasses"
-					:aria-labelledby="navigationId">
+					:aria-label="navigationAriaLabelAttr"
+					:aria-labelledby="navigationAriaLabelledbyAttr">
 					<slot name="navigation" :is-collapsed="isNavigationCollapsed" />
 				</nav>
 				<!-- Main dialog content -->
@@ -255,6 +256,30 @@ export default defineComponent({
 		},
 
 		/**
+		 * aria-label for the dialog navigation.
+		 * Use it when you want to provide a more meaningful label than the dialog name.
+		 *
+		 * By default, navigation is labeled by the dialog name.
+		 */
+		navigationAriaLabel: {
+			type: String,
+			required: false,
+			default: '',
+		},
+
+		/**
+		 * aria-labelledby for the dialog navigation.
+		 * Use it when you have an implicit navigation label (e.g. a heading).
+		 *
+		 * By default, navigation is labeled by the dialog name.
+		 */
+		navigationAriaLabelledby: {
+			type: String,
+			required: false,
+			default: '',
+		},
+
+		/**
 		 * Optionally pass additionaly classes which will be set on the content wrapper for custom styling
 		 * @default ''
 		 */
@@ -305,6 +330,23 @@ export default defineComponent({
 		 * The unique id of the nav element
 		 */
 		const navigationId = ref(GenRandomId())
+
+		/**
+		 * aria-label attribute for the nav element
+		 */
+		const navigationAriaLabelAttr = computed(() => props.navigationAriaLabel || undefined)
+
+		/**
+		 * aria-labelledby attribute for the nav element
+		 */
+		const navigationAriaLabelledbyAttr = computed(() => {
+			if (props.navigationAriaLabel) {
+				// Not needed, already labelled by aria-label
+				return undefined
+			}
+			// Use dialog name as a fallback label for navigation
+			return props.navigationAriaLabelledby || navigationId.value
+		})
 
 		/**
 		 * If the underlaying modal is shown
@@ -365,6 +407,8 @@ export default defineComponent({
 			handleClosed,
 			hasNavigation,
 			navigationId,
+			navigationAriaLabelAttr,
+			navigationAriaLabelledbyAttr,
 			isNavigationCollapsed,
 			modalProps,
 			wrapper,


### PR DESCRIPTION
### ☑️ Resolves

Allows labeling navigation in dialogs when the name doesn't work well as a navigation label.

For example, "Select location for attachments" doesn't work well as a navigation for "All files", "Recent", Favorites".

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/599bd56f-b96a-43c7-982d-ec7fb7cc7185)

Also, updated labeling in `NcAppSettingsDialog` using this new prop

Before | After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/33086b69-7e81-4f3a-b650-6e646df587d9) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/39ce99e1-e0fc-4fbc-b902-7a4c3e409a7f)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
