### PR TITLE
[next] fix(NcAppSidebar): adjust animation class names

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -1146,12 +1146,12 @@ $top-buttons-spacing: 6px;
 }
 
 .slide-right-enter-to,
-.slide-right-leave {
+.slide-right-leave-from {
 	min-width: $sidebar-min-width;
 	max-width: $sidebar-max-width;
 }
 
-.slide-right-enter,
+.slide-right-enter-from,
 .slide-right-leave-to {
 	min-width: 0 !important;
 	max-width: 0 !important;


### PR DESCRIPTION
### ☑️ Resolves

* This PR fixes the animation class names of `NcAppSidebar`. The names were changed with vue 3, see here https://v3-migration.vuejs.org/breaking-changes/transition.html