### PR TITLE
fix(CI): Adjust npm-publish to work with GPR

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -54,9 +54,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Set up Github Package Registry ${{ steps.versions.outputs.nodeVersion }}
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v3
+        with:
+          node-version: ${{ steps.versions.outputs.nodeVersion }}
+          registry-url: https://npm.pkg.github.com/
+          scope: nextcloud-libraries
+
       - name: Publish package on Github Package Registry
         run: |
-          npm config set //npm.pkg.github.com/:_authToken=$NODE_AUTH_TOKEN
+          npm config set registry=https://npm.pkg.github.com/
           npm publish --tag $RELEASE_GROUP
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This did not work since we migrated from `nextcloud` to `nextcloud-libraries`.