### PR TITLE
Comment textarea placeholder stickiness fix

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -1059,7 +1059,6 @@ export default {
 		&--empty:not(&--has-label):before {
 			content: attr(aria-placeholder);
 			color: var(--color-text-maxcontrast);
-			position: absolute;
 		}
 
 		&[contenteditable='false']:not(&--disabled) {


### PR DESCRIPTION
Fixes comment textarea placeholder stickiness. Seen in Circles. I don't have other usage of this field in other apps. I think we should check if it doesn't create problems elsewhere. 

Check the video to understand : 

[Capture vidéo du 09-02-2024 09:57:10.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/33763786/252291ba-0b52-45c8-ba4c-03cf44a930d2)


