### PR TITLE
fix(NcAvatar): Remove span wrapper button semantics in favour of internal button components

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -226,9 +226,6 @@ msgstr ""
 msgid "online"
 msgstr ""
 
-msgid "Open contact menu"
-msgstr ""
-
 msgid "Open link to \"{resourceName}\""
 msgstr ""
 

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -984,6 +984,7 @@ export default {
 		'close',
 		'focus',
 		'blur',
+		'click',
 	],
 
 	data() {
@@ -1222,6 +1223,17 @@ export default {
 		onBlur(event) {
 			this.$emit('blur', event)
 		},
+		onClick(event) {
+			/**
+			 * Event emitted when the menu toggle button is clicked.
+			 *
+			 * This is e.g. necessary for the NcAvatar component
+			 * which needs to fetch the menu items on click.
+			 *
+			 * @type {PointerEvent}
+			 */
+			this.$emit('click', event)
+		},
 	},
 
 	/**
@@ -1420,6 +1432,7 @@ export default {
 						on: {
 							focus: this.onFocus,
 							blur: this.onBlur,
+							click: this.onClick,
 						},
 					}, [
 						h('template', { slot: 'icon' }, [triggerIcon]),

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -115,16 +115,8 @@ export default {
 			'avatardiv--with-menu': hasMenu,
 			'avatardiv--with-menu-loading': contactsMenuLoading
 		}"
-		:title="tooltip"
 		:style="avatarStyle"
-		class="avatardiv popovermenu-wrapper"
-		:tabindex="hasMenu ? '0' : undefined"
-		:aria-label="avatarAriaLabel"
-		:role="hasMenu ? 'button' : undefined"
-		v-on="hasMenu ? {
-			click: toggleMenu,
-			keydown: toggleMenu,
-		} : null">
+		class="avatardiv popovermenu-wrapper">
 		<!-- @slot Icon slot -->
 		<slot name="icon">
 			<!-- Avatar icon or image -->
@@ -137,10 +129,12 @@ export default {
 
 		<!-- Contact menu -->
 		<!-- We show a button if the menu is not loaded yet. -->
-		<NcButton v-if="hasMenu && !menu.length"
-			:aria-label="t('Open contact menu')"
+		<NcButton v-if="hasMenu && menu.length === 0"
 			type="tertiary-no-background"
-			class="action-item action-item__menutoggle">
+			class="action-item action-item__menutoggle"
+			:aria-label="avatarAriaLabel"
+			:title="tooltip"
+			@click="toggleMenu">
 			<template #icon>
 				<NcLoadingIcon v-if="contactsMenuLoading" />
 				<DotsHorizontal v-else :size="20" />
@@ -151,7 +145,10 @@ export default {
 			manual-open
 			type="tertiary-no-background"
 			:container="menuContainer"
-			:open="contactsMenuOpenState">
+			:open.sync="contactsMenuOpenState"
+			:aria-label="avatarAriaLabel"
+			:title="tooltip"
+			@click="toggleMenu">
 			<NcActionLink v-for="(item, key) in menu"
 				:key="key"
 				:href="item.href"
@@ -747,7 +744,7 @@ export default {
 			cursor: pointer;
 			opacity: 0;
 		}
-		&:focus,
+		&:focus-within,
 		&:hover,
 		&#{&}-loading {
 			:deep(.action-item__menutoggle) {

--- a/tests/unit/components/NcAvatar/NcAvatar.spec.ts
+++ b/tests/unit/components/NcAvatar/NcAvatar.spec.ts
@@ -42,7 +42,7 @@ describe('NcAvatar.vue', () => {
 		await nextTick()
 
 		expect(wrapper.find('.avatardiv__user-status').exists()).toBe(true)
-		expect(wrapper.attributes('aria-label')).toBe('Avatar of J. Doe, online')
+		expect(wrapper.find('.action-item__menutoggle').attributes('aria-label')).toBe('Avatar of J. Doe, online')
 	})
 
 	it('aria label is set to include status even if status is do-not-disturb', async () => {
@@ -63,7 +63,7 @@ describe('NcAvatar.vue', () => {
 		await nextTick()
 
 		expect(wrapper.find('.avatardiv__user-status').exists()).toBe(true)
-		expect(wrapper.attributes('aria-label')).toBe('Avatar of J. Doe, do not disturb')
+		expect(wrapper.find('.action-item__menutoggle').attributes('aria-label')).toBe('Avatar of J. Doe, do not disturb')
 	})
 
 	it('aria label is does not include status if status not shown', async () => {
@@ -85,7 +85,7 @@ describe('NcAvatar.vue', () => {
 		await nextTick()
 
 		expect(wrapper.find('.avatardiv__user-status').exists()).toBe(false)
-		expect(wrapper.attributes('aria-label')).toBe('Avatar of J. Doe')
+		expect(wrapper.find('.action-item__menutoggle').attributes('aria-label')).toBe('Avatar of J. Doe')
 	})
 
 	it('should display initials for user id', async () => {


### PR DESCRIPTION
### ☑️ Resolves

- For https://github.com/nextcloud/server/issues/42957

### Summary

<details>
<summary>Previous iteration</summary>

- Previously the tab sequence would go from wrapper span[role="button"] -> action menu button -> next element on page. Only the span focus would show visual focus while the action menu button had none so there would appear to be a gap in the tab sequence.
- W3 states that "a button element allows phrasing content as descendants, and does not allow interactive content or descendants with a tabindex attribute. Therefore, any elements specified with a role=button would follow the same descendant restrictions, and not allow any interactive content descendants, elements with a tabindex specified, or any elements with role values that are in the interactive content category" -https://www.w3.org/TR/html-aria/#allowed-descendants-of-aria-roles
- The buttons inside span[role="button"] would be classified as interactive content and so is invalid HTML
- Setting tabindex="-1" would violate the above requirement and only removes sequential focus but not focusability via click or programmatic .focus()
- The NcAvatar wrapper span acts as a button with role="button" + event listeners and for the purposes of this component should be the only interative element which programmatically activates NcActions. This makes direct interaction on the NcActions button redundant.
- All descendants of a role="button" element implictly have role="presenation" but because browsers ignore role="presentation" on focusable elements (the buttons) we have to set inert explicitly
- This inert fix corrects the invalid HTML and removes redundant behaviour

</details>

- Remove button semantics from span wrapper
- Fixes focus return on Escape from menu
- Uses button semantics from internal button components

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable