### PR TITLE
fix(NcListItem): compensate added margin for list items

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -737,12 +737,12 @@ export default {
 	flex: 0 0 auto;
 	justify-content: flex-start;
 	padding: 8px 10px;
-	// 4px padding for the focus-visible styles
+	// 4px padding for the focus-visible styles. Width is reduced to compensate it
 	margin: 4px;
+	width: calc(100% - 8px);
 	// Fix for border-radius being too large for 3-line entries like in Mail
 	// 44px avatar size / 2 + 8px padding, and 2px for better visual quality
 	border-radius: 32px;
-	width: 100%;
 	cursor: pointer;
 	transition: background-color var(--animation-quick) ease-in-out;
 	list-style: none;


### PR DESCRIPTION
### ☑️ Resolves

- Fix regression from #5198

### 🖼️ Screenshots

Tested against Talk

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-02-19 10-47-38](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/e0fa06bb-477e-47bb-b59e-132794e590d3) | ![Screenshot from 2024-02-19 10-48-57](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/64d75605-331e-49ad-ba3d-43decf03d5de)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
