### PR TITLE
fix(NcPopover): fix docs example

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -123,7 +123,8 @@ See code example below.
 			Hi! 🚀
 		</NcPopover>
 	</div>
-````
+</template>
+```
 
 #### Provide role for the popover content
 
@@ -151,7 +152,7 @@ See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/
 		</NcPopover>
 	</div>
 </template>
-````
+```
 </docs>
 
 <template>


### PR DESCRIPTION
### ☑️ Resolves

Fixes a typo in the `NcPopover` docs. Not critical for vue 2, but breaks the example for vue 3.