### PR TITLE
fix(header): width regression fixed

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -347,8 +347,8 @@ $externalMargin: 8px;
 	width: var(--header-height);
 	height: var(--header-height);
 
-	&__trigger {
-		width: var(--header-height);
+	#{&}__trigger {
+		width: var(--header-height) !important;
 		height: var(--header-height);
 		opacity: .85;
 


### PR DESCRIPTION
### ☑️ For #5101

### 🖼️ Screenshots

🏡 After
---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/25db9e82-0bd1-4d69-b4fe-d83129e8f341)



### 🚧 Tasks

- [X] The mentioned PR above introduced a regression: the button width became 44px due to NcButton, being `width: 44px !important`. This pr fixes this!


### 🏁 Checklist

- [X] ⛑️ Tests are included or are not applicable
- [X] 📘 Component documentation has been extended, updated or is not applicable
