### PR TITLE
fix(NcActions): hotfix for custom children

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -807,6 +807,131 @@ p {
 }
 </style>
 ```
+
+## NcActions children limitations
+
+`<NcActions>` is supposed to be used with direct `<NcAction*>` children.
+Although it works when actions are not direct children but wrapped in custom components, it has limitations:
+- No `inline` prop property, including a single action display;
+- Accessibility issues, including changed keyboard behavior;
+- Invalid HTML.
+
+```
+<template>
+	<table class="actions-limitations-table">
+		<tr>
+			<th style="width: 50%">Non-direct children</th>
+			<th style="width: 50%">Direct NcAction* children</th>
+		</tr>
+
+		<tr>
+			<th colspan="2">This single button is supposed to be rendered as inline action but it is rendered as a menu:</th>
+		</tr>
+		<tr>
+			<td>
+				<NcActions>
+					<MyUserActionButton />
+				</NcActions>
+			</td>
+			<td>
+				<NcActions>
+					<NcActionButton>
+						<template #icon>
+							<Account :size="20" />
+						</template>
+						Button
+					</NcActionButton>
+				</NcActions>
+			</td>
+		</tr>
+		<tr>
+			<th colspan="2">This NcActions is supposed to have 2 inline buttons but it has none:</th>
+		</tr>
+		<tr>
+			<td>
+				<NcActions :inline="2">
+					<MyUserActionButton v-for="i in 4" />
+				</NcActions>
+			</td>
+			<td>
+				<NcActions :inline="2">
+					<NcActionButton v-for="i in 4">
+						<template #icon>
+							<Account :size="20" />
+						</template>
+						Button
+					</NcActionButton>
+				</NcActions>
+			</td>
+		</tr>
+		<tr>
+			<th colspan="2">This NcActions is supposed to have a11y role menu and keyboard navigation but it acts like a dialog:</th>
+		</tr>
+		<tr>
+			<td>
+				<NcActions>
+					<MyActionsList />
+				</NcActions>
+			</td>
+			<td>
+				<NcActions>
+					<NcActionButton v-for="i in 4">
+						<template #icon>
+							<Account :size="20" />
+						</template>
+						Button
+					</NcActionButton>
+				</NcActions>
+			</td>
+		</tr>
+	</table>
+</template>
+
+<script>
+import Account from 'vue-material-design-icons/Account.vue'
+
+export default {
+	components: {
+		Account,
+
+		MyUserActionButton: {
+			name: 'MyUserActionButton',
+			components: { Account },
+			render: (h) => h('NcActionButton', ['Button', h('Account', { props: { size: 20 }, slot: 'icon' })]),
+		},
+
+		MyActionsList: {
+			name: 'MyActionsList',
+			components: { Account },
+			render: (h) => h('div', [
+				h('NcActionButton', ['Button', h('Account', { props: { size: 20 }, slot: 'icon' })]),
+				h('NcActionButton', ['Button', h('Account', { props: { size: 20 }, slot: 'icon' })]),
+				h('NcActionButton', ['Button', h('Account', { props: { size: 20 }, slot: 'icon' })]),
+				h('NcActionButton', ['Button', h('Account', { props: { size: 20 }, slot: 'icon' })]),
+			]),
+		}
+	}
+}
+</script>
+
+<style>
+.actions-limitations-table {
+	border-collapse: collapse;
+	width: 100%;
+	th,
+	td {
+		border: 1px solid var(--color-border);
+		padding: var(--default-grid-baseline);
+		max-width: 50%;
+	}
+
+	th {
+		text-align: center;
+		text-wrap: wrap;
+	}
+}
+</style>
+```
 </docs>
 
 <script>


### PR DESCRIPTION
### ☑️ Resolves

* Hotfix for https://github.com/nextcloud-libraries/nextcloud-vue/issues/5171
* Particularly a regression of https://github.com/nextcloud-libraries/nextcloud-vue/pull/5153

In `NcActions` we check what `NcAction*` components were passed as direct children. But some apps (Text, Mail) pass `NcAction*` not as direct children of `NcActions`, but as a sub-child.

```html
<NcActions>
  <MyUserActionsList /> // renders <NcActionButton />
</NcActions>
```

The current `NcActions` implementation doesn't fully support this.
- In past it resulted in ignoring `inline` prop and incorrect render of single actions
- After mentioned PR it was completely broken:
  1. Menu is rendered
  2. There are no direct `NcAction*` interactive children (they are sub-children)
  3. Menu is considered a tooltip
  4. It should close on blur
  5. After opening, it focuses on an interactive element, causing blur and closing.

Unfortunately, in Vue 2 it is not possible to easily fix. When render function is executed, children are not rendered yet, so we don't know if they are to render `NcAction*` components or not.

This PR adds a hotfix that prevents component from being unusable. If children are not allowed custom components - consider menu a dialog with the default focus trap.

So the component works like it worked in the past. Yet it still has bad accessibility in this case.

### 🖼️ Screenshots

#### Docs

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/ee43b4b6-90e8-4379-a56f-8aa7baabe3b3)

🏚️ Before | 🏡 After
---|---
![nc-actions-children-before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/62bae6c3-7be8-40e5-891f-e1db495a0c4f) | ![nc-actions-children-after](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/1af49f41-d496-4f55-92a9-7e8db9e70ae7)

### 🚧 Tasks

- [x] Document `NCActions` children limitations
- [x] Add a hotfix - make NcActions be considered a semantic `dialog` if there are custom 

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
