### PR TITLE
feat: Implement widget flag for requesting interactive view

### DIFF
--- a/src/components/NcRichText/NcReferenceList.vue
+++ b/src/components/NcRichText/NcReferenceList.vue
@@ -34,6 +34,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		interactive: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -60,7 +64,12 @@ export default {
 			return this.values[0] ?? null
 		},
 		displayedReferences() {
-			return this.values.slice(0, this.limit)
+			return this.values.slice(0, this.limit).map(reference => {
+				return {
+					...reference,
+					interactive: this.interactive,
+				}
+			})
 		},
 		fallbackReference() {
 			return {

--- a/src/components/NcRichText/widgets.js
+++ b/src/components/NcRichText/widgets.js
@@ -19,7 +19,7 @@ const registerWidget = (id, callback, onDestroy = (el) => {}) => {
 	}
 }
 
-const renderWidget = (el, { richObjectType, richObject, accessible }) => {
+const renderWidget = (el, { richObjectType, richObject, accessible, interactive }) => {
 	if (richObjectType === 'open-graph') {
 		return
 	}
@@ -29,7 +29,7 @@ const renderWidget = (el, { richObjectType, richObject, accessible }) => {
 		return
 	}
 
-	window._vue_richtext_widgets[richObjectType].callback(el, { richObjectType, richObject, accessible })
+	window._vue_richtext_widgets[richObjectType].callback(el, { richObjectType, richObject, accessible, interactive })
 }
 
 const destroyWidget = (richObjectType, el) => {


### PR DESCRIPTION
### ☑️ Resolves

* Fix #5090 

Allow apps that display link previews to pass in if they want to request interactive link previews or not. We default to false to not have any breaking behaviour for apps. When apps register a preview render function with `registerWidget` they can then handle either the non-interactive or interactive view based on that flag. Apps not handling this will just fallback to the existing preview rendering that is currently in place already.

### Render interactive widgets as link preview

Just pass in the interactive property to the NcReferenceList component

```
<NcReferenceList :text="'https://nextcloud.com/f/1234'" :interactive="true" />
```

### Render interactive widgets as reference provider

```
registerWidget('deck-board', (el, { richObjectType, richObject, accessible, interactive }) => {
	if (interactive) {
		// render interactive component to el
		return
	}
	// existing custom render functionality
})

```

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
