### PR TITLE
fix: Update emoji-mart-vue-fast to make skin tone selector reactive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "clone": "^2.1.2",
         "debounce": "2.0.0",
         "dompurify": "^3.0.5",
-        "emoji-mart-vue-fast": "^15.0.0",
+        "emoji-mart-vue-fast": "^15.0.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",
         "focus-trap": "^7.4.3",
@@ -10722,9 +10722,9 @@
       }
     },
     "node_modules/emoji-mart-vue-fast": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.0.tgz",
-      "integrity": "sha512-3BzkDrs60JyT00dLHMAxWKbpFhbyaW9C+q1AjtqGovSxTu8TC2mYAGsvTmXNYKm39IRRAS56v92TihOcB98IsQ==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.1.tgz",
+      "integrity": "sha512-FcBio4MZsad+IwbaD2+1/obaK7W0F8EXlVXOXKgNCICaxkJD5WnA5bAtSXR0+FSBrMWz7DCAOqOojm7EapZ1eg==",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "core-js": "^3.23.5"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "clone": "^2.1.2",
     "debounce": "2.0.0",
     "dompurify": "^3.0.5",
-    "emoji-mart-vue-fast": "^15.0.0",
+    "emoji-mart-vue-fast": "^15.0.1",
     "escape-html": "^1.0.3",
     "floating-vue": "^1.0.0-beta.19",
     "focus-trap": "^7.4.3",


### PR DESCRIPTION
### ☑️ Resolves

* Follow up on #5103 to make the selector reactive

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
