### PR TITLE
Remove inaccessible opacity from SettingsSection

### DIFF
--- a/src/components/NcSettingsSection/NcSettingsSection.vue
+++ b/src/components/NcSettingsSection/NcSettingsSection.vue
@@ -154,17 +154,17 @@ $maxWidth: 900px;
 		// make sure to properly align the icon with the text
 		margin: -$icon-margin;
 		margin-left: 0;
-		opacity: $opacity_normal;
+		color: var(--color-text-maxcontrast);
 
 		&:hover, &:focus, &:active {
-			opacity: $opacity_full;
+			color: var(--color-main-text);
 		}
 	}
 
 	&__desc {
 		margin-top: -.2em;
 		margin-bottom: 1em;
-		opacity: $opacity_normal;
+		color: var(--color-text-maxcontrast);
 		max-width: $maxWidth;
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

* For https://github.com/nextcloud/server/issues/42941

Opacity is a bad choice for a11y in general. Let's remove it.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-01-22 11-21-09](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/1c95523e-c8a9-4549-a743-1e9f145cc283) | ![Screenshot from 2024-01-22 11-21-21](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/2ab4c206-7a99-4b9a-88fa-7cf813bf31e1)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
