### PR TITLE
revert: fix(NcActions): use new slots api

### DIFF
--- a/src/mixins/actionGlobal.js
+++ b/src/mixins/actionGlobal.js
@@ -40,7 +40,7 @@ export default {
 
 	methods: {
 		getText() {
-			return this.$scopedSlots.default ? this.$scopedSlots.default()?.[0].text.trim() : ''
+			return this.$slots.default ? this.$slots.default[0].text.trim() : ''
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/mail/issues/9282
* Reverts: https://github.com/nextcloud-libraries/nextcloud-vue/pull/5118

`$scopedSlots` cannot be used in `beforeUpdated` hook.
- On re-rendering, when `vnode` is reused, on beforeUpdated state `$scopedSlots` still returns an old value and breaks rendering.
- Officially, `$slots/$scopedSlots` should be used only during the rendering and not supposed to be used in `data`, `computed` or life cycle hooks.

This commit returns `$slots` to have an old behavior and resolve a regression

TODO: find a better solution to support both slots API. Use method in template and always call it, like we do in Vue 3?

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
