### PR TITLE
fix: app-navigation-toggle remains on screen on small viewports

### DIFF
--- a/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
+++ b/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
@@ -55,6 +55,11 @@ export default {
 	},
 
 	props: {
+		/**
+		 * Tracks whether the toggle has been clicked or not.
+		 * If it has been clicked, switches between the different MenuIcons
+		 * and emits a boolean indicating its opened status
+		 */
 		open: {
 			type: Boolean,
 			required: true,
@@ -69,6 +74,10 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * Once the toggle has been clicked, emits the toggle status
+		 * so parent components can gauge the status of the navigation button
+		 */
 		toggleNavigation() {
 			this.$emit('update:open', !this.open)
 		},


### PR DESCRIPTION
### ☑️ For nextcloud/photos#2278

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![firefox_lHUQ9YnsiM](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/c33b4e2d-b776-4cd3-a5d2-cf59a0c0e4bb)|![firefox_mBytSzpcFp](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/39db677a-83f1-4b20-b300-93ae721ca327)



### 🚧 Tasks

This has the same changes from nextcloud/photos#2285

- When the viewport got small in the photos app, the app-navigation-button overflowed to the right of the screen, becoming inaccessible
- To fix this, since the button is positioned relative to the header, I removed some of the negative right positioning on the button

This allows the button to still be in view, while a little tight, and also still allows it to be found with keyboard navigation 👍
Any styling choices can be commented on !

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable

