### PR TITLE
feat(NcProgressBar): add circular progress bar

### DIFF
--- a/src/components/NcProgressBar/NcProgressBar.vue
+++ b/src/components/NcProgressBar/NcProgressBar.vue
@@ -3,6 +3,9 @@
   -
   - @author Marco Ambrosini <marcoambrosini@icloud.com>
   -
+  - @copyright Copyright (c) 2024 Raimund Schlüßler <raimund.schluessler@mailbox.org>
+  - @author Raimund Schlüßler
+  -
   - @license GNU AGPL version 3 or any later version
   -
   - This program is free software: you can redistribute it and/or modify
@@ -23,27 +26,73 @@
 This is a simple progress bar component.
 ## Usage:
 
-### Small
+### Linear
 ```vue
-<NcProgressBar :value="60" />
+<template>
+	<span>
+		Small
+		<NcProgressBar :value="20" />
+		<br>
+		Medium
+		<NcProgressBar :value="60" size="medium" />
+		<br>
+		Medium with color
+		<NcProgressBar :value="55" size="medium" color="green" />
+		<br>
+		Error
+		<NcProgressBar :value="80" :error="true" />
+	</span>
+</template>
 ```
 
-### Medium
+### Circular
 ```vue
-<NcProgressBar :value="60" size="medium" />
+<template>
+	<span>
+		Default
+		<NcProgressBar type="circular" :value="55" />
+		<br />
+		Color
+		<NcProgressBar type="circular" :value="70" color="green" />
+		<br />
+		Error
+		<NcProgressBar type="circular" :value="60" :error="true" />
+	</span>
+</template>
 ```
-
-### error
-```vue
-<NcProgressBar :value="60" :error="true" />
-```
-
 </docs>
 
 <template>
-	<progress class="progress-bar vue"
+	<span v-if="type === 'circular'"
+		role="progressbar"
+		:aria-valuenow="value"
+		:style="{ '--progress-bar-height': height + 'px' }"
 		:class="{ 'progress-bar--error': error }"
-		:style="{'--progress-bar-height': height }"
+		class="progress-bar progress-bar--circular">
+		<svg :height="height"
+			:width="height">
+			<circle stroke="currentColor"
+				fill="transparent"
+				:stroke-dasharray="`${progress * circumference} ${(1 - progress) * circumference}`"
+				:stroke-dashoffset="0.25*circumference"
+				:stroke-width="stroke"
+				:r="radiusNormalized"
+				:cx="radius"
+				:cy="radius" />
+			<circle stroke="var(--color-background-darker)"
+				fill="transparent"
+				:stroke-dasharray="`${(1 - progress) * circumference} ${progress * circumference}`"
+				:stroke-dashoffset="(0.25 - progress) * circumference"
+				:stroke-width="stroke"
+				:r="radiusNormalized"
+				:cx="radius"
+				:cy="radius" />
+		</svg>
+	</span>
+	<progress v-else
+		class="progress-bar progress-bar--linear vue"
+		:class="{ 'progress-bar--error': error }"
+		:style="{'--progress-bar-height': height + 'px' }"
 		:value="value"
 		max="100" />
 </template>
@@ -70,12 +119,14 @@ export default {
 		 * Possible values:
 		 * - 'small' (default)
 		 * - 'medium'
+		 * - Number
+		 * @type {'small'|'medium'|number}
 		 */
 		size: {
-			type: String,
+			type: [String, Number],
 			default: 'small',
 			validator(value) {
-				return ['small', 'medium'].indexOf(value) !== -1
+				return ['small', 'medium'].includes(value) || typeof value === 'number'
 			},
 		},
 		/**
@@ -85,17 +136,55 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		/**
+		 * ProgressBar type
+		 */
+		type: {
+			type: String,
+			default: 'linear',
+			validator(value) {
+				return ['linear', 'circular'].includes(value)
+			},
+		},
+		color: {
+			type: String,
+			default: null,
+		},
+	},
+	data() {
+		return {
+			stroke: 4,
+		}
 	},
 	computed: {
 		height() {
-			if (this.size === 'small') {
-				return '4px'
+			if (this.type === 'circular') {
+				if (Number.isInteger(this.size)) {
+					return this.size
+				}
+				return 44
 			}
-			return '6px'
+			if (this.size === 'small') {
+				return 4
+			} else if (this.size === 'medium') {
+				return 6
+			}
+			return this.size
+		},
+		progress() {
+			return this.value / 100
+		},
+		radius() {
+			return this.height / 2
+		},
+		radiusNormalized() {
+			return this.radius - 3 * this.stroke
+		},
+		circumference() {
+			return this.radiusNormalized * 2 * Math.PI
 		},
 	},
 }
-
 </script>
 
 <style lang="scss" scoped>
@@ -103,27 +192,37 @@ export default {
 .progress-bar {
 	display: block;
 	height: var(--progress-bar-height);
-	width: 100%;
-	overflow: hidden;
-	border: 0;
-	padding: 0;
-	background: var(--color-background-dark);
-	border-radius: calc(var(--progress-bar-height) / 2);
 
-	// Browser specific rules
-	&::-webkit-progress-bar {
-		height: var(--progress-bar-height);
-		background-color: transparent;
-	}
-	&::-webkit-progress-value {
-		background: var(--gradient-primary-background);
+	--progress-bar-color: v-bind(color);
+
+	&--linear {
+		width: 100%;
+		overflow: hidden;
+		border: 0;
+		padding: 0;
+		background: var(--color-background-dark);
 		border-radius: calc(var(--progress-bar-height) / 2);
+
+		// Browser specific rules
+		&::-webkit-progress-bar {
+			height: var(--progress-bar-height);
+			background-color: transparent;
+		}
+		&::-webkit-progress-value {
+			background: var(--progress-bar-color, var(--gradient-primary-background));
+			border-radius: calc(var(--progress-bar-height) / 2);
+		}
+		&::-moz-progress-bar {
+			background: var(--progress-bar-color, var(--gradient-primary-background));
+			border-radius: calc(var(--progress-bar-height) / 2);
+		}
 	}
-	&::-moz-progress-bar {
-		background: var(--gradient-primary-background);
-		border-radius: calc(var(--progress-bar-height) / 2);
+	&--circular {
+		width: var(--progress-bar-height);
+		color: var(--progress-bar-color, var(--color-primary-element));
 	}
 	&--error {
+		color: var(--color-error) !important;
 		// Override previous values
 		&::-moz-progress-bar {
 			background: var(--color-error) !important;


### PR DESCRIPTION
### ☑️ Resolves

* Implement the option to have a circular progress bar for `NcProgressBar`. For this I added the `type` prop to switch between `linear`  and `circular` with `linear` being the default. I also added a `color` prop, to give it a custom color.
* Required for https://github.com/nextcloud/tasks/pull/2464

### 🖼️ Screenshots

No visual changes to existing components, no breaking changes.

![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/25052601-365e-4154-af55-62708856c465)

Used in the Tasks app it looks like this:
![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/f8e62fe0-7822-49cc-98be-0bf5bbd58e48)

