### PR TITLE
enh: added option to render icon and text for breadcrumb

### DIFF
--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -40,28 +40,19 @@ Renders a button element when given no redirection props, otherwise, renders <a/
 		@dragover.prevent="() => {}"
 		@dragenter="dragEnter"
 		@dragleave="dragLeave">
-		<NcButton v-if="(icon || $slots.icon) && !$slots.default"
+		<NcButton v-if="(name || icon || $slots.icon) && !$slots.default"
 			:title="title"
 			:aria-label="icon ? name : undefined"
 			type="tertiary"
 			v-bind="linkAttributes"
 			v-on="$listeners">
-			<template #icon>
+			<template v-if="$slots.icon || icon" #icon>
 				<!-- @slot Slot for passing a material design icon. Precedes the icon and name prop. -->
 				<slot name="icon">
 					<span :class="icon" class="icon" />
 				</slot>
 			</template>
-			<template v-if="forceIconText" #default>
-				{{ name }}
-			</template>
-		</NcButton>
-		<NcButton v-else-if="!$slots.default"
-			:aria-label="icon ? name : undefined"
-			type="tertiary"
-			v-bind="linkAttributes"
-			v-on="$listeners">
-			<template #default>
+			<template v-if="!($slots.icon || icon) || forceIconText" #default>
 				{{ name }}
 			</template>
 		</NcButton>

--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -40,19 +40,28 @@ Renders a button element when given no redirection props, otherwise, renders <a/
 		@dragover.prevent="() => {}"
 		@dragenter="dragEnter"
 		@dragleave="dragLeave">
-		<NcButton v-if="(name || icon) && !$slots.default"
+		<NcButton v-if="(icon || $slots.icon) && !$slots.default"
 			:title="title"
 			:aria-label="icon ? name : undefined"
 			type="tertiary"
 			v-bind="linkAttributes"
 			v-on="$listeners">
-			<template v-if="$slots.icon || icon" #icon>
+			<template #icon>
 				<!-- @slot Slot for passing a material design icon. Precedes the icon and name prop. -->
 				<slot name="icon">
 					<span :class="icon" class="icon" />
 				</slot>
 			</template>
-			<template v-else #default>
+			<template v-if="forceIconText" #default>
+				{{ name }}
+			</template>
+		</NcButton>
+		<NcButton v-else-if="!$slots.default"
+			:aria-label="icon ? name : undefined"
+			type="tertiary"
+			v-bind="linkAttributes"
+			v-on="$listeners">
+			<template #default>
 				{{ name }}
 			</template>
 		</NcButton>
@@ -137,11 +146,19 @@ export default {
 		},
 
 		/**
-		 * Set a css icon-class to show an icon instead of the name text.
+		 * Set a css icon-class to show an icon along name text (if forceIconText is provided, otherwise just icon).
 		 */
 		icon: {
 			type: String,
 			default: '',
+		},
+
+		/**
+		 * Enables text to accompany the icon, if the icon was provided. The text that will be displayed is the name prop.
+		 */
+		forceIconText: {
+			type: Boolean,
+			default: false,
 		},
 
 		/**


### PR DESCRIPTION
For nextcloud/server#43604

### 🖼️ Screenshots

🏡 After
-
![firefox_FroddX5muA](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/92754606-71d9-4fae-b3b4-77ca17d6b148)
-

## Summary
* To prevent a breaking change, I decided to add a prop that user configures to enable the nationality to add text to accompany a icon breadcrumb that is a NcButton, and not an NcAction.
* Since default for iconText is false, all previous library users of NcBreadcrumb will not have breaking changes
* Library now allows user to have NcButton with just text, just icon, and now icon and text 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
