### PR TITLE
fix(NcPopover): a11y attrs provide-inject reactivity

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -440,9 +440,9 @@ export default {
 	name: 'NcButton',
 
 	inject: {
-		ncPopoverTriggerAttrs: {
+		getNcPopoverTriggerAttrs: {
 			from: 'NcPopover:trigger:attrs',
-			default: () => ({}),
+			default: () => () => ({}),
 		},
 	},
 
@@ -599,6 +599,10 @@ export default {
 		 */
 		isReverseAligned() {
 			return this.alignment.includes('-')
+		},
+
+		ncPopoverTriggerAttrs() {
+			return this.getNcPopoverTriggerAttrs()
 		},
 	},
 

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -157,13 +157,14 @@ See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/
 
 <template>
 	<Dropdown ref="popover"
-		:shown.sync="shownProxy"
 		:distance="10"
 		:arrow-padding="10"
 		v-bind="$attrs"
 		:no-auto-focus="true /* Handled by the focus trap */"
 		:popper-class="popoverBaseClass"
+		:shown="internalShown"
 		v-on="$listeners"
+		@update:shown="internalShown = $event"
 		@apply-show="afterShow"
 		@apply-hide="afterHide">
 		<NcPopoverTriggerProvider v-slot="slotProps" :shown="internalShown" :popup-role="popupRole">
@@ -252,21 +253,13 @@ export default {
 		}
 	},
 
-	computed: {
-		shownProxy: {
-			get() {
-				return this.shown
-			},
-			set(value) {
-				this.internalShown = value
-				this.$emit('update:shown', value)
-			},
-		},
-	},
-
 	watch: {
 		shown(value) {
 			this.internalShown = value
+		},
+
+		internalShown(value) {
+			this.$emit('update:shown', value)
 		},
 	},
 

--- a/src/components/NcPopover/NcPopoverTriggerProvider.vue
+++ b/src/components/NcPopover/NcPopoverTriggerProvider.vue
@@ -1,13 +1,13 @@
 <script>
-import { computed, defineComponent } from 'vue'
+import { defineComponent } from 'vue'
 
 export default defineComponent({
 	name: 'NcPopoverTriggerProvider',
 
 	provide() {
 		return {
-			'NcPopover:trigger:shown': computed(() => this.shown),
-			'NcPopover:trigger:attrs': computed(() => this.triggerAttrs),
+			'NcPopover:trigger:shown': () => this.shown,
+			'NcPopover:trigger:attrs': () => this.triggerAttrs,
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

Though it must be fine in Vue 3.3+, for some reason, sometimes `computed` in `provide/inject` is not reactive.

It works in `docs`, in `server`, in `Talk`. But it doesn't work in `Text`...

We had a similar issue with provide/inject in `NcSidebarTabs` in past.

@raimund-schluessler I also included a small fix with `internalShown` based on your comment somewhere

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
