### PR TITLE
chore: add backport to `next` (Vue 3) in the PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,12 @@
 ### ☑️ Resolves
 
-* Fix #…
+- Fix #…
 
 ### 🖼️ Screenshots
 
 🏚️ Before | 🏡 After
 ---|---
 B | A
-
 
 ### 🚧 Tasks
 
@@ -17,3 +16,4 @@ B | A
 
 - [ ] ⛑️ Tests are included or are not applicable
 - [ ] 📘 Component documentation has been extended, updated or is not applicable
+- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade


### PR DESCRIPTION
@raimund-schluessler Would it be a good alternative for merging `master` into `next`?