### PR TITLE
chore: Prepare 8.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v8.5.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.5.1) (2024-01-24)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.5.0...v8.5.1)
+
+### 🐛 Fixed bugs
+* fix(NcPopover): a11y attrs provide-inject reactivity [\#5142](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5142) \([ShGKme](https://github.com/ShGKme)\)
+* fix(NcCheckboxRadioSwitch): On button style align the text vertically [\#5151](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5151) \([susnux](https://github.com/susnux)\)
+* fix: removed groupings in timezone picker [\#5130](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5130) \([emoral435](https://github.com/emoral435)\)
+* fix(fields): adjust label line-height [\#5133](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5133) \([ShGKme](https://github.com/ShGKme)\)
+* fix(header): width regression fixed [\#5129](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5129) \([emoral435](https://github.com/emoral435)\)
+* fix(NcCheckboxRadioSwitch): Make sure to include current value in checked array [\#5150](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5150) \([susnux](https://github.com/susnux)\)
+* fix: Ensure no double scrollbars for NcDialog and NcAppNavigationSettings [\#5139](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5139) \([susnux](https://github.com/susnux)\)
+
+### Other Changes
+* Updated translation
+* chore: Fix missing PR from changelog [\#5125](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5125) \([Pytal](https://github.com/Pytal)\)
+* chore: Migrate cypress config to vite instead of webpack [\#4961](https://github.com/nextcloud-libraries/nextcloud-vue/pull/4961) \([susnux](https://github.com/susnux)\)
+* chore(styleguide): set line-height from server styles [\#5132](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5132) \([ShGKme](https://github.com/ShGKme)\)
+
 ## [v8.5.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.5.0) (2024-01-23)
-[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.5.0...v8.4.0)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.4.0...v8.5.0)
 
 ### 🚀 Enhancements
 * enh(NcSelect): Add visible input label by @Pytal in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4963

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.5.0",
+      "version": "8.5.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v8.5.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.5.1) (2024-01-24)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.5.0...v8.5.1)

### 🐛 Fixed bugs
* fix(NcPopover): a11y attrs provide-inject reactivity [\#5142](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5142) \([ShGKme](https://github.com/ShGKme)\)
* fix(NcCheckboxRadioSwitch): On button style align the text vertically [\#5151](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5151) \([susnux](https://github.com/susnux)\)
* fix: removed groupings in timezone picker [\#5130](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5130) \([emoral435](https://github.com/emoral435)\)
* fix(fields): adjust label line-height [\#5133](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5133) \([ShGKme](https://github.com/ShGKme)\)
* fix(header): width regression fixed [\#5129](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5129) \([emoral435](https://github.com/emoral435)\)
* fix(NcCheckboxRadioSwitch): Make sure to include current value in cheched array [\#5150](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5150) \([susnux](https://github.com/susnux)\)
* fix: Ensure no double scrollbars for NcDialog and NcAppNavigationSettings [\#5139](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5139) \([susnux](https://github.com/susnux)\)

### Other Changes
* Updated translation
* chore: Fix missing PR from changelog [\#5125](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5125) \([Pytal](https://github.com/Pytal)\)
* chore: Migrate cypress config to vite instead of webpack [\#4961](https://github.com/nextcloud-libraries/nextcloud-vue/pull/4961) \([susnux](https://github.com/susnux)\)
* chore(styleguide): set line-height from server styles [\#5132](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5132) \([ShGKme](https://github.com/ShGKme)\)