### PR TITLE
fix: removed groupings in timezone picker

### DIFF
--- a/src/components/NcTimezonePicker/NcTimezonePicker.vue
+++ b/src/components/NcTimezonePicker/NcTimezonePicker.vue
@@ -115,15 +115,18 @@ export default {
 			/**
 			 * Since NcSelect does not support groups,
 			 * we create an object with the grouped timezones and continent labels.
+			 *
+			 * NOTE for now we are removing the grouping from the fields to fix an accessibility issue
+			 * in the future, other options can be introduced to better display the different areas
 			 */
 			let timezonesGrouped = []
 			Object.values(timezoneList).forEach(group => {
 				// Add an entry as group label
-				timezonesGrouped.push({
-					label: group.continent,
-					timezoneId: `tz-group__${group.continent}`,
-					regions: group.regions,
-				})
+				// timezonesGrouped.push({
+				// label: group.continent,
+				// timezoneId: `tz-group__${group.continent}`,
+				// regions: group.regions,
+				// })
 				timezonesGrouped = timezonesGrouped.concat(group.regions)
 			})
 			return timezonesGrouped


### PR DESCRIPTION
### ☑️ For nextcloud/server#41842

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![firefox_zBqhJRiF04](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/dcd5fa47-33da-4827-a738-84c742661aa9)|![firefox_9PTdGieRfq](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/3945c67c-6c02-4ffd-b960-ff386c09ed93)


### 🚧 Tasks

- [x] Removed the groupings from the TimeZone picker. This does two things:

1.  Removes the styling issue presented in the before picture (contrast ratio for the heading of the grouping not being correct. This is due to NcSelect marking the header as a non-selectable element due to us passing in the header as an object)
2. Now leaves us (for later!) to decide how to better organize the groupings better visually, as right now, I personally do not like the presentation of the areas. But that is me, personally, and we can always work on a better design later :)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
