### PR TITLE
Create possibility to change a color theme for native datetime picker on system default theme

### DIFF
--- a/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
+++ b/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
@@ -399,4 +399,18 @@ export default {
 			color-scheme: dark;
 		}
 	}
+
+	[data-theme-default],
+	[data-themes*=default] {
+		@media (prefers-color-scheme: light) {
+			.native-datetime-picker--input {
+				color-scheme: light;
+			}
+		}
+		@media (prefers-color-scheme: dark) {
+			.native-datetime-picker--input {
+				color-scheme: dark;
+			}
+		}
+	}
 </style>


### PR DESCRIPTION
Create possibility to change a color theme for native datetime picker on system default theme

### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/42392

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-01-30 15-15-35](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/4c43058d-3a57-4c28-a11e-b11c7d54fa58) | ![Screenshot from 2024-01-30 15-13-23](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/ccd928ac-fe87-4600-bade-494026885dc7)



### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
