### PR TITLE
fix(NcAppNavigationNewItem): bring back correct CSS class

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -34,7 +34,7 @@
 		}
 
 		// overwrite active text color
-		.app-navigation-entry-link {
+		.app-navigation-entry-link, .app-navigation-entry-button {
 			color: var(--color-primary-element-text) !important;
 		}
 	}
@@ -68,12 +68,14 @@
 		display: none;
 	}
 
-	&:not(.app-navigation-entry--editing) .app-navigation-entry-link {
-		padding-right: $icon-margin;
+	&:not(.app-navigation-entry--editing) {
+		.app-navigation-entry-link, .app-navigation-entry-button {
+			padding-right: $icon-margin;
+		}
 	}
 
 	// Main entry link
-	.app-navigation-entry-link {
+	.app-navigation-entry-link, .app-navigation-entry-button {
 		z-index: 100; /* above the bullet to allow click*/
 		display: flex;
 		overflow: hidden;


### PR DESCRIPTION
### ☑️ Resolves

* Fixes a regression with `NcAppNavigationNewItem` that I introduced in #4989. Closes #5159.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/8fb2c65d-3d6c-4692-b797-fd85f32b7666) | ![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/2496460/7806aaf2-ce52-4160-8ff4-3f3d35e8387e)

