### PR TITLE
fix(NcReferenceWidget): `useResizeObserver`

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -20,6 +20,7 @@
 </template>
 <script>
 import { renderWidget, isWidgetRegistered, destroyWidget } from './../../functions/reference/widgets.js'
+import { useResizeObserver } from '@vueuse/core'
 
 export default {
 	name: 'NcReferenceWidget',
@@ -71,7 +72,7 @@ export default {
 	},
 	mounted() {
 		this.renderWidget()
-		this.observer = new ResizeObserver(entries => {
+		useResizeObserver(this.$el, entries => {
 			if (entries[0].contentRect.width < 450) {
 				this.compact = 0
 			} else if (entries[0].contentRect.width < 550) {
@@ -83,10 +84,8 @@ export default {
 			}
 
 		})
-		this.observer.observe(this.$el)
 	},
 	beforeDestroy() {
-		this.observer.disconnect()
 		destroyWidget(this.reference.richObjectType, this.$el)
 	},
 	methods: {


### PR DESCRIPTION
* `new ResizeObserver(...)` is not available in some contexts. `useResizeObserver` handles these gracefully.

* `useResizeObserver` also takes care of the cleanup. See https://v5-3-0.vueuse.org/core/useresizeobserver/#usage .

### ☑️ Resolves

- Fix `"ReferenceError: ResizeObserver is not defined"` in [jest tests](https://github.com/nextcloud/text/actions/runs/7862298422/job/21451607906#step:7:13)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/97337118/66c376d9-a3d4-49ad-80f2-459192f244f3)| ![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/97337118/532318b8-b4b0-4f42-89d6-8a754514b560)


### 🏁 Checklist

- [x] ⛑️ Tests are not applicable
- [x] 📘 Component documentation is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
