### PR TITLE
fix(NcPopover): check trigger a11y compatible with Vue 3

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -178,6 +178,7 @@ See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/
 </template>
 
 <script>
+import Vue from 'vue'
 import { Dropdown } from 'floating-vue'
 import { createFocusTrap } from 'focus-trap'
 import { getTrapStack } from '../../utils/focusTrap.js'
@@ -268,12 +269,32 @@ export default {
 		},
 	},
 
+	mounted() {
+		this.checkTriggerA11y()
+	},
+
 	beforeDestroy() {
 		this.clearFocusTrap()
 		this.clearEscapeStopPropagation()
 	},
 
 	methods: {
+		/**
+		 * Check if the trigger has all required a11y attributes.
+		 * Important to check custom trigger button.
+		 */
+		checkTriggerA11y() {
+			if (window.OC?.debug) {
+				// TODO: Vue 3: should be
+				// this.$refs.popover.$refs.popper.$refs.reference
+				const triggerContainer = this.$refs.popover.$refs.reference
+				const requiredTriggerButton = triggerContainer.querySelector('[aria-expanded][aria-haspopup]')
+				if (!requiredTriggerButton) {
+					Vue.util.warn('It looks like you are using a custom button as a <NcPopover> or other popover #trigger. If you are not using <NcButton> as a trigger, you need to bind attrs from the #trigger slot props to your custom button. See <NcPopover> docs for an example.')
+				}
+			}
+		},
+
 		/**
 		 * @return {HTMLElement|undefined}
 		 */

--- a/src/components/NcPopover/NcPopoverTriggerProvider.vue
+++ b/src/components/NcPopover/NcPopoverTriggerProvider.vue
@@ -1,5 +1,5 @@
 <script>
-import Vue, { computed, defineComponent } from 'vue'
+import { computed, defineComponent } from 'vue'
 
 export default defineComponent({
 	name: 'NcPopoverTriggerProvider',
@@ -29,16 +29,6 @@ export default defineComponent({
 				'aria-expanded': this.shown.toString(),
 			}
 		},
-	},
-
-	mounted() {
-		if (window.OC?.debug) {
-			const rootElement = this.$el
-			const innerElement = this.$el.querySelector('[aria-expanded][aria-haspopup]')
-			if (!rootElement.getAttribute('aria-expanded') && !innerElement) {
-				Vue.util.warn('It looks like you are using a custom button as a <NcPopover> or other popover #trigger. If you are not using <NcButton> as a trigger, you need to bind attrs from the #trigger slot props to your custom button. See <NcPopover> docs for an example.')
-			}
-		}
 	},
 
 	render() {


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/5108
* Alternative to https://github.com/nextcloud-libraries/nextcloud-vue/pull/5104 to keep check in Vue 3

Popover content is usually only the trigger. So no need to check content in a slot component.

Trigger's parent DOM node is accessible by `$refs` of Floating-Vue.

For Vue 3 only requires to change `refs` from Floating-Vue.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable