### PR TITLE
fix(NcActions): use new slots api

### DIFF
--- a/src/mixins/actionGlobal.js
+++ b/src/mixins/actionGlobal.js
@@ -19,19 +19,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import Vue from 'vue'
-
 export default {
-	before() {
-		// all actions requires a valid text content
-		// if none, forbid the component mount and throw error
-		if (!this.$slots.default || this.text.trim() === '') {
-			Vue.util.warn(`${this.$options.name} cannot be empty and requires a meaningful text content`, this)
-			this.$destroy()
-			this.$el.remove()
-		}
-	},
-
 	beforeUpdate() {
 		this.text = this.getText()
 	},
@@ -52,7 +40,7 @@ export default {
 
 	methods: {
 		getText() {
-			return this.$slots.default ? this.$slots.default[0].text.trim() : ''
+			return this.$scopedSlots.default ? this.$scopedSlots.default()?.[0].text.trim() : ''
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

- Since Vue 2.6 with new slots api, it is guaranteed that `$scopedSlots` has render function for all slots passed any way, while `$slots` only has value when using deprecated API or short-hand syntax
- It also closer to Vue 3 API
- `before` method is removed, there is no such lifecycle hook

It allows dynamically defining text content of the component in template without the need to rewrite the component to render-function.

See: https://v2.vuejs.org/v2/api/#vm-scopedSlots

### 🖼️ Screenshots

When using non-deprecated slots api:

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/17fdbc42-efaf-416c-b97a-71a7dfdf35f0) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/be73d3db-d34e-41e6-853d-6a3c5f71717a)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
