### PR TITLE
fix(fields): adjust label line-height

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -468,6 +468,7 @@ export default {
 	&__input:focus + &__label,
 	&__input:not(:placeholder-shown) + &__label {
 		inset-block-start: -10px;
+		line-height: 1.5; // minimum allowed line height for accessibility
 		font-size: 13px; // minimum allowed font size for accessibility
 		font-weight: 500;
 		border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0;

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -871,6 +871,7 @@ export default {
 	&__input:focus + &__label,
 	&__input:not(&__input--empty) + &__label {
 		inset-block-start: -10px;
+		line-height: 1.5; // minimum allowed line height for accessibility
 		font-size: 13px; // minimum allowed font size for accessibility
 		font-weight: 500;
 		border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0;

--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -396,6 +396,7 @@ export default {
 	&__input:focus + &__label,
 	&__input:not(:placeholder-shown) + &__label {
 		inset-block-start: -10px;
+		line-height: 1.5; // minimum allowed line height for accessibility
 		font-size: 13px; // minimum allowed font size for accessibility
 		font-weight: 500;
 		color: var(--color-main-text);


### PR DESCRIPTION
Before, it had the same line-height in docs, but server has different styles.
See: https://github.com/nextcloud-libraries/nextcloud-vue/pull/5132

Manually set the same line-height, which is the minimum allowed for a11y and was supposed to be set during development.

### ☑️ Resolves

* Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/5128

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/b9c3420f-f7a9-4c4c-a792-1dd2dc5c79f2) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/1df0992b-01ee-4dc1-a7d7-dd246970e849)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
