### PR TITLE
fix: button size regression on small viewports fixed

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -348,7 +348,7 @@ $externalMargin: 8px;
 	height: var(--header-height);
 
 	#{&}__trigger {
-		width: var(--header-height) !important;
+		width: 100% !important;
 		height: var(--header-height);
 		opacity: .85;
 
@@ -412,10 +412,6 @@ $externalMargin: 8px;
 @media only screen and (max-width: $breakpoint-small-mobile) {
 	.header-menu {
 		width: $clickable-area;
-
-		&__trigger {
-			width: $clickable-area;
-		}
 	}
 }
 </style>


### PR DESCRIPTION
### ☑️ For #5129

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/7f042758-d854-4333-b385-160a372cffc1)|![firefox_I6ssjqt0MZ](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/5a5f3714-fae4-49ab-a2d1-28c904ba7890)



### 🚧 Tasks
Regression for the aforementioned PR

- On small viewports, the button nested inside the wrapper for NcHeaderMenu stayed 50x50 px. This change ensures that the trigger button is the same size as the wrapper component on small viewports, which is 44x50 px. This now keeps the styling on the server consistent and working!

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
