### PR TITLE
fix(NcRichContenteditable): bring back label for autocomplete

### DIFF
--- a/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
+++ b/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
@@ -34,10 +34,10 @@
 				:status="status.status" />
 		</div>
 
-		<!-- Title and subline -->
+		<!-- Label and subline -->
 		<span class="autocomplete-result__content">
-			<span class="autocomplete-result__title" :title="title">
-				{{ title }}
+			<span class="autocomplete-result__title" :title="labelWithFallback">
+				{{ labelWithFallback }}
 			</span>
 			<span v-if="subline" class="autocomplete-result__subline">
 				{{ subline }}
@@ -59,9 +59,18 @@ export default {
 	},
 
 	props: {
+		/**
+		 * @deprecated Use `label` instead
+		 */
 		title: {
 			type: String,
-			required: true,
+			required: false,
+			default: null,
+		},
+		label: {
+			type: String,
+			required: false,
+			default: null,
 		},
 		subline: {
 			type: String,
@@ -97,6 +106,10 @@ export default {
 			return this.id && this.source === 'users'
 				? this.getAvatarUrl(this.id, 44)
 				: null
+		},
+		// For backwards compatibility
+		labelWithFallback() {
+			return this.label || this.title
 		},
 	},
 

--- a/src/components/NcRichContenteditable/NcMentionBubble.vue
+++ b/src/components/NcRichContenteditable/NcMentionBubble.vue
@@ -31,7 +31,7 @@
 					class="mention-bubble__icon" />
 
 				<!-- Title -->
-				<span role="heading" class="mention-bubble__title" :title="title" />
+				<span role="heading" class="mention-bubble__title" :title="labelWithFallback" />
 			</span>
 
 			<!-- Selectable text for copy/paste -->
@@ -51,9 +51,18 @@ export default {
 			type: String,
 			required: true,
 		},
+		/**
+		 * @deprecated Use `label` instead
+		 */
 		title: {
 			type: String,
-			required: true,
+			required: false,
+			default: null,
+		},
+		label: {
+			type: String,
+			required: false,
+			default: null,
 		},
 		icon: {
 			type: String,
@@ -86,6 +95,10 @@ export default {
 			return !this.id.includes(' ') && !this.id.includes('/')
 				? `@${this.id}`
 				: `@"${this.id}"`
+		},
+		// Fallback to title for compatibility
+		labelWithFallback() {
+			return this.label || this.title
 		},
 	},
 

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -70,14 +70,14 @@ export default {
 				Test01: {
 					icon: 'icon-user',
 					id: 'Test01',
-					title: 'Test01',
+					label: 'Test01',
 					source: 'users',
 					primary: true,
 				},
 				Test02: {
 					icon: 'icon-user',
 					id: 'Test02',
-					title: 'Test02',
+					label: 'Test02',
 					source: 'users',
 					status: {
 						clearAt: null,
@@ -90,7 +90,7 @@ export default {
 				'Test@User': {
 					icon: 'icon-user',
 					id: 'Test@User',
-					title: 'Test 03',
+					label: 'Test 03',
 					source: 'users',
 					status: {
 						clearAt: null,
@@ -103,7 +103,7 @@ export default {
 				'Test Offline': {
 					icon: 'icon-user',
 					id: 'Test Offline',
-					title: 'Test Offline',
+					label: 'Test Offline',
 					source: 'users',
 					status: {
 						clearAt: null,
@@ -116,7 +116,7 @@ export default {
 				'Test DND': {
 					icon: 'icon-user',
 					id: 'Test DND',
-					title: 'Test DND',
+					label: 'Test DND',
 					source: 'users',
 					status: {
 						clearAt: null,
@@ -560,8 +560,8 @@ export default {
 				// Allow spaces in the middle of mentions
 				allowSpaces: true,
 				fillAttr: 'id',
-				// Search against id and title (display name)
-				lookup: result => `${result.id} ${result.title}`,
+				// Search against id and label (display name) (fallback to title for v8.0.0..8.6.1 compatibility)
+				lookup: result => `${result.id} ${result.label ?? result.title}`,
 				// Where to inject the menu popup
 				menuContainer: this.menuContainer,
 				// Popup mention autocompletion templates

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -168,14 +168,14 @@ See [NcRichContenteditable](#/Components/NcRichContenteditable) documentation fo
 					Test01: {
 						icon: 'icon-user',
 						id: 'Test01',
-						title: 'Test01',
+						label: 'Test01',
 						source: 'users',
 						primary: true,
 					},
 					Test02: {
 						icon: 'icon-user',
 						id: 'Test02',
-						title: 'Test02',
+						label: 'Test02',
 						source: 'users',
 						status: {
 							clearAt: null,
@@ -188,7 +188,7 @@ See [NcRichContenteditable](#/Components/NcRichContenteditable) documentation fo
 					'Test@User': {
 						icon: 'icon-user',
 						id: 'Test@User',
-						title: 'Test 03',
+						label: 'Test 03',
 						source: 'users',
 						status: {
 							clearAt: null,
@@ -201,7 +201,7 @@ See [NcRichContenteditable](#/Components/NcRichContenteditable) documentation fo
 					'Test Offline': {
 						icon: 'icon-user',
 						id: 'Test Offline',
-						title: 'Test Offline',
+						label: 'Test Offline',
 						source: 'users',
 						status: {
 							clearAt: null,
@@ -214,7 +214,7 @@ See [NcRichContenteditable](#/Components/NcRichContenteditable) documentation fo
 					'Test DND': {
 						icon: 'icon-user',
 						id: 'Test DND',
-						title: 'Test DND',
+						label: 'Test DND',
 						source: 'users',
 						status: {
 							clearAt: null,

--- a/tests/unit/mixins/richEditor.spec.js
+++ b/tests/unit/mixins/richEditor.spec.js
@@ -70,7 +70,7 @@ describe('richEditor.js', () => {
 					userData: {
 						jdoe: {
 							id: 'jdoe',
-							title: 'J. Doe',
+							label: 'J. Doe',
 							source: 'users',
 							icon: 'icon-user',
 						},


### PR DESCRIPTION
### ☑️ Resolves

* Kind of a regression of https://github.com/nextcloud-libraries/nextcloud-vue/pull/4222/

`NcAutoComplete` used in `NcRichContenteditable` had props that were in line with server API response for mentions.

In that PR `label` was renamed to `title`. not it is not possible to use mentions API resopnse without data mapping.

For example, in Talk https://github.com/nextcloud/spreed/pull/10626/commits/ea667ff6e1b9ae8515bd55b8d499a316b6dfe25f a work around was added:

https://github.com/nextcloud/spreed/blob/ea667ff6e1b9ae8515bd55b8d499a316b6dfe25f/src/components/NewMessage/NewMessage.vue#L709-L712

```js
// TODO fix backend for userMention
if (!possibleMention.title && possibleMention.label) {
	possibleMention.title = possibleMention.label
}
```

While in server it was forgotten: 

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d2de6c0b-e768-437b-a3e9-a16cbd6d171d)

This PR brings back `title` prop and uses `label` as a fallback for light migration.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/b2e4b535-18ab-49aa-885b-965839e1eade) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/134631e7-8f14-464c-92eb-c8466a4de194)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
