### PR TITLE
chore(deps): bump nextcloud-vite-config library from 1.2.0 to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@nextcloud/browserslist-config": "^3.0.0",
         "@nextcloud/eslint-config": "^8.3.0-beta.0",
         "@nextcloud/stylelint-config": "^2.3.1",
-        "@nextcloud/vite-config": "^1.0.1",
+        "@nextcloud/vite-config": "^1.2.1",
         "@nextcloud/webpack-vue-config": "github:nextcloud/webpack-vue-config#master",
         "@types/gettext-parser": "^4.0.4",
         "@types/jest": "^29.5.5",
@@ -3903,28 +3903,29 @@
       }
     },
     "node_modules/@nextcloud/vite-config": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.2.0.tgz",
-      "integrity": "sha512-rGV/0oDp7aa5EiH8RUS/vhRpQoexaqwaZRzsaCh7989yK7KO1EuQK91T53vWujETUXJPncLTDbpPlQ/uiypr4g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.2.1.tgz",
+      "integrity": "sha512-BMsGuwG1tRjWTJQmtVOQEBhqxmdyhUjD0KMqYpeNrRkMBQIstA6Q37iQuyTExVS0yLZ8agyqzuWzdw9h0eHWLQ==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-replace": "^5.0.5",
         "@vitejs/plugin-vue2": "^2.3.1",
-        "browserslist-to-esbuild": "^1.2.0",
+        "browserslist-to-esbuild": "^2.1.1",
         "magic-string": "^0.30.5",
         "rollup-plugin-corejs": "^1.0.0-beta.2",
         "rollup-plugin-esbuild-minify": "^1.1.1",
         "rollup-plugin-license": "^3.2.0",
         "rollup-plugin-node-externals": "^6.1.2",
-        "vite-plugin-css-injected-by-js": "^3.3.0",
-        "vite-plugin-dts": "^3.6.4",
-        "vite-plugin-node-polyfills": "^0.17.0"
+        "vite-plugin-css-injected-by-js": "^3.3.1",
+        "vite-plugin-dts": "^3.7.2",
+        "vite-plugin-node-polyfills": "^0.19.0"
       },
       "engines": {
         "node": "^20",
         "npm": "^9 || ^10"
       },
       "peerDependencies": {
+        "browserslist": ">=4.0",
         "sass": ">=1.60",
         "vite": "^4 || ^5"
       }
@@ -3941,9 +3942,8 @@
       }
     },
     "node_modules/@nextcloud/webpack-vue-config": {
-      "version": "6.0.0",
-      "resolved": "git+ssh://git@github.com/nextcloud/webpack-vue-config.git#7976a359293392baf4a8535a63e575ad5870deec",
-      "integrity": "sha512-1LRLr5TXCb+oXImZ82rYXSAhrjjdLLmoZCOFPOyUp9On+n97S3TBfAMzHqeIUvAwv9Dg2bBxpakn6JQXMP9uCg==",
+      "version": "6.0.1",
+      "resolved": "git+ssh://git@github.com/nextcloud/webpack-vue-config.git#14068ae8d02f8be8421058f3910bd243b8a5a927",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "engines": {
@@ -3956,7 +3956,7 @@
         "css-loader": "^6.8.1",
         "node-polyfill-webpack-plugin": "3.0.0",
         "sass": "^1.64.2",
-        "sass-loader": "^13.3.2",
+        "sass-loader": "^14.0.0",
         "style-loader": "^3.3.3",
         "ts-loader": "^9.4.4",
         "vue": "^2.7.16",
@@ -7456,15 +7456,33 @@
       }
     },
     "node_modules/browserslist-to-esbuild": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserslist-to-esbuild/-/browserslist-to-esbuild-1.2.0.tgz",
-      "integrity": "sha512-ftrrbI/VHBgEnmnSyhkqvQVMp6jAKybfs0qMIlm7SLBrQTGMsdCIP4q3BoKeLsZTBQllIQtY9kbxgRYV2WU47g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/browserslist-to-esbuild/-/browserslist-to-esbuild-2.1.1.tgz",
+      "integrity": "sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.17.3"
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "browserslist-to-esbuild": "cli/index.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "browserslist": "*"
+      }
+    },
+    "node_modules/browserslist-to-esbuild/node_modules/meow": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.1.0.tgz",
+      "integrity": "sha512-o5R/R3Tzxq0PJ3v3qcQJtSvSE9nKOLSAaDuuoMzDVuGTwHdccMWcYomh9Xolng2tjT6O/Y83d+0coVGof6tqmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bser": {
@@ -7657,31 +7675,6 @@
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
       "dev": true
-    },
-    "node_modules/buffer-polyfill": {
-      "name": "buffer",
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -23903,32 +23896,28 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.2.tgz",
-      "integrity": "sha512-CQbKl57kdEv+KDLquhC+gE3pXt74LEAzm+tzywcA0/aHZuub8wTErbjAoNI57rPUWRYRNC5WUnNl8eGJNbDdwg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-14.0.0.tgz",
+      "integrity": "sha512-oceP9wWbep/yRJ2+sMbCzk0UsXsDzdNis+N8nu9i5GwPXjy6v3DNB6TqfJLSpPO9k4+B8x8p/CEgjA9ZLkoLug==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "fibers": ">= 3.1.0",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
         "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "fibers": {
-          "optional": true
-        },
         "node-sass": {
           "optional": true
         },
@@ -27401,18 +27390,18 @@
       }
     },
     "node_modules/vite-plugin-css-injected-by-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.3.0.tgz",
-      "integrity": "sha512-xG+jyHNCmUqi/TXp6q88wTJGeAOrNLSyUUTp4qEQ9QZLGcHWQQsCsSSKa59rPMQr8sOzfzmWDd8enGqfH/dBew==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.3.1.tgz",
+      "integrity": "sha512-PjM/X45DR3/V1K1fTRs8HtZHEQ55kIfdrn+dzaqNBFrOYO073SeSNCxp4j7gSYhV9NffVHaEnOL4myoko0ePAg==",
       "dev": true,
       "peerDependencies": {
         "vite": ">2.0.0-0"
       }
     },
     "node_modules/vite-plugin-dts": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.7.0.tgz",
-      "integrity": "sha512-np1uPaYzu98AtPReB8zkMnbjwcNHOABsLhqVOf81b3ol9b5M2wPcAVs8oqPnOpr6Us+7yDXVauwkxsk5+ldmRA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.7.2.tgz",
+      "integrity": "sha512-kg//1nDA01b8rufJf4TsvYN8LMkdwv0oBYpiQi6nRwpHyue+wTlhrBiqgipdFpMnW1oOYv6ywmzE5B0vg6vSEA==",
       "dev": true,
       "dependencies": {
         "@microsoft/api-extractor": "7.39.0",
@@ -27436,15 +27425,13 @@
       }
     },
     "node_modules/vite-plugin-node-polyfills": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.17.0.tgz",
-      "integrity": "sha512-iPmPn7376e5u6QvoTSJa16hf5Q0DFwHFXJk2uYpsNlmI3JdPms7hWyh55o+OysJ5jo9J5XPhLC9sMOYifwFd1w==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.19.0.tgz",
+      "integrity": "sha512-AhdVxAmVnd1doUlIRGUGV6ZRPfB9BvIwDF10oCOmL742IsvsFIAV4tSMxSfu5e0Px0QeJLgWVOSbtHIvblzqMw==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-inject": "^5.0.5",
-        "buffer-polyfill": "npm:buffer@^6.0.3",
-        "node-stdlib-browser": "^1.2.0",
-        "process": "^0.11.10"
+        "node-stdlib-browser": "^1.2.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/davidmyersdev"
@@ -27695,9 +27682,9 @@
       }
     },
     "node_modules/vue-loader": {
-      "version": "15.10.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
-      "integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
+      "version": "15.11.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.11.1.tgz",
+      "integrity": "sha512-0iw4VchYLePqJfJu9s62ACWUXeSqM30SQqlIftbYWM3C+jpPcEHKSPUZBLjSF9au4HTHQ/naF6OGnO3Q/qGR3Q==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -27713,6 +27700,9 @@
       },
       "peerDependenciesMeta": {
         "cache-loader": {
+          "optional": true
+        },
+        "prettier": {
           "optional": true
         },
         "vue-template-compiler": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@nextcloud/browserslist-config": "^3.0.0",
     "@nextcloud/eslint-config": "^8.3.0-beta.0",
     "@nextcloud/stylelint-config": "^2.3.1",
-    "@nextcloud/vite-config": "^1.0.1",
+    "@nextcloud/vite-config": "^1.2.1",
     "@nextcloud/webpack-vue-config": "github:nextcloud/webpack-vue-config#master",
     "@types/gettext-parser": "^4.0.4",
     "@types/jest": "^29.5.5",


### PR DESCRIPTION
Full changelog: https://github.com/nextcloud-libraries/nextcloud-vite-config/compare/v1.2.0...v1.2.1

## [v1.2.1](https://github.com/nextcloud-libraries/nextcloud-vite-config/tree/v1.2.1) (2024-01-29)
### :bug: Fixed bugs
* fix(css-plugin): Use `generateBundle` hook to prevent CSS imports from being lost [\#112](https://github.com/nextcloud-libraries/nextcloud-vite-config/pull/112) \([susnux](https://github.com/susnux)\)
