### PR TITLE
release: v8.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v8.6.2](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.6.2) (2024-02-07)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.6.1...v8.6.2)
+
+### 📝 Notes
+* In `NcRichContenteditable` properties `autoComplete.title`/`userData.title` were renamed back to `label` to be in line with server API. The `title` property is still working as a fallback, but deprecated. See https://github.com/nextcloud-libraries/nextcloud-vue/pull/5215
+
+### 🐛 Fixed bugs
+* fix(NcHeaderMenu): button size regression on small viewports fixed by @emoral435 in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5149
+* fix(NcListItem): Remove actions from within `a` which caused invalid HTML output by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5198
+* fix(NcRichContenteditable): make autocomplete accessible by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4904
+* fix(NcRichContenteditable): unify styles and add contrast border on keyboard navigation by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5214
+* fix(NcRichContenteditable): bring back label for autocomplete by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5215
+* fix(NcAppSidebar): move focus to sidebar on open and auto return focus on close by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5219
+
+### Other Changes
+* chore(NcSelect): Mention labelOutside for external label use by @Pytal in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5211
+
 ## [v8.6.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.6.1) (2024-02-01)
-[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.6.0...v8.6.1)
 
 ### 🐛 Fixed bugs
 * fix(NcAppNavigationNewItem): bring back correct CSS class [\#5194](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5194) \([raimund-schluessler](https://github.com/raimund-schluessler)\)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.6.1",
+      "version": "8.6.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v8.6.2](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.6.1) (2024-02-07)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.6.1...v8.6.2)
### 📝 Notes
* In `NcRichContenteditable` properties `autoComplete.title`/`userData.title` were renamed back to `label` to be in line with server API. The `title` property is still working as a fallback, but deprecated. See https://github.com/nextcloud-libraries/nextcloud-vue/pull/5215

### 🐛 Fixed bugs
* fix(NcHeaderMenu): button size regression on small viewports fixed by @emoral435 in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5149
* fix(NcListItem): Remove actions from within `a` which caused invalid HTML output by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5198
* fix(NcRichContenteditable): make autocomplete accessible by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/4904
* fix(NcRichContenteditable): unify styles and add contrast border on keyboard navigation by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5214
* fix(NcRichContenteditable): bring back label for autocomplete by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5215
* fix(NcAppSidebar): move focus to sidebar on open and auto return focus on close by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5219

### Other Changes
* chore(NcSelect): Mention labelOutside for external label use by @Pytal in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5211