### PR TITLE
fix(`NcColorPicker`): define a container prop

### DIFF
--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -161,6 +161,7 @@ export default {
 
 <template>
 	<NcPopover popup-role="dialog"
+		:container="container"
 		v-bind="$attrs"
 		v-on="$listeners"
 		@apply-hide="handleClose">
@@ -187,7 +188,7 @@ export default {
 							@click="pickColor(color)">
 					</label>
 				</div>
-				<Chrome v-if="advanced"
+				<Chrome v-else
 					v-model="currentColor"
 					class="color-picker__advanced"
 					:disable-alpha="true"
@@ -289,6 +290,14 @@ export default {
 				(typeof item === 'string' && HEX_REGEX.test(item))
 				|| (typeof item === 'object' && item.color && HEX_REGEX.test(item.color)),
 			),
+		},
+
+		/**
+		 * Selector for the popover container
+		 */
+		container: {
+			type: [String, Object, Element, Boolean],
+			default: 'body',
 		},
 	},
 

--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -166,6 +166,7 @@ This component allows the user to pick an emoji.
 						@trailing-button-click="clearSearch(); slotProps.onSearch(search);"
 						@update:value="slotProps.onSearch(search)" />
 					<NcColorPicker palette-only
+						:container="container"
 						:palette="skinTonePalette"
 						:value="currentColor.color"
 						@update:value="onChangeSkinTone">


### PR DESCRIPTION
### ☑️ Resolves

* Fix regression from #5103
  * Because `container` was not provided to NcColorPicker, Popover content is rendered on a 'body', which could be different from NcEmojiPicker container

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/38649880-a3fe-405f-84d8-5052d626db92) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/61af6cad-affa-4bc6-bcbd-9e2f7a9e7cd9)