### PR TITLE
fix(NcSelect): list width on page scaling

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -968,6 +968,7 @@ export default {
 						Object.assign(dropdownMenu.style, {
 							left: `${x}px`,
 							top: `${y}px`,
+							width: `${component.$refs.toggle.getBoundingClientRect().width}px`,
 						})
 					})
 				}


### PR DESCRIPTION
By default Vue-Select takes width for content list on element insert.
But if select is resized after opening (for example, on page scale), that width is not actual anymore.
Manually set width according to the toggle element on update.

The current solution is a bit glitchy when select has flexible width. Not sure, how to fix better.

### ☑️ Resolves

* Fix #4943

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![select-before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9ac559a3-9167-46a6-aa53-55f7725da2b0) | ![select-after](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a325fc59-3dff-47a8-8b41-6a451acdf3df)
![select-before-2](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/fe4a492d-d90f-4265-a33d-0f55a47c0924) | ![select-after-2](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d3b866c6-71b1-474f-b76a-99af312e9f4b)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
