### PR TITLE
fix(NcRichContenteditable):  unify styles and add contrast border on keyboard navigation

### DIFF
--- a/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
+++ b/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
@@ -112,32 +112,22 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-$autocomplete-padding: 10px;
-
 .autocomplete-result {
 	display: flex;
-	height: $clickable-area;
-	padding: $autocomplete-padding;
-
-	.highlight & {
-		color: var(--color-primary-element-light-text);
-		background: var(--color-primary-element-light);
-		&, * {
-			cursor: pointer;
-		}
-	}
+	height: var(--default-clickable-area);
+	padding: var(--default-grid-baseline) 0;
 
 	&__icon {
 		position: relative;
-		flex: 0 0 $clickable-area;
-		width: $clickable-area;
-		min-width: $clickable-area;
-		height: $clickable-area;
-		border-radius: $clickable-area;
+		flex: 0 0 var(--default-clickable-area);
+		width: var(--default-clickable-area);
+		min-width: var(--default-clickable-area);
+		height: var(--default-clickable-area);
+		border-radius: var(--default-clickable-area);
 		background-color: var(--color-background-darker);
 		background-repeat: no-repeat;
 		background-position: center;
-		background-size: $clickable-area - 2 * $autocomplete-padding;
+		background-size: contain;
 		&--with-avatar {
 			color: inherit;
 			background-size: cover;
@@ -174,7 +164,7 @@ $autocomplete-padding: 10px;
 		flex-direction: column;
 		justify-content: center;
 		min-width: 0;
-		padding-left: $autocomplete-padding;
+		padding-left: calc(var(--default-grid-baseline) * 2);
 	}
 
 	&__title,

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -553,7 +553,7 @@ export default {
 		},
 
 		initializeTribute() {
-			const renderMenuItem = (content) => `<div id="nc-rich-contenteditable-tribute-item-${GenRandomId(5)}" role="option">${content}</div>`
+			const renderMenuItem = (content) => `<div id="nc-rich-contenteditable-tribute-item-${GenRandomId(5)}" class="tribute-item" role="option">${content}</div>`
 
 			const tributesCollection = []
 			tributesCollection.push({
@@ -572,6 +572,11 @@ export default {
 				selectTemplate: item => this.genSelectTemplate(item?.original?.id),
 				// Autocompletion results
 				values: this.debouncedAutoComplete,
+				// Class added to the menu container
+				containerClass: 'tribute-container tribute-container-autocomplete',
+				// Class added to each list item
+				itemClass: 'tribute-container__item',
+
 			})
 
 			if (this.emojiAutocomplete) {
@@ -618,9 +623,9 @@ export default {
 						cb(emojiResults)
 					},
 					// Class added to the menu container
-					containerClass: 'tribute-container-emoji',
+					containerClass: 'tribute-container tribute-container-emoji',
 					// Class added to each list item
-					itemClass: 'tribute-container-emoji__item',
+					itemClass: 'tribute-container__item tribute-container-emoji__item',
 				})
 			}
 
@@ -640,9 +645,9 @@ export default {
 					// Pass the search results as values
 					values: (text, cb) => cb(searchProvider(text)),
 					// Class added to the menu container
-					containerClass: 'tribute-container-link',
+					containerClass: 'tribute-container tribute-container-link',
 					// Class added to each list item
-					itemClass: 'tribute-container-link__item',
+					itemClass: 'tribute-container__item tribute-container-link__item',
 				})
 			}
 
@@ -1085,56 +1090,77 @@ export default {
 </style>
 
 <style lang="scss">
-.tribute-container, .tribute-container-emoji, .tribute-container-link {
+.tribute-container {
 	z-index: 9000;
 	overflow: auto;
-	min-width: 250px;
-	max-width: 300px;
-	// Show maximum 4 entries and a half to show scroll
-	// 44px + 10px padding
-	max-height: ($clickable-area + 20px) * 4.5;
 	// Space it out a bit from the text
-	margin: 5px 0;
-	color: var(--color-main-text);
+	margin: var(--default-grid-baseline) 0;
+	padding: var(--default-grid-baseline);
+	color: var(--color-text-maxcontrast);
 	border-radius: var(--border-radius);
 	background: var(--color-main-background);
 	box-shadow: 0 1px 5px var(--color-box-shadow);
-}
 
-.tribute-container-emoji, .tribute-container-link {
-	min-width: 200px;
-	max-width: 200px;
-	padding: 4px;
-	// Show maximum 5 entries and a half to show scroll
-	max-height: 35px * 5 + math.div(35px, 2) !important;
-
-	&__item {
-		border-radius: 8px;
-		padding: 4px 8px;
-		margin-bottom: 4px;
-		opacity: 0.8;
+	.tribute-container__item {
+		color: var(--color-max-contrast);
+		border-radius: var(--border-radius);
+		padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
+		margin-bottom: var(--default-grid-baseline);
 		cursor: pointer;
-
-		// Take care of long names
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 
 		&:last-child {
 			margin-bottom: 0;
 		}
 
-		&__emoji {
-			padding-right: 8px;
+		&.highlight {
+			color: var(--color-main-text);
+			background: var(--color-background-hover);
+
+			&, * {
+				cursor: pointer;
+			}
 		}
 	}
 
-	.highlight {
-		opacity: 1;
-		color: var(--color-primary-element-light-text);
-		background: var(--color-primary-element-light);
-		&, * {
-			cursor: pointer;
+	&.tribute-container--focus-visible {
+		.highlight.tribute-container__item {
+			outline: 2px solid var(--color-main-text) !important;
+		}
+	}
+}
+
+.tribute-container-autocomplete {
+	min-width: 250px;
+	max-width: 300px;
+	// Show maximum 4 entries and a half to show scroll
+	// Autocomplete height
+	// + 2 paddings around autocomplete
+	// + 2 paddings arouind tribute item
+	// + 1 padding gap
+	// And 1.5 paddings - container's padding without the last gap
+	max-height: calc((var(--default-clickable-area) + 5 * var(--default-grid-baseline)) * 4.5 - 1.5 * var(--default-grid-baseline));
+}
+
+.tribute-container-emoji,
+.tribute-container-link {
+	min-width: 200px;
+	max-width: 200px;
+	// Show maximum 5 entries and a half to show scroll
+	// Item height
+	// + 2 paddings around autocomplete
+	// + 2 paddings arouind tribute item
+	// + 1 padding gap
+	// And 1.5 paddings - container's padding without the last gap
+	max-height: calc((24px + 3 * var(--default-grid-baseline)) * 5.5 - 1.5 * var(--default-grid-baseline));
+
+	.tribute-item {
+		// Take care of long names
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+
+		&__emoji {
+			padding-right: calc(var(--default-grid-baseline) * 2);
 		}
 	}
 }
@@ -1142,7 +1168,7 @@ export default {
 .tribute-container-link {
 	min-width: 200px;
 	max-width: 300px;
-	&__item {
+	.tribute-item {
 		display: flex;
 		align-items: center;
 		&__title {
@@ -1155,7 +1181,7 @@ export default {
 			width: 20px;
 			height: 20px;
 			object-fit: contain;
-			padding-right: 8px;
+			padding-right: calc(var(--default-grid-baseline) * 2);
 			filter: var(--background-invert-if-dark);
 		}
 	}


### PR DESCRIPTION
### ☑️ Resolves

* Fix https://github.com/nextcloud/server/issues/41896

Adds a contrast outline border for keyboard navigation only.

Also, unifies styles in different autocompletes with NcActions and NcSelect components.

Previously, there were no "general" styles for the tribute container and items. Different autocompletes had a bit different styles on always individual classes. Now:
- There are common classes and structure is always:
  ```
  div.tribute-container (+ additional custom .tribute-container-NAME)
    ul
      li.tribute-container__item (+ .highlight + .tribute-container-NAME__item)
        div.tribute-item
          <custom content>
  ```
- An autocomplete item now:
  - Always has padding
  - Always has border radius
  - Always has `hover` background color same as `NcSelect` or `NcActions`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d07a7ab7-e024-4549-9b4f-9f0fc5d8e7ce) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/ad8156c9-b529-4807-8de1-085525d31d13)
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/2b927478-40b7-4118-a6bb-06cab421baa2) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9305d140-b733-46e9-a525-4e452dbf0a57)
![before-outline-autocomplete](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e006d2a3-3e8f-4023-9cd7-e2a669ed9880) | ![after-outline-autocomplete](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/c76fe3dc-4bd5-45c3-b80f-a70ded0fdf01)
![before-outline-emoji](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/2791d007-d1f3-45d9-91ab-6bdf07414391) | ![after-outline-emoji](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/4b6db646-6117-4a0f-98b5-3f16ffaaf550)

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/990b1615-208c-45ea-97a9-8d000db7ab73)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
