### PR TITLE
fix: regression in list item's extra slot

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -394,20 +394,19 @@
 							</div>
 						</div>
 					</div>
+					<!-- Actions -->
+					<div v-show="forceDisplayActions || displayActionsOnHoverFocus"
+						class="list-item-content__actions"
+						@focusout="handleBlur">
+						<NcActions ref="actions"
+							:primary="isActive || active"
+							:aria-label="computedActionsAriaLabel"
+							@update:open="handleActionsUpdateOpen">
+							<!-- @slot Provide the actions for the right side quick menu -->
+							<slot name="actions" />
+						</NcActions>
+					</div>
 				</a>
-
-				<!-- Actions -->
-				<div v-show="forceDisplayActions || displayActionsOnHoverFocus"
-					class="list-item-content__actions"
-					@focusout="handleBlur">
-					<NcActions ref="actions"
-						:primary="isActive || active"
-						:aria-label="computedActionsAriaLabel"
-						@update:open="handleActionsUpdateOpen">
-						<!-- @slot Provide the actions for the right side quick menu -->
-						<slot name="actions" />
-					</NcActions>
-				</div>
 
 				<!-- @slot Extra elements below the item -->
 				<div v-if="$slots.extra" class="list-item__extra">
@@ -732,7 +731,7 @@ export default {
 // NcListItem
 .list-item {
 	box-sizing: border-box;
-	display: flex;
+	display: block;
 	position: relative;
 	flex: 0 0 auto;
 	justify-content: flex-start;


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/mail/issues/9334

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="307" alt="image" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/40746210/326d531e-8a58-48bc-a413-9efb99c05718"> | <img width="307" alt="image" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/40746210/e1e9588e-1e81-4a0c-a693-45611b67cef7">

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
