### PR TITLE
fix(NcSelect): remove visual gap on top of the list

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1221,9 +1221,13 @@ body {
 
 .vs__dropdown-menu {
 	border-color: var(--color-main-text) !important;
-	outline: 2px solid var(--color-main-background);
+	outline: none !important;
+	box-shadow:
+		-2px 0 0 var(--color-main-background), // Right
+		0 2px 0 var(--color-main-background), // Bottom
+		2px 0 0 var(--color-main-background), // Left
+		!important;
 	padding: 4px !important;
-	box-shadow: none;
 
 	&--floating {
 		/* Fallback styles overidden by programmatically set inline styles */
@@ -1236,6 +1240,11 @@ body {
 			border-radius: var(--vs-border-radius) var(--vs-border-radius) 0 0 !important;
 			border-top-style: var(--vs-border-style) !important;
 			border-bottom-style: none !important;
+			box-shadow:
+				0 -2px 0 var(--color-main-background), // Top
+				-2px 0 0 var(--color-main-background), // Right
+				2px 0 0 var(--color-main-background), // Left
+				!important
 		}
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/4943

`outline` shows a border on all the sides, including the top, which looks like a gap.

Using `box-shadow` allows adding outline only on 3 sides, except the top.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/bfbbef18-25a1-4d6e-8248-1a58917aa991) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a194ba15-c0fa-43b9-b8ef-d09ed8dc3de3)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
