### PR TITLE
fix(NcPopoverTriggerProvider): Make debugging code more defensive

### DIFF
--- a/src/components/NcPopover/NcPopoverTriggerProvider.vue
+++ b/src/components/NcPopover/NcPopoverTriggerProvider.vue
@@ -34,8 +34,8 @@ export default defineComponent({
 	mounted() {
 		if (window.OC?.debug) {
 			const rootElement = this.$el
-			const innerElement = this.$el.querySelector('[aria-expanded][aria-haspopup]')
-			if (!rootElement.getAttribute('aria-expanded') && !innerElement) {
+			const innerElement = this.$el?.querySelector?.('[aria-expanded][aria-haspopup]')
+			if (!rootElement?.getAttribute?.('aria-expanded') && !innerElement) {
 				Vue.util.warn('It looks like you are using a custom button as a <NcPopover> or other popover #trigger. If you are not using <NcButton> as a trigger, you need to bind attrs from the #trigger slot props to your custom button. See <NcPopover> docs for an example.')
 			}
 		}


### PR DESCRIPTION
### ☑️ Resolves

The code asserts that `this.$el` is always set or an `Element` but it is not, so in some cases errors like this could happen:

```
[Vue warn]: Error in mounted hook: "TypeError: this.$el.querySelector is not a function"
```

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/88095b0a-ef1d-4a41-8365-547031c51849)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
