### PR TITLE
fix(NcMentionBubble): inject component styles in NcRichContenteditable

### DIFF
--- a/src/assets/NcMentionBubble.scss
+++ b/src/assets/NcMentionBubble.scss
@@ -1,0 +1,69 @@
+$bubble-height: 20px;
+$bubble-max-width: 150px;
+$bubble-padding: 2px;
+$bubble-avatar-size: $bubble-height - 2 * $bubble-padding;
+
+@mixin mention-bubble {
+	.mention-bubble--primary .mention-bubble__content {
+		color: var(--color-primary-element-text);
+		background-color: var(--color-primary-element);
+	}
+
+	.mention-bubble__wrapper {
+		max-width: $bubble-max-width;
+		// Align with text
+		height: $bubble-height - $bubble-padding;
+		vertical-align: text-bottom;
+		display: inline-flex;
+		align-items: center;
+	}
+
+	// Should be in both places
+	.mention-bubble__content {
+		display: inline-flex;
+		overflow: hidden;
+		align-items: center;
+		max-width: 100%;
+		height: $bubble-height;
+		-webkit-user-select: none;
+		user-select: none;
+		padding-right: $bubble-padding * 3;
+		padding-left: $bubble-padding;
+		border-radius: math.div($bubble-height, 2);
+		background-color: var(--color-background-dark);
+	}
+
+	.mention-bubble__icon {
+		position: relative;
+		width: $bubble-avatar-size;
+		height: $bubble-avatar-size;
+		border-radius: math.div($bubble-avatar-size, 2);
+		background-color: var(--color-background-darker);
+		background-repeat: no-repeat;
+		background-position: center;
+		background-size: $bubble-avatar-size - 2 * $bubble-padding;
+
+		&--with-avatar {
+			color: inherit;
+			background-size: cover;
+		}
+	}
+
+	.mention-bubble__title {
+		overflow: hidden;
+		margin-left: $bubble-padding;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		// Put title in ::before so it is not selectable
+		&::before {
+			content: attr(title);
+		}
+	}
+
+	// Hide the mention id so it is selectable
+	.mention-bubble__select {
+		position: absolute;
+		z-index: -1;
+		left: -1000px;
+	}
+}

--- a/src/components/NcRichContenteditable/NcMentionBubble.vue
+++ b/src/components/NcRichContenteditable/NcMentionBubble.vue
@@ -101,73 +101,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-$bubble-height: 20px;
-$bubble-max-width: 150px;
-$bubble-padding: 2px;
-$bubble-avatar-size: $bubble-height - 2 * $bubble-padding;
+@import '../../assets/NcMentionBubble';
 
 .mention-bubble {
-	&--primary &__content {
-		color: var(--color-primary-element-text);
-		background-color: var(--color-primary-element);
-	}
-
-	&__wrapper {
-		max-width: $bubble-max-width;
-		// Align with text
-		height: $bubble-height - $bubble-padding;
-		vertical-align: text-bottom;
-		display: inline-flex;
-		align-items: center;
-	}
-
-	&__content {
-		display: inline-flex;
-		overflow: hidden;
-		align-items: center;
-		max-width: 100%;
-		height: $bubble-height ;
-		-webkit-user-select: none;
-		user-select: none;
-		padding-right: $bubble-padding * 3;
-		padding-left: $bubble-padding;
-		border-radius: math.div($bubble-height, 2);
-		background-color: var(--color-background-dark);
-	}
-
-	&__icon {
-		position: relative;
-		width: $bubble-avatar-size;
-		height: $bubble-avatar-size;
-		border-radius: math.div($bubble-avatar-size, 2);
-		background-color: var(--color-background-darker);
-		background-repeat: no-repeat;
-		background-position: center;
-		background-size: $bubble-avatar-size - 2 * $bubble-padding;
-
-		&--with-avatar {
-			color: inherit;
-			background-size: cover;
-		}
-	}
-
-	&__title {
-		overflow: hidden;
-		margin-left: $bubble-padding;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-		// Put title in ::before so it is not selectable
-		&::before {
-			content: attr(title);
-		}
-	}
-
-	// Hide the mention id so it is selectable
-	&__select {
-		position: absolute;
-		z-index: -1;
-		left: -1000px;
-	}
+	@include mention-bubble;
 }
-
 </style>

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -845,6 +845,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../assets/NcMentionBubble';
+
 // Standalone styling, independent from server
 .rich-contenteditable {
 	position: relative;
@@ -934,6 +936,11 @@ export default {
 			border-radius: var(--border-radius);
 			background-color: var(--color-background-dark);
 		}
+	}
+
+	// Inject NcMentionBubble styles
+	:deep(.mention-bubble) {
+		@include mention-bubble;
 	}
 }
 

--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -122,6 +122,7 @@ export default {
 			}
 
 			// Return template and make sure we strip of new lines and tabs
+			// Make sure to @include mention-bubble mixin in the component style template, where this method is used
 			return this.renderComponentHtml(data, NcMentionBubble).replace(/[\n\t]/gmi, '')
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

* Fix #4901
  * :-1: `genSelectTemplate` returns a HTML template of NcMentionBubble component with scoped style attribute `data-v-123`, but these styles are not included in the bundled chunk for some reason
  * :-1: Because of that, NcRichContenteditable renders mention template as expected, but without applied styles
  * :+1: PR extracts NcMentionBubble styles to a mixin, so it could be included in every needed component to its scoped styles like this:
```css
@import '../../assets/NcMentionBubble';
:deep(.mention-bubble) {
	@include mention-bubble;
}
```
Drawback: because NcMentionBubble is still imported by richeditor mixin, styles in the compiled JS file are duplicated, but it's about 7 style rules, so lesser evil :imp: 

Tested with Talk chat, Files comments, and should be applicable for other apps

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/2ef2f812-c479-4834-82a5-37b32e78dcad) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/40780d2a-d790-4125-a08b-1b4d290ffd68)
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/25436146-7dc1-4301-a2d7-b38b48df2d1d) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/f17686dd-f84d-4a9e-bae5-63402ed71395)

_For Files, name/label is not provided on server-side -> unrelated to this PR_

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
