### PR TITLE
fix(NcCheckboxRadioSwitch): On button style align the text vertically

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -224,6 +224,8 @@ export default {
 
 	&__text {
 		flex: 1 0;
+		display: flex;
+		align-items: center;
 
 		&:empty {
 			// hide text if empty to ensure checkbox outline is a circle instead of oval


### PR DESCRIPTION
### ☑️ Resolves

The text was not correctly centered, see below

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot_20240126_202347](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/d4d32f9b-ca8a-4c1a-a3cb-3e8790bbdae9)|![Screenshot_20240126_202421](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/2882bdf1-788e-468d-af7e-97d24f5cb56e)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
