### PR TITLE
feat(NcRichText): handle internal links with Vue Router

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -4,10 +4,10 @@
 			<div ref="customWidget" />
 		</div>
 
-		<a v-else-if="!noAccess && reference && reference.openGraphObject && !hasCustomWidget"
-			:href="reference.openGraphObject.link"
+		<component :is="referenceWidgetLinkComponent"
+			v-else-if="!noAccess && reference && reference.openGraphObject && !hasCustomWidget"
+			v-bind="referenceWidgetLinkProps"
 			rel="noopener noreferrer"
-			target="_blank"
 			class="widget-default">
 			<img v-if="reference.openGraphObject.thumb" class="widget-default--image" :src="reference.openGraphObject.thumb">
 			<div class="widget-default--details">
@@ -15,10 +15,13 @@
 				<p class="widget-default--description" :style="descriptionStyle">{{ reference.openGraphObject.description }}</p>
 				<p class="widget-default--link">{{ compactLink }}</p>
 			</div>
-		</a>
+		</component>
 	</div>
 </template>
 <script>
+import { RouterLink } from 'vue-router'
+
+import { getRoute } from './autolink.js'
 import { renderWidget, isWidgetRegistered, destroyWidget } from './../../functions/reference/widgets.js'
 
 export default {
@@ -67,6 +70,17 @@ export default {
 				return link.substring(7)
 			}
 			return link
+		},
+		route() {
+			return getRoute(this.$router, this.reference.openGraphObject.link)
+		},
+		referenceWidgetLinkComponent() {
+			return this.route ? RouterLink : 'a'
+		},
+		referenceWidgetLinkProps() {
+			return this.route
+				? { to: this.route }
+				: { href: this.reference.openGraphObject.link, target: '_blank' }
 		},
 	},
 	mounted() {

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -291,7 +291,7 @@ See [NcRichContenteditable](#/Components/NcRichContenteditable) documentation fo
 <script>
 import NcReferenceList from './NcReferenceList.vue'
 import NcCheckboxRadioSwitch from '../NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue'
-import { remarkAutolink } from './autolink.js'
+import { getRoute, remarkAutolink } from './autolink.js'
 import { remarkPlaceholder, prepareTextNode } from './placeholder.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 
@@ -302,6 +302,7 @@ import breaks from 'remark-breaks'
 import remark2rehype from 'remark-rehype'
 import rehype2react from 'rehype-react'
 import rehypeExternalLinks from 'rehype-external-links'
+import { RouterLink } from 'vue-router'
 
 export default {
 	name: 'NcRichText',
@@ -458,6 +459,22 @@ export default {
 									return h(tag, attrs, [inputComponent])
 								}
 							}
+
+							if (tag === 'a') {
+								const route = getRoute(this.$router, attrs.attrs.href)
+								if (route) {
+									delete attrs.attrs.href
+									delete attrs.attrs.target
+
+									return h(RouterLink, {
+										...attrs,
+										props: {
+											to: route,
+										},
+									}, children)
+								}
+							}
+
 							return h(tag, attrs, children)
 						}
 

--- a/src/components/NcRichText/autolink.js
+++ b/src/components/NcRichText/autolink.js
@@ -2,6 +2,7 @@ import { URL_PATTERN_AUTOLINK } from './helpers.js'
 
 import { visit, SKIP } from 'unist-util-visit'
 import { u } from 'unist-builder'
+import { getBaseUrl } from '@nextcloud/router'
 
 const NcLink = {
 	name: 'NcLink',
@@ -81,4 +82,22 @@ export const parseUrl = (text) => {
 	}
 	console.error('Failed to reassemble the chunked text: ' + text)
 	return text
+}
+
+export const getRoute = (router, url) => {
+	// Skip if Router is not defined in app, or baseUrl does not match
+	if (!router || !url.includes(getBaseUrl())) {
+		return null
+	}
+
+	const regexArray = router.getRoutes()
+		// route.regex matches only complete string (^.$), need to remove these characters
+		.map(route => new RegExp(route.regex.source.slice(1, -1), route.regex.flags))
+
+	for (const regex of regexArray) {
+		const match = url.search(regex)
+		if (match !== -1) {
+			return url.slice(match)
+		}
+	}
 }


### PR DESCRIPTION
### ☑️ Resolves

- Ref https://github.com/nextcloud/spreed/issues/10565
- Ref https://github.com/nextcloud/spreed/issues/8855

### 🖼️ Screenshots

Tested against Talk:
- link to app root `/apps/spreed`
- links between different conversation `/call/{token}`
- links between specific messages `/call/{token}#message_id`
- both inline links and previews in NcReferenceWidget

Cursor is missing, but browser address bar is visible

https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/9706a0d3-1e88-4dda-b897-4e6e28d7e7c2



### 🚧 Tasks

- [ ] Code review
- [ ] Test coverage

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
