### PR TITLE
fix(NcModal): scope modal-container size to current modal, don't propagate it on nested

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -1004,28 +1004,28 @@ export default {
 
 	// Sizing
 	&--small {
-		.modal-container {
+		& > .modal-container {
 			width: 400px;
 			max-width: 90%;
 			max-height: $max-modal-height;
 		}
 	}
 	&--normal {
-		.modal-container {
+		& > .modal-container {
 			max-width: 90%;
 			width: 600px;
 			max-height: $max-modal-height;
 		}
 	}
 	&--large {
-		.modal-container {
+		& > .modal-container {
 			max-width: 90%;
 			width: 900px;
 			max-height: $max-modal-height;
 		}
 	}
 	&--full {
-		.modal-container {
+		& > .modal-container {
 			width: 100%;
 			height: calc(100% - var(--header-height));
 			position: absolute;


### PR DESCRIPTION
### ☑️ Resolves

- Fix #5228

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-02-12 10-48-17](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/4da5fbc2-9d15-468f-9304-0fa54c9d6202) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/6e74998a-e541-428e-b271-5355a4886d9b)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
