### PR TITLE
feat(NcPopover): auto return focus to trigger button on close

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1894,7 +1894,7 @@ export default {
 						container: this.container,
 						popoverBaseClass: 'action-item__popper',
 						popupRole: this.config.popupRole,
-						setReturnFocus: this.config.withFocusTrap ? this.$refs.triggerButton?.$el : null,
+						noAutoReturnFocus: !this.withFocusTrap,
 						focusTrap: this.config.withFocusTrap,
 					},
 					// For some reason the popover component


### PR DESCRIPTION
### ☑️ Resolves

* Fix #5141

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [x] Automatically find a button inside the `NcPopover` trigger and use it as fallback for `setReturnFocus`
- [x] Add `noAutoReturnFocus` to optionally disable this behavior
  - Useful when there is a custom focus control, like in `NcActions`
- [ ] Adjust `NcActions`

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
