### PR TITLE
fix(NcActions): adjust wrapper names

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -830,7 +830,7 @@ Although it works when actions are not direct children but wrapped in custom com
 		<tr>
 			<td>
 				<NcActions>
-					<MyUserActionButton />
+					<NcActionUserButton />
 				</NcActions>
 			</td>
 			<td>
@@ -850,7 +850,7 @@ Although it works when actions are not direct children but wrapped in custom com
 		<tr>
 			<td>
 				<NcActions :inline="2">
-					<MyUserActionButton v-for="i in 4" />
+					<NcActionUserButton v-for="i in 4" />
 				</NcActions>
 			</td>
 			<td>
@@ -870,7 +870,7 @@ Although it works when actions are not direct children but wrapped in custom com
 		<tr>
 			<td>
 				<NcActions>
-					<MyActionsList />
+					<NcActionsList />
 				</NcActions>
 			</td>
 			<td>
@@ -895,14 +895,14 @@ export default {
 	components: {
 		Account,
 
-		MyUserActionButton: {
-			name: 'MyUserActionButton',
+		NcActionUserButton: {
+			name: 'NcActionUserButton',
 			components: { Account },
 			render: () => h(resolveComponent('NcActionButton'), null, { default: () => 'Button', icon: () => h(Account, { size: 20 }) }),
 		},
 
-		MyActionsList: {
-			name: 'MyActionsList',
+		NcActionsList: {
+			name: 'NcActionsList',
 			components: { Account },
 			render: () => h('div', null, {
 				default: () => [


### PR DESCRIPTION
### ☑️ Resolves

If we adjust the action wrapper names to start with `NcAction` (or alternatively relax the "what is an action condition"), then we at least get the same (broken) behaviour for `next` as we get for `master`. Would that be an improvement?