### PR TITLE
fix(NcActions): fix LI roles

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -331,7 +331,7 @@ export default {
 </docs>
 
 <template>
-	<li class="action" :class="{ 'action--disabled': disabled }" :role="isInSemanticMenu && 'presentation'">
+	<li class="action" :class="{ 'action--disabled': disabled }" :role="liRole">
 		<button :aria-label="ariaLabel"
 			:class="['action-button button-vue', {
 				'action-button--active': isChecked,
@@ -386,6 +386,7 @@ export default {
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import ActionTextMixin from '../../mixins/actionText.js'
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
 
 /**
  * Button component to be used in Actions
@@ -398,13 +399,6 @@ export default {
 		ChevronRightIcon,
 	},
 	mixins: [ActionTextMixin],
-
-	inject: {
-		isInSemanticMenu: {
-			from: 'NcActions:isSemanticMenu',
-			default: false,
-		},
-	},
 
 	props: {
 		/**
@@ -471,6 +465,14 @@ export default {
 		},
 	},
 
+	setup() {
+		const { menuType, liRole } = useNcActionsContext()
+		return {
+			menuType,
+			liRole,
+		}
+	},
+
 	computed: {
 		/**
 		 * determines if the action is focusable
@@ -507,7 +509,7 @@ export default {
 		buttonAttributes() {
 			const attributes = {}
 
-			if (this.isInSemanticMenu) {
+			if (this.menuType === 'menu') {
 				// By default it needs to be a menu item in semantic menus
 				attributes.role = 'menuitem'
 

--- a/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
+++ b/src/components/NcActionButtonGroup/NcActionButtonGroup.vue
@@ -90,7 +90,7 @@ export default {
 </docs>
 
 <template>
-	<li class="nc-button-group-base" :role="isInSemanticMenu && 'presentation'">
+	<li class="nc-button-group-base" :role="liRole">
 		<div v-if="name" :id="labelId">
 			{{ name }}
 		</div>
@@ -104,19 +104,13 @@ export default {
 import { defineComponent } from 'vue'
 import GenRandomId from '../../utils/GenRandomId.js'
 import { t } from '../../l10n.js'
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
 
 /**
  * A wrapper for allowing inlining NcAction components within the action menu
  */
 export default defineComponent({
 	name: 'NcActionButtonGroup',
-
-	inject: {
-		isInSemanticMenu: {
-			from: 'NcActions:isSemanticMenu',
-			default: false,
-		},
-	},
 
 	props: {
 		/**
@@ -130,7 +124,9 @@ export default defineComponent({
 	},
 
 	setup() {
+		const { liRole } = useNcActionsContext()
 		return {
+			liRole,
 			labelId: `nc-action-button-group-${GenRandomId()}`,
 		}
 	},

--- a/src/components/NcActionCaption/NcActionCaption.vue
+++ b/src/components/NcActionCaption/NcActionCaption.vue
@@ -30,21 +30,16 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 </docs>
 
 <template>
-	<li class="app-navigation-caption" :role="isInSemanticMenu && 'presentation'">
+	<li class="app-navigation-caption" :role="liRole">
 		{{ name }}
 	</li>
 </template>
 
 <script>
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
+
 export default {
 	name: 'NcActionCaption',
-
-	inject: {
-		isInSemanticMenu: {
-			from: 'NcActions:isSemanticMenu',
-			default: false,
-		},
-	},
 
 	props: {
 		/**
@@ -54,6 +49,13 @@ export default {
 			type: String,
 			required: true,
 		},
+	},
+
+	setup() {
+		const { liRole } = useNcActionsContext()
+		return {
+			liRole,
+		}
 	},
 }
 </script>

--- a/src/components/NcActionCheckbox/NcActionCheckbox.vue
+++ b/src/components/NcActionCheckbox/NcActionCheckbox.vue
@@ -35,8 +35,8 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 </docs>
 
 <template>
-	<li class="action" :class="{ 'action--disabled': disabled }" :role="isInSemanticMenu && 'presentation'">
-		<span class="action-checkbox" :role="isInSemanticMenu && 'menuitemcheckbox'" :aria-checked="ariaChecked">
+	<li class="action" :class="{ 'action--disabled': disabled }" :role="liRole">
+		<span class="action-checkbox" :role="menuType === 'menu' && 'menuitemcheckbox'" :aria-checked="ariaChecked">
 			<input :id="id"
 				ref="checkbox"
 				:disabled="disabled"
@@ -58,18 +58,12 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 <script>
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import GenRandomId from '../../utils/GenRandomId.js'
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
 
 export default {
 	name: 'NcActionCheckbox',
 
 	mixins: [ActionGlobalMixin],
-
-	inject: {
-		isInSemanticMenu: {
-			from: 'NcActions:isSemanticMenu',
-			default: false,
-		},
-	},
 
 	props: {
 		/**
@@ -113,6 +107,14 @@ export default {
 		'update:checked',
 	],
 
+	setup() {
+		const { menuType, liRole } = useNcActionsContext()
+		return {
+			menuType,
+			liRole,
+		}
+	},
+
 	computed: {
 		/**
 		 * determines if the action is focusable
@@ -129,7 +131,7 @@ export default {
 		 * @return {'true'|'false'|undefined} aria-checked value if needed
 		 */
 		ariaChecked() {
-			if (this.isInSemanticMenu) {
+			if (this.menuType === 'menu') {
 				return this.checked ? 'true' : 'false'
 			}
 			return undefined

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -136,7 +136,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 </docs>
 
 <template>
-	<li class="action" :class="{ 'action--disabled': disabled }">
+	<li class="action" :class="{ 'action--disabled': disabled }" :role="liRole">
 		<span :class="{
 				'action-input-picker--disabled': disabled,
 				'action-input--visible-label': labelOutside && label,
@@ -269,6 +269,7 @@ import NcTextField from '../NcTextField/index.js'
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 import { t } from '../../l10n.js'
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
 
 export default {
 	name: 'NcActionInput',
@@ -401,6 +402,13 @@ export default {
 		'change',
 		'update:value',
 	],
+
+	setup() {
+		const { liRole } = useNcActionsContext()
+		return {
+			liRole,
+		}
+	},
 
 	computed: {
 		isIconUrl() {

--- a/src/components/NcActionLink/NcActionLink.vue
+++ b/src/components/NcActionLink/NcActionLink.vue
@@ -78,7 +78,7 @@ export default {
 </docs>
 
 <template>
-	<li class="action" :role="isInSemanticMenu && 'presentation'">
+	<li class="action" :role="liRole">
 		<a :download="download"
 			:href="href"
 			:aria-label="ariaLabel"
@@ -86,7 +86,7 @@ export default {
 			:title="title"
 			class="action-link focusable"
 			rel="nofollow noreferrer noopener"
-			:role="isInSemanticMenu && 'menuitem'"
+			:role="menuType === 'menu' ? 'menuitem' : undefined"
 			@click="onClick">
 
 			<!-- @slot Manually provide icon -->
@@ -127,18 +127,12 @@ export default {
 
 <script>
 import ActionTextMixin from '../../mixins/actionText.js'
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
 
 export default {
 	name: 'NcActionLink',
 
 	mixins: [ActionTextMixin],
-
-	inject: {
-		isInSemanticMenu: {
-			from: 'NcActions:isSemanticMenu',
-			default: false,
-		},
-	},
 
 	props: {
 		/**
@@ -190,6 +184,14 @@ export default {
 			type: Boolean,
 			default: null,
 		},
+	},
+
+	setup() {
+		const { menuType, liRole } = useNcActionsContext()
+		return {
+			menuType,
+			liRole,
+		}
 	},
 }
 </script>

--- a/src/components/NcActionRadio/NcActionRadio.vue
+++ b/src/components/NcActionRadio/NcActionRadio.vue
@@ -37,7 +37,7 @@ So that only one of each name set can be selected at the same time.
 </docs>
 
 <template>
-	<li class="action" :class="{ 'action--disabled': disabled }" :role="isInSemanticMenu && 'presentation'">
+	<li class="action" :class="{ 'action--disabled': disabled }" :role="liRole">
 		<span class="action-radio" role="menuitemradio" :aria-checked="ariaChecked">
 			<input :id="id"
 				ref="radio"
@@ -61,18 +61,12 @@ So that only one of each name set can be selected at the same time.
 <script>
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import GenRandomId from '../../utils/GenRandomId.js'
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
 
 export default {
 	name: 'NcActionRadio',
 
 	mixins: [ActionGlobalMixin],
-
-	inject: {
-		isInSemanticMenu: {
-			from: 'NcActions:isSemanticMenu',
-			default: false,
-		},
-	},
 
 	props: {
 		/**
@@ -124,6 +118,14 @@ export default {
 		'change',
 	],
 
+	setup() {
+		const { menuType, liRole } = useNcActionsContext()
+		return {
+			menuType,
+			liRole,
+		}
+	},
+
 	computed: {
 		/**
 		 * determines if the action is focusable
@@ -140,7 +142,7 @@ export default {
 		 * @return {'true'|'false'|undefined} aria-checked value if needed
 		 */
 		 ariaChecked() {
-			if (this.isInSemanticMenu) {
+			if (this.menuType === 'menu') {
 				return this.checked ? 'true' : 'false'
 			}
 			return undefined

--- a/src/components/NcActionRouter/NcActionRouter.vue
+++ b/src/components/NcActionRouter/NcActionRouter.vue
@@ -22,14 +22,14 @@
   -->
 
 <template>
-	<li class="action" :role="isInSemanticMenu && 'presentation'">
+	<li class="action" :role="liRole">
 		<RouterLink :to="to"
 			:aria-label="ariaLabel"
 			:exact="exact"
 			:title="title"
 			class="action-router focusable"
 			rel="nofollow noreferrer noopener"
-			:role="isInSemanticMenu && 'menuitem'"
+			:role="menuType === 'menu' ? 'menuitem' : undefined"
 			@click.native="onClick">
 			<!-- @slot Manually provide icon -->
 			<slot name="icon">
@@ -69,18 +69,12 @@
 
 <script>
 import ActionTextMixin from '../../mixins/actionText.js'
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
 
 export default {
 	name: 'NcActionRouter',
 
 	mixins: [ActionTextMixin],
-
-	inject: {
-		isInSemanticMenu: {
-			from: 'NcActions:isSemanticMenu',
-			default: false,
-		},
-	},
 
 	props: {
 		/**
@@ -98,6 +92,14 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+	},
+
+	setup() {
+		const { menuType, liRole } = useNcActionsContext()
+		return {
+			menuType,
+			liRole,
+		}
 	},
 }
 </script>

--- a/src/components/NcActionText/NcActionText.vue
+++ b/src/components/NcActionText/NcActionText.vue
@@ -22,7 +22,7 @@
   -->
 
 <template>
-	<li class="action" :role="isInSemanticMenu && 'presentation'">
+	<li class="action" :role="liRole">
 		<span class="action-text"
 			@click="onClick">
 			<!-- @slot Manually provide icon -->
@@ -64,17 +64,18 @@
 
 <script>
 import ActionTextMixin from '../../mixins/actionText.js'
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
 
 export default {
 	name: 'NcActionText',
 
 	mixins: [ActionTextMixin],
 
-	inject: {
-		isInSemanticMenu: {
-			from: 'NcActions:isSemanticMenu',
-			default: false,
-		},
+	setup() {
+		const { liRole } = useNcActionsContext()
+		return {
+			liRole,
+		}
 	},
 }
 </script>

--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -58,7 +58,7 @@ export default {
 </docs>
 
 <template>
-	<li class="action" :class="{ 'action--disabled': disabled }">
+	<li class="action" :class="{ 'action--disabled': disabled }" :role="liRole">
 		<span class="action-text-editable"
 			@click="onClick">
 			<!-- @slot Manually provide icon -->
@@ -104,6 +104,7 @@ import ActionTextMixin from '../../mixins/actionText.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 
 import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import { useNcActionsContext } from '../NcActions/composables/useNcActionsContext.js'
 
 export default {
 	name: 'NcActionTextEditable',
@@ -144,6 +145,13 @@ export default {
 		'update:value',
 		'submit',
 	],
+
+	setup() {
+		const { liRole } = useNcActionsContext()
+		return {
+			liRole,
+		}
+	},
 
 	computed: {
 		/**

--- a/src/components/NcActions/composables/useNcActionsContext.js
+++ b/src/components/NcActions/composables/useNcActionsContext.js
@@ -1,0 +1,20 @@
+import { computed, inject } from 'vue'
+
+/**
+ * Get the NcActions's context for NcAction-item component.
+ * Supposed to be used in all NcAction-item components.
+ *
+ * @return {{ liRole: import('vue').ComputedRef<string | undefined>, menuType: import('vue').ComputedRef<string | undefined>}}
+ */
+export function useNcActionsContext() {
+	const getActionsListRole = inject('NcActions:getMenuType')
+	const menuType = computed(() => getActionsListRole())
+
+	const getListItemRole = inject('NcActions:getListItemRole')
+	const liRole = computed(() => getListItemRole())
+
+	return {
+		liRole,
+		menuType,
+	}
+}


### PR DESCRIPTION
### ☑️ Resolves

Currently the menu in `NcActions` has the following structure:

```html
<ul role="POPUP_ROLE">
  <li role="LI_ROLE" />
</ul>
```

`POPUP_ROLE` can be - `menu | dialog | tooltip` or nothing (=`list`) in navigation:
- When it is a navigation, native roles works fine
- When it is a `menu`, `<li>` has role `presentation`, because there are `menuitem`-s inside.
- When it is `dialog` or `tooltip`, `<li>` had native `listitem` role because there is a list in the popup.

The problem is that in the last case `<UL>` is at the same time:
- A list items' container - should have `list` role
- A popup's container - should have `dialog` or `tooltip` role.

But it is not possible to have 2 roles. So, when it is a `dialog` or `tooltip`, list items are not in a **list**.

A proper solution should have been to wrap `UL` into another element.

```html
<div role="POPUP_ROLE">
  <ul>
    <li />
  </ul>
</div>
```

However, we decided that this is too risky change of the structure for apps and testing.

Temporal solution - remove `listitem` role in `dialogs` and `tooltips`.

### 🖼️ Screenshots

Example | 🏚️ Before | 🏡 After
---|---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/268e258a-7b2c-48c7-8896-ab5f31c659a0) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/7d9acba4-5b0e-41bf-9181-dd8aec02204a) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/4b27ba7c-f3ce-42ef-989a-5ec1bac9c18d)

### 🚧 Tasks

- [x] Better store HTML roles for different types of menu
- [x] Provide `NcActions` context with as menu type and LI role
  - Relaces existing `isSemanticMenu` to provide more important data
- [x] Add a composable to use this context
  - Replaces existing `inject`
- [x] Set list item role on all action items, except `NcActionSeparator` (it is always `separator`)

### P.S.

I haven't used existing **mixins** (`actionText`, `actionGlobal`) because they are not used on all the action items.

I haven't created a new **mixin**, because I decided, that we should move to **composables**.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
