### PR TITLE
fix(NcActions): keyboard navigation

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1020,15 +1020,24 @@ export default {
 
 	methods: {
 		/**
+		 * Get the name of the action component
+		 *
+		 * @param {import('vue').VNode} action - a vnode with a NcAction* component instance
+		 * @return {string} the name of the action component
+		 */
+		getActionName(action) {
+			return action?.componentOptions?.Ctor?.extendOptions?.name ?? action?.componentOptions?.tag
+		},
+
+		/**
 		 * Do we have exactly one Action and
 		 * is it allowed as a standalone element?
 		 *
-		 * @param {Array} action The action to check
+		 * @param {import('vue').VNode} action The action to check
 		 * @return {boolean}
 		 */
 		isValidSingleAction(action) {
-			const componentName = action?.componentOptions?.Ctor?.extendOptions?.name ?? action?.componentOptions?.tag
-			return ['NcActionButton', 'NcActionLink', 'NcActionRouter'].includes(componentName)
+			return ['NcActionButton', 'NcActionLink', 'NcActionRouter'].includes(this.getActionName(action))
 		},
 
 		/**
@@ -1236,19 +1245,20 @@ export default {
 		 * This also ensure that we don't get 'text' elements, which would
 		 * become problematic later on.
 		 */
-		const actions = (this.$slots.default || []).filter(
-			action => action?.componentOptions?.tag || action?.componentOptions?.Ctor?.extendOptions?.name,
-		)
+		const actions = (this.$slots.default || []).filter(action => this.getActionName(action))
 
-		const getActionName = (action) => action?.componentOptions?.Ctor?.extendOptions?.name ?? action?.componentOptions?.tag
+		// Check that we have at least one action
+		if (actions.length === 0) {
+			return
+		}
 
 		const menuItemsActions = ['NcActionButton', 'NcActionButtonGroup', 'NcActionCheckbox', 'NcActionRadio']
 		const textInputActions = ['NcActionInput', 'NcActionTextEditable']
 		const linkActions = ['NcActionLink', 'NcActionRouter']
 
-		const hasTextInputAction = actions.some(action => textInputActions.includes(getActionName(action)))
-		const hasMenuItemAction = actions.some(action => menuItemsActions.includes(getActionName(action)))
-		const hasLinkAction = actions.some(action => linkActions.includes(getActionName(action)))
+		const hasTextInputAction = actions.some(action => textInputActions.includes(this.getActionName(action)))
+		const hasMenuItemAction = actions.some(action => menuItemsActions.includes(this.getActionName(action)))
+		const hasLinkAction = actions.some(action => linkActions.includes(this.getActionName(action)))
 
 		// We consider the NcActions to have role="menu" if it consists some button-like action and not text inputs
 		this.isSemanticMenu = hasMenuItemAction && !hasTextInputAction
@@ -1270,11 +1280,6 @@ export default {
 		if (this.forceMenu && inlineActions.length > 0 && this.inline > 0) {
 			Vue.util.warn('Specifying forceMenu will ignore any inline actions rendering.')
 			inlineActions = []
-		}
-
-		// Check that we have at least one action
-		if (actions.length === 0) {
-			return
 		}
 
 		/**

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1274,13 +1274,25 @@ export default {
 				: 'true'
 
 		/**
-		 * Filter and list actions that are allowed to be displayed inline
+		 * Separate the actions into inline and menu actions
+		 */
+
+		/**
+		 * @type {import('vue').VNode[]}
 		 */
 		let validInlineActions = actions.filter(this.isValidSingleAction)
 		if (this.forceMenu && validInlineActions.length > 0 && this.inline > 0) {
 			Vue.util.warn('Specifying forceMenu will ignore any inline actions rendering.')
 			validInlineActions = []
 		}
+		/**
+		 * @type {import('vue').VNode[]}
+		 */
+		const inlineActions = validInlineActions.slice(0, this.inline)
+		/**
+		 * @type {import('vue').VNode[]}
+		 */
+		const menuActions = actions.filter(action => !inlineActions.includes(action))
 
 		/**
 		 * Render the provided action
@@ -1463,7 +1475,7 @@ export default {
 		 * we render the action as a standalone button
 		 */
 		if (actions.length === 1 && validInlineActions.length === 1 && !this.forceMenu) {
-			return renderInlineAction(validInlineActions[0])
+			return renderInlineAction(actions[0])
 		}
 
 		// If we completely re-render the children
@@ -1481,10 +1493,7 @@ export default {
 		/**
 		 * If we some inline actions to render, render them, then the menu
 		 */
-		if (validInlineActions.length > 0 && this.inline > 0) {
-			const inlineActions = validInlineActions.slice(0, this.inline)
-			// Filter already rendered actions
-			const menuActions = actions.filter(action => !inlineActions.includes(action))
+		if (inlineActions.length > 0 && this.inline > 0) {
 			return h('div',
 				{
 					class: [

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1276,10 +1276,10 @@ export default {
 		/**
 		 * Filter and list actions that are allowed to be displayed inline
 		 */
-		let inlineActions = actions.filter(this.isValidSingleAction)
-		if (this.forceMenu && inlineActions.length > 0 && this.inline > 0) {
+		let validInlineActions = actions.filter(this.isValidSingleAction)
+		if (this.forceMenu && validInlineActions.length > 0 && this.inline > 0) {
 			Vue.util.warn('Specifying forceMenu will ignore any inline actions rendering.')
-			inlineActions = []
+			validInlineActions = []
 		}
 
 		/**
@@ -1462,8 +1462,8 @@ export default {
 		 * If we have a single action only and didn't force a menu,
 		 * we render the action as a standalone button
 		 */
-		if (actions.length === 1 && inlineActions.length === 1 && !this.forceMenu) {
-			return renderInlineAction(inlineActions[0])
+		if (actions.length === 1 && validInlineActions.length === 1 && !this.forceMenu) {
+			return renderInlineAction(validInlineActions[0])
 		}
 
 		// If we completely re-render the children
@@ -1481,10 +1481,10 @@ export default {
 		/**
 		 * If we some inline actions to render, render them, then the menu
 		 */
-		if (inlineActions.length > 0 && this.inline > 0) {
-			const renderedInlineActions = inlineActions.slice(0, this.inline)
+		if (validInlineActions.length > 0 && this.inline > 0) {
+			const inlineActions = validInlineActions.slice(0, this.inline)
 			// Filter already rendered actions
-			const menuActions = actions.filter(action => !renderedInlineActions.includes(action))
+			const menuActions = actions.filter(action => !inlineActions.includes(action))
 			return h('div',
 				{
 					class: [
@@ -1494,7 +1494,7 @@ export default {
 				},
 				[
 					// Render inline actions
-					...renderedInlineActions.map(renderInlineAction),
+					...inlineActions.map(renderInlineAction),
 					// render the rest within the popover menu
 					menuActions.length > 0
 						? h('div',

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -4,6 +4,7 @@
   - @author John Molakvoæ <skjnldsv@protonmail.com>
   - @author Marco Ambrosini <marcoambrosini@icloud.com>
   - @author Raimund Schlüßler <raimund.schluessler@mailbox.org>
+  - @author Grigorii K. Shartsev <me@shgk.me>
   -
   - @license GNU AGPL version 3 or any later version
   -
@@ -1252,27 +1253,6 @@ export default {
 			return
 		}
 
-		const menuItemsActions = ['NcActionButton', 'NcActionButtonGroup', 'NcActionCheckbox', 'NcActionRadio']
-		const textInputActions = ['NcActionInput', 'NcActionTextEditable']
-		const linkActions = ['NcActionLink', 'NcActionRouter']
-
-		const hasTextInputAction = actions.some(action => textInputActions.includes(this.getActionName(action)))
-		const hasMenuItemAction = actions.some(action => menuItemsActions.includes(this.getActionName(action)))
-		const hasLinkAction = actions.some(action => linkActions.includes(this.getActionName(action)))
-
-		// We consider the NcActions to have role="menu" if it consists some button-like action and not text inputs
-		this.isSemanticMenu = hasMenuItemAction && !hasTextInputAction
-		// We consider the NcActions to be navigation if it consists some link-like action
-		this.isSemanticNavigation = hasLinkAction && !hasMenuItemAction && !hasTextInputAction
-		// If it is not a menu and not a navigation, it is a popover with items: a form or just a text
-		this.isSemanticPopoverLike = !this.isSemanticMenu && !this.isSemanticNavigation
-
-		const popupRole = this.isSemanticMenu
-			? 'menu'
-			: hasTextInputAction
-				? 'dialog'
-				: 'true'
-
 		/**
 		 * Separate the actions into inline and menu actions
 		 */
@@ -1293,6 +1273,32 @@ export default {
 		 * @type {import('vue').VNode[]}
 		 */
 		const menuActions = actions.filter(action => !inlineActions.includes(action))
+
+		/**
+		 * Determine what kind of menu we have.
+		 * It defines focus behavior and a11y.
+		 */
+
+		const menuItemsActions = ['NcActionButton', 'NcActionButtonGroup', 'NcActionCheckbox', 'NcActionRadio']
+		const textInputActions = ['NcActionInput', 'NcActionTextEditable']
+		const linkActions = ['NcActionLink', 'NcActionRouter']
+
+		const hasTextInputAction = menuActions.some(action => textInputActions.includes(this.getActionName(action)))
+		const hasMenuItemAction = menuActions.some(action => menuItemsActions.includes(this.getActionName(action)))
+		const hasLinkAction = menuActions.some(action => linkActions.includes(this.getActionName(action)))
+
+		// We consider the NcActions to have role="menu" if it consists some button-like action and not text inputs
+		this.isSemanticMenu = hasMenuItemAction && !hasTextInputAction
+		// We consider the NcActions to be navigation if it consists some link-like action
+		this.isSemanticNavigation = hasLinkAction && !hasMenuItemAction && !hasTextInputAction
+		// If it is not a menu and not a navigation, it is a popover with items: a form or just a text
+		this.isSemanticPopoverLike = !this.isSemanticMenu && !this.isSemanticNavigation
+
+		const popupRole = this.isSemanticMenu
+			? 'menu'
+			: hasTextInputAction
+				? 'dialog'
+				: 'true'
 
 		/**
 		 * Render the provided action


### PR DESCRIPTION
### ☑️ Resolves

* Fix - see comment https://github.com/nextcloud-libraries/nextcloud-vue/pull/4953#pullrequestreview-1845179797

Fixes keyboard navigation in two cases:
1. When a menu type is determined incorrect because **inline actions** were taken into account
   - E.g. where is an inline button and we thought, it is in the menu
2. Correctly handle <kbd>Tab</kbd> blur, when there is no focusable element in the actions

There are quite a lot of changes.

Separated with 💙 into small commits to be easier to review.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before-tab](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e1d5e524-f745-4a87-9c16-9680e8020c1e) | ![after-tab](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/12d7357d-69b0-421f-b748-53bfe5a1aec9)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
