### PR TITLE
feat(NcAppSidebar): move focus to sidebar on open and auto return focus on close

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1249,10 +1249,15 @@ export default {
 			 */
 			this.$emit('open')
 		},
-		closeMenu(returnFocus = true) {
+		async closeMenu(returnFocus = true) {
 			if (!this.opened) {
 				return
 			}
+
+			// Wait for the next tick to keep the menu in DOM, allowing other components to find what button in what menu was used,
+			// for example, to implement auto set return focus.
+			// NcPopover will actually remove the menu from DOM also on the next tick.
+			await this.$nextTick()
 
 			this.opened = false
 

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -348,6 +348,7 @@ export default {
 		<aside id="app-sidebar-vue"
 			ref="sidebar"
 			class="app-sidebar"
+			:aria-labelledby="`app-sidebar-vue-${uid}__header`"
 			@keydown.esc.stop="isMobile && closeSidebar()">
 			<header :class="{
 					'app-sidebar-header--with-figure': hasFigure,
@@ -403,6 +404,7 @@ export default {
 							<div class="app-sidebar-header__mainname-container">
 								<!-- main name -->
 								<h2 v-show="!nameEditable"
+									:id="`app-sidebar-vue-${uid}__header`"
 									v-linkify="{text: name, linkify: linkifyName}"
 									:aria-label="title"
 									:title="title"
@@ -492,6 +494,7 @@ import Focus from '../../directives/Focus/index.js'
 import Linkify from '../../directives/Linkify/index.js'
 import Tooltip from '../../directives/Tooltip/index.js'
 import { useIsSmallMobile } from '../../composables/useIsMobile/index.js'
+import GenRandomId from '../../utils/GenRandomId.js'
 import { getTrapStack } from '../../utils/focusTrap.js'
 import { t } from '../../l10n.js'
 
@@ -650,6 +653,7 @@ export default {
 
 	setup() {
 		return {
+			uid: GenRandomId(),
 			isMobile: useIsSmallMobile(),
 		}
 	},

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -865,6 +865,17 @@ export default {
 		},
 
 		/**
+		 * Focus the active tab
+		 * @public
+		 */
+		focusActiveTabContent() {
+			// If a tab is focused then probably a new trigger element moved the focus to the sidebar
+			this.preserveElementToReturnFocus()
+
+			this.$refs.tabs.focusActiveTabContent()
+		},
+
+		/**
 		 * Emit name change event to parent component
 		 *
 		 * @param {Event} event input event

--- a/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
+++ b/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
@@ -30,8 +30,8 @@
 		:aria-label="isTablistShown() ? undefined : name"
 		:aria-labelledby="isTablistShown() ? `tab-button-${id}` : undefined"
 		class="app-sidebar__tab"
-		tabindex="0"
-		role="tabpanel"
+		:tabindex="isTablistShown() ? 0 : -1"
+		:role="isTablistShown() ? 'tabpanel' : undefined"
 		@scroll="onScroll">
 		<h3 class="hidden-visually">
 			{{ name }}


### PR DESCRIPTION
### ☑️ Resolves

* Fix for https://github.com/nextcloud/server/issues/41877
* Can be tested with https://github.com/nextcloud/server/pull/42444

See description in commits.

## Screenshots

### On desktop

1. Open sidebar
2. Focus is moved to the sidebar
3. Close sidebar
4. Focus is moved to the trigger button
5. For menu - special case, return to the menu trigger

https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a286b6a2-5a55-4d70-bd39-674016000bc4

### On mobile with focus-trap - also works

https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/2dd59a40-0587-4c64-8e96-ebd0e70df85a

### When sidebar was open, but a new file or tab was selected — focus is moved to the tab, and the element to return is updated

https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/6698351a-883b-4162-850f-6c250081f11d

### When the sidebar is initially open on page load - no focus move

https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/7d940181-8ee8-43c0-88bd-50d42f7aa60e

### Also works for apps

https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/0dab45a7-e618-4a11-9fcb-ca8962d60dae

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
