### PR TITLE
feat(NcPopover): provide a11y attributes to the trigger

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -115,6 +115,9 @@ msgstr ""
 msgid "Edit item"
 msgstr ""
 
+msgid "Emoji picker"
+msgstr ""
+
 msgid "Enter link"
 msgstr ""
 

--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -96,6 +96,9 @@ msgstr ""
 msgid "Collapse menu"
 msgstr ""
 
+msgid "Color picker"
+msgstr ""
+
 msgid "Confirm changes"
 msgstr ""
 

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1254,8 +1254,14 @@ export default {
 		this.isSemanticMenu = hasMenuItemAction && !hasTextInputAction
 		// We consider the NcActions to be navigation if it consists some link-like action
 		this.isSemanticNavigation = hasLinkAction && !hasMenuItemAction && !hasTextInputAction
-		// If it is no a manu and not a navigation, it is a popover with items: a form or just a text
+		// If it is not a menu and not a navigation, it is a popover with items: a form or just a text
 		this.isSemanticPopoverLike = !this.isSemanticMenu && !this.isSemanticNavigation
+
+		const popupRole = this.isSemanticMenu
+			? 'menu'
+			: hasTextInputAction
+				? 'dialog'
+				: 'true'
 
 		/**
 		 * Filter and list actions that are allowed to be displayed inline
@@ -1364,6 +1370,7 @@ export default {
 						boundary: this.boundariesElement,
 						container: this.container,
 						popoverBaseClass: 'action-item__popper',
+						popupRole,
 						// Menu and navigation should not have focus trap
 						// Tab should close the menu and move focus to the next UI element
 						setReturnFocus: !this.isSemanticPopoverLike ? null : this.$refs.menuButton?.$el,
@@ -1397,10 +1404,8 @@ export default {
 						slot: 'trigger',
 						ref: 'menuButton',
 						attrs: {
-							'aria-haspopup': this.isSemanticMenu ? 'menu' : null,
 							'aria-label': this.menuName ? null : this.ariaLabel,
 							'aria-controls': this.opened ? this.randomId : null,
-							'aria-expanded': this.opened ? 'true' : 'false',
 						},
 						on: {
 							focus: this.onFocus,
@@ -1427,7 +1432,8 @@ export default {
 							attrs: {
 								id: this.randomId,
 								tabindex: '-1',
-								role: this.isSemanticMenu ? 'menu' : undefined,
+								role: popupRole !== 'true' ? popupRole : undefined,
+								// TODO: allow to provide dialog aria-label
 							},
 						}, [
 							actions,

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -438,6 +438,13 @@ td.row-size {
 export default {
 	name: 'NcButton',
 
+	inject: {
+		ncPopoverTriggerAttrs: {
+			from: 'NcPopover:trigger:attrs',
+			default: () => ({}),
+		},
+	},
+
 	props: {
 		/**
 		 * Set the text and icon alignment
@@ -639,6 +646,9 @@ export default {
 					target: (!this.to && this.href) ? '_self' : null,
 					rel: (!this.to && this.href) ? 'nofollow noreferrer noopener' : null,
 					download: (!this.to && this.href && this.download) ? this.download : null,
+					// If this button is used as a popover trigger, we need to apply trigger attrs, e.g. aria attributes
+					...this.ncPopoverTriggerAttrs,
+					// Inherit all the component attrs
 					...this.$attrs,
 				},
 				on: {

--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -89,8 +89,8 @@ export default {
 <template>
 	<div class="container1">
 		<NcButton @click="open = !open"> Click Me </NcButton>
-		<NcColorPicker :value="color" @input="updateColor" :shown.sync="open">
-			<div :style="{'background-color': color}" class="color1" />
+		<NcColorPicker :value="color" @input="updateColor" :shown.sync="open" v-slot="{ attrs }">
+			<div v-bind="attrs" :style="{'background-color': color}" class="color1" />
 		</NcColorPicker>
 	</div>
 </template>
@@ -160,11 +160,16 @@ export default {
 </docs>
 
 <template>
-	<NcPopover v-bind="$attrs" v-on="$listeners" @apply-hide="handleClose">
-		<template #trigger>
-			<slot />
+	<NcPopover popup-role="dialog"
+		v-bind="$attrs"
+		v-on="$listeners"
+		@apply-hide="handleClose">
+		<template #trigger="slotProps">
+			<slot v-bind="slotProps" />
 		</template>
-		<div class="color-picker"
+		<div role="dialog"
+			class="color-picker"
+			:aria-label="t('Color picker')"
 			:class="{ 'color-picker--advanced-fields': advanced && advancedFields }">
 			<Transition name="slide" mode="out-in">
 				<div v-if="!advanced" class="color-picker__simple">

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -142,24 +142,29 @@ export default {
 		@update:value="$emit('update:value', value)">
 		<template #icon-calendar>
 			<NcPopover v-if="showTimezoneSelect"
+				popup-role="dialog"
 				:shown.sync="showTimezonePopover"
 				popover-base-class="timezone-select__popper">
-				<template #trigger>
+				<template #trigger="{ attrs }">
 					<button class="datetime-picker-inline-icon"
 						:class="{'datetime-picker-inline-icon--highlighted': highlightTimezone}"
+						v-bind="attrs"
 						@mousedown.stop.prevent="() => {}">
 						<Web :size="20" />
 					</button>
 				</template>
 
-				<div class="timezone-popover-wrapper__label">
-					<strong>
-						{{ t('Please select a time zone:') }}
-					</strong>
+				<div role="dialog"
+					:aria-labelledby="timezoneDialogHeaderId">
+					<div class="timezone-popover-wrapper__label">
+						<strong :id="timezoneDialogHeaderId">
+							{{ t('Please select a time zone:') }}
+						</strong>
+					</div>
+					<NcTimezonePicker v-model="tzVal"
+						class="timezone-popover-wrapper__timezone-select"
+						@input="$emit('update:timezone-id', arguments[0])" />
 				</div>
-				<NcTimezonePicker v-model="tzVal"
-					class="timezone-popover-wrapper__timezone-select"
-					@input="$emit('update:timezone-id', arguments[0])" />
 			</NcPopover>
 			<CalendarBlank v-else :size="20" />
 		</template>
@@ -171,6 +176,7 @@ export default {
 
 <script>
 import { t } from '../../l10n.js'
+import GenRandomId from '../../utils/GenRandomId.js'
 
 import NcTimezonePicker from '../NcTimezonePicker/index.js'
 import NcPopover from '../NcPopover/index.js'
@@ -290,6 +296,12 @@ export default {
 		'update:value',
 		'update:timezone-id',
 	],
+
+	setup() {
+		return {
+			timezoneDialogHeaderId: `timezone-dialog-header-${GenRandomId()}`,
+		}
+	},
 
 	data() {
 		return {

--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -126,12 +126,13 @@ This component allows the user to pick an emoji.
 <template>
 	<NcPopover :shown.sync="open"
 		:container="container"
+		popup-role="dialog"
 		v-bind="$attrs"
 		v-on="$listeners"
 		@after-show="afterShow"
 		@after-hide="afterHide">
-		<template #trigger>
-			<slot />
+		<template #trigger="slotProps">
+			<slot v-bind="slotProps" />
 		</template>
 		<Picker ref="picker"
 			:auto-focus="false /* We manage the input focus ourselves */"
@@ -145,6 +146,8 @@ This component allows the user to pick an emoji.
 			:picker-styles="{ width: '320px' }"
 			:show-preview="showPreview"
 			:title="previewFallbackName"
+			role="dialog"
+			:aria-label="t('Emoji picker')"
 			v-bind="$attrs"
 			@select="select">
 			<template #searchTemplate="slotProps">

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -36,18 +36,18 @@ open prop on this component;
 
 ### Examples
 
-#### With a `<button>` as a trigger:
+#### With a `<NcButton>` as a trigger:
 
 ```vue
 <template>
 	<div style="display: flex">
-		<NcPopover>
+		<NcPopover popup-role="dialog">
 			<template #trigger>
 				<NcButton>I am the trigger</NcButton>
 			</template>
 			<template>
-				<form tabindex="0" @submit.prevent>
-					<h2>this is some content</h2>
+				<form tabindex="0" role="dialog" aria-labelledby="popover-example-dialog-header-1" @submit.prevent>
+					<h2 id="popover-example-dialog-header-1">this is some content</h2>
 					<p>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. <br/>
 						Vestibulum eget placerat velit.
@@ -89,7 +89,7 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 ```vue
 <template>
 	<div style="display: flex">
-		<NcPopover container="body" :popper-hide-triggers="(triggers) => [...triggers, 'click']">
+		<NcPopover container="body" :popper-hide-triggers="(triggers) => [...triggers, 'click']" popup-role="dialog">
 			<template #trigger>
 				<NcButton>I am the trigger</NcButton>
 			</template>
@@ -100,10 +100,63 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 	</div>
 </template>
 ```
+
+#### With a custom button in as a trigger:
+
+When `<NcButton>` is used as a `<NcPopover>` trigger, it injects required for a11y attributes to the button.
+
+If you are using your own custom button as a trigger make sure to bind `attrs` from the trigger slot props.
+See code example below.
+
+```vue
+<template>
+	<div style="display: flex">
+		<NcPopover>
+			<!-- Take "attrs" from the slot props -->
+			<template #trigger="{ attrs }">
+				<!-- Bind attrs as the button attrs -->
+				<button v-bind="attrs">
+					I am a custom button in the trigger
+				</button>
+			</template>
+
+			Hi! 🚀
+		</NcPopover>
+	</div>
+````
+
+#### Provide role for the popover content
+
+For accessibility reasons, popover should have a role. Provide it to the `popup-role` and make sure that the popover content is an element with the same role.
+
+See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup
+
+```vue
+<template>
+	<div style="display: flex">
+		<!-- Provide popup role -->
+		<NcPopover popup-role="dialog">
+			<template #trigger>
+				<NcButton>Delete</NcButton>
+			</template>
+
+			<!-- Popover content should has the same role -->
+			<div role="dialog" aria-labelledby="popover-example-custom-role-1">
+				<!-- This is not required but better to provide a label -->
+				<header id="popover-example-custom-role-1">
+					<strong>Confirm remove</strong>
+				</header>
+				<NcButton type="danger">Delete</NcButton>
+			</div>
+		</NcPopover>
+	</div>
+</template>
+````
 </docs>
 
 <template>
 	<Dropdown ref="popover"
+		:shown.sync="shownProxy"
 		:distance="10"
 		:arrow-padding="10"
 		v-bind="$attrs"
@@ -112,8 +165,11 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 		v-on="$listeners"
 		@apply-show="afterShow"
 		@apply-hide="afterHide">
-		<!-- This will be the popover target (for the events and position) -->
-		<slot name="trigger" />
+		<NcPopoverTriggerProvider v-slot="slotProps" :shown="internalShown" :popup-role="popupRole">
+			<!-- This will be the popover target (for the events and position) -->
+			<slot name="trigger" v-bind="slotProps" />
+		</NcPopoverTriggerProvider>
+
 		<!-- This will be the content of the popover -->
 		<template #popper>
 			<slot />
@@ -125,17 +181,38 @@ The prop `:focus-trap="false"` help to prevent it when the default behavior is n
 import { Dropdown } from 'floating-vue'
 import { createFocusTrap } from 'focus-trap'
 import { getTrapStack } from '../../utils/focusTrap.js'
+import NcPopoverTriggerProvider from './NcPopoverTriggerProvider.vue'
 
 export default {
 	name: 'NcPopover',
 
 	components: {
 		Dropdown,
+		NcPopoverTriggerProvider,
 	},
 
 	inheritAttrs: false,
 
 	props: {
+		/**
+		 * Show or hide the popper
+		 * @see https://floating-vue.starpad.dev/api/#shown
+		 */
+		shown: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
+		 * Popup role
+		 * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup#values
+		 */
+		popupRole: {
+			type: String,
+			default: 'true',
+			validator: (value) => ['menu', 'listbox', 'tree', 'grid', 'dialog', 'true'].includes(value),
+		},
+
 		popoverBaseClass: {
 			type: String,
 			default: '',
@@ -161,7 +238,35 @@ export default {
 	emits: [
 		'after-show',
 		'after-hide',
+		/**
+		 * @see https://floating-vue.starpad.dev/api/#update-shown
+		 */
+		'update:shown',
 	],
+
+	data() {
+		return {
+			internalShown: this.shown,
+		}
+	},
+
+	computed: {
+		shownProxy: {
+			get() {
+				return this.shown
+			},
+			set(value) {
+				this.internalShown = value
+				this.$emit('update:shown', value)
+			},
+		},
+	},
+
+	watch: {
+		shown(value) {
+			this.internalShown = value
+		},
+	},
 
 	beforeDestroy() {
 		this.clearFocusTrap()

--- a/src/components/NcPopover/NcPopoverTriggerProvider.vue
+++ b/src/components/NcPopover/NcPopoverTriggerProvider.vue
@@ -1,0 +1,41 @@
+<script>
+import { computed, defineComponent } from 'vue'
+
+export default defineComponent({
+	name: 'NcPopoverTriggerProvider',
+
+	provide() {
+		return {
+			'NcPopover:trigger:shown': computed(() => this.shown),
+			'NcPopover:trigger:attrs': computed(() => this.triggerAttrs),
+		}
+	},
+
+	props: {
+		shown: {
+			type: Boolean,
+			required: true,
+		},
+		popupRole: {
+			type: String,
+			required: true,
+		},
+	},
+
+	computed: {
+		triggerAttrs() {
+			return {
+				'aria-haspopup': this.popupRole,
+				'aria-expanded': this.shown.toString(),
+			}
+		},
+	},
+
+	render() {
+		// TODO: Vue 3 - replace with $slots
+		return this.$scopedSlots.default?.({
+			attrs: this.triggerAttrs,
+		})
+	},
+})
+</script>

--- a/src/components/NcPopover/NcPopoverTriggerProvider.vue
+++ b/src/components/NcPopover/NcPopoverTriggerProvider.vue
@@ -1,5 +1,5 @@
 <script>
-import { computed, defineComponent } from 'vue'
+import Vue, { computed, defineComponent } from 'vue'
 
 export default defineComponent({
 	name: 'NcPopoverTriggerProvider',
@@ -29,6 +29,16 @@ export default defineComponent({
 				'aria-expanded': this.shown.toString(),
 			}
 		},
+	},
+
+	mounted() {
+		if (window.OC?.debug) {
+			const rootElement = this.$el
+			const innerElement = this.$el.querySelector('[aria-expanded][aria-haspopup]')
+			if (!rootElement.getAttribute('aria-expanded') && !innerElement) {
+				Vue.util.warn('It looks like you are using a custom button as a <NcPopover> or other popover #trigger. If you are not using <NcButton> as a trigger, you need to bind attrs from the #trigger slot props to your custom button. See <NcPopover> docs for an example.')
+			}
+		}
 	},
 
 	render() {

--- a/src/components/NcUserBubble/NcUserBubble.vue
+++ b/src/components/NcUserBubble/NcUserBubble.vue
@@ -83,12 +83,13 @@ export default {
 		class="user-bubble__wrapper"
 		@update:open="onOpenChange">
 		<!-- Main userbubble structure -->
-		<template #trigger>
+		<template #trigger="{ attrs }">
 			<component :is="isLinkComponent"
 				class="user-bubble__content"
 				:style="styles.content"
 				:href="hasUrl ? url : null"
 				:class="{ 'user-bubble__content--primary': primary }"
+				v-bind="attrs"
 				@click="onClick">
 				<!-- NcAvatar -->
 				<NcAvatar :url="isCustomAvatar && isAvatarUrl ? avatarImage : undefined"

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -114,6 +114,7 @@ module.exports = async () => {
 					'src/components/NcSettings*/*.vue',
 					'src/components/NcUserBubble/NcUserBubbleDiv.vue',
 					'src/components/NcTextArea/*.vue',
+					'src/components/NcPopover/NcPopoverTriggerProvider.vue',
 				],
 				sections: [
 					{

--- a/styleguide/global.requires.js
+++ b/styleguide/global.requires.js
@@ -72,6 +72,7 @@ function chunkify(t) {
 }
 
 window.OC = {
+	debug: true,
 	getCurrentUser() {
 		return {
 			uid: 'admin',

--- a/tests/OC.js
+++ b/tests/OC.js
@@ -1,4 +1,5 @@
 export default {
+	debug: true,
 
 	getLanguage() {
 		return 'en-GB'


### PR DESCRIPTION
## ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/41904
* In the issue there is only 1 place, but we have this issue in literally all `NcPopover` usages except `NcActions`...

### A problem

1. `NcPopover` trigger button should have a11y attributes
   - `aria-haspopup="<role>"`
   - `aria-expanded="<is shown>"`
3. Trigger button is provided via slot in place, we don't control it
   ```html
   <NcPopover>
     <template #trigger>
       Any button here should have attrs
     </template>
   </NcPopover>
   ```
3. We don't want to control all the places where `NcPopover` is used to make sure its trigger button has attributes.

This implementation might look a bit complex, but it helps to make a lot of popovers more accessible.

### 1. Provide `NcPopover:trigger:attrs` from `NcPopover` to its `#trigger` slot's content

So any component used as a trigger may receive the attrs, required to be on the trigger


A small component `NcPopoverTriggerProvider` is created to provide content only to the trigger, not to the content.

### 2. Inject it in `NcButton`

`NcButton` is the most popular `NcPopover` trigger.

This may look incorrect that `NcButton` "knows" something about the popover. But as it is a part of one library, and they are used together very often, it is a plain solution to cover a lot of cases. Without requirements to change anything in the apps.

Covers:
- `NcColorPicker`, `NcEmojiPicker`, `NcActions`
- Most of custom `NcPopover` usages with `NcButton` trigger **in all Nextcloud apps**

```html
<NcPopover>
  <template #trigger>
    <!-- 🥳 Magically this button will have all the attrs --> 
    <NcButton>My custom popover</NcButton>
  </template>
  
  Popover Content
</NcPopover>
```

### 3. Provide the attributes as slot props

To manually set them in other cases
- Covers `NcDatetimePicker`, `NcUserBubble`
- Allow very custom popover triggers in some Nextcloud apps

And the same in `NcColorPicker`

```html
<NcPopover>
  <template #trigger="{ attrs }">
    <!-- 🙂 No magic, but we can still just assign attrs --> 
    <button v-bind="attrs">My Very Custom Button</button>
  </template>
  
  Popover Content
</NcPopover>

<NcColorPicker v-slot="attrs">
  <button v-bind="attrs">My Very Custom Color Picker Button</button>
</NcColorPicker>
```

### 4. Add `role` prop to specify the role of the popover

See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup

## 🖼️ Screenshots

| Component / Trigger                                                                                                          | Popover                                                                                                              |
|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
| **NcDateTimePicker**                                                                                                | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/c52c01f3-bbf2-4d6c-ba62-ac2147e625fa) |
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/154cf7d1-4dba-4e5e-8d60-37de380cd654) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/912d5c4e-4978-4883-ae1c-533b3f7bcfca) |
| **NcColorPicker**                                                                                                   | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/6e1b6a63-f97f-4837-9b62-7c3aa2474598) |
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/6b1eaa2e-ec6c-4838-b4aa-c7f5a4db6a71) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/97dcf4a8-7697-4990-88af-7f146dcd5b7e) |
| **Custom NcColorPicker**                                                                                            | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/97f860b7-54a9-4f08-9750-7dcc89ac6c74) |
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/8ed2314c-2cff-4184-a093-d4d4df3737c5) | .                                                                                                                   |
| **NcEmojiPicker**                                                                                                   | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/6edb79cc-b4b7-47bd-9153-ae5c57672f50) |
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/8e90840c-25f7-4bcb-8c67-daaad94b4818) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/06a72ac5-0edd-4c1f-b511-06b3e1324fee) |
| **Custom EmojiPicker**                                                                                              | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e8d71867-6603-4260-bb73-5903c26e2536) |
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/6aa74983-5617-4ef4-9db4-adc45e33d14b) | .                                                                                                                   |
| **NcUserBubble**                                                                                                    | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/215beeb8-c532-414a-9b2f-5e8903cf9e79) |
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/cfb26ccd-1581-4097-9bf5-4e516a1dba74) | .                                                                                                                   |
| **NcActions** - Dialog                                                                                              | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/235a5f99-24e8-47b6-bbac-6da3054f023d) |
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d3b724ca-7fd0-4730-bd09-3b0a6f2d4979) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/7a3b10c6-b8b7-4fd3-aa60-bb15a2d9183a) |
| **NcActions** - Navigation                                                                                          | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/79f091d0-f893-48a5-8b2d-fdff5cbbf49a) |
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/357ae128-fef2-4541-8d07-7d966bb18ad3) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/2185734d-eb0c-4cbe-b3e0-95e551fbf2d2) |
| **NcActions** - Menu                                                                                                | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/b228ceca-6490-41f0-bc3b-8e9ee3288e31) |
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9f8dbd79-0e95-4a11-bd53-db528d4564a3) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9f619659-6c43-404c-9aed-d1d2b22c7e71) |
| **NcPopover** - Custom                                                                                              | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/b1161a91-55e1-4aca-838b-cb90869e8834) | 
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/94a5b1f4-7076-4073-b766-c3d97d439cdc) | .                                                                                                                   |

### What still have to be done manually in place

- For custom trigger button without `NcButton`: `v-slot="{ attrs }" + v-bind="attrs"`
- For `NcPopover` content:
  - `popupRole` on `<NcPopover>`
  - The same `role` on the content
  - `aria-label` or `aria-labelledby` for dialog content

This is where a warning in the `debug` mode helps to find the issue:

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e18af252-2568-47cd-880e-cd3c66e02ad1)

### Alternative solution

Using DOM API by `querySelector` find any `button` in the `#trigger` slot and mutate it.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
