### PR TITLE
chore: prepare v9.0.0 alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ All notable changes to this project will be documented in this file.
 * fix(NcBreadcrumb): correctly emit drag events [\#5011](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5011) \([raimund-schluessler](https://github.com/raimund-schluessler)\)
 * fix(NcCheckboxContent): correctly check default slot [\#5058](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5058) \([raimund-schluessler](https://github.com/raimund-schluessler)\)
 * fix(NcBreadcrumbs): do not forward refs to hidden crumbs [\#5066](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5066) \([raimund-schluessler](https://github.com/raimund-schluessler)\)
+* fix(NcAppSidebar): adjust animation class names [\#5168](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5168) \([raimund-schluessler](https://github.com/raimund-schluessler)\)
+* fix(docs): bring back NcAppSidebar in docs [\#5167](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5167) \([raimund-schluessler](https://github.com/raimund-schluessler)\)
 
 ### Other Changes
 * Rename `checked` prop to `modelValue` [\#4994](https://github.com/nextcloud-libraries/nextcloud-vue/pull/4994) \([raimund-schluessler](https://github.com/raimund-schluessler)\)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "9.0.0-alpha.0",
+      "version": "9.0.0-alpha.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@ckpack/vue-color": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.0.0-alpha.0",
+  "version": "9.0.0-alpha.1",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v9.0.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.0.0-alpha.0) (unreleased)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.5.0...v9.0.0-alpha.1)

### 🐛 Fixed bugs
* fix(NcAppSidebar): adjust animation class names by @raimund-schluessler in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5168
* fix(docs): bring back NcAppSidebar in docs by @raimund-schluessler in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5167
