### PR TITLE
fix(NcRichContenteditable): register props globally for new Tribute

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -557,13 +557,9 @@ export default {
 
 			const tributesCollection = []
 			tributesCollection.push({
-				// Allow spaces in the middle of mentions
-				allowSpaces: true,
 				fillAttr: 'id',
 				// Search against id and label (display name) (fallback to title for v8.0.0..8.6.1 compatibility)
 				lookup: result => `${result.id} ${result.label ?? result.title}`,
-				// Where to inject the menu popup
-				menuContainer: this.menuContainer,
 				// Popup mention autocompletion templates
 				menuItemTemplate: item => renderMenuItem(this.renderComponentHtml(item.original, NcAutoCompleteResult)),
 				// Hide if no results
@@ -585,8 +581,6 @@ export default {
 					// Don't use the tribute search function at all
 					// We pass search results as values (see below)
 					lookup: (result, query) => query,
-					// Where to inject the menu popup
-					menuContainer: this.menuContainer,
 					// Popup mention autocompletion templates
 					menuItemTemplate: item => {
 						if (textSmiles.includes(item.original)) {
@@ -635,8 +629,6 @@ export default {
 					// Don't use the tribute search function at all
 					// We pass search results as values (see below)
 					lookup: (result, query) => query,
-					// Where to inject the menu popup
-					menuContainer: this.menuContainer,
 					// Popup mention autocompletion templates
 					menuItemTemplate: item => renderMenuItem(`<img class="${this.$style['tribute-item__icon']}" src="${item.original.icon_url}"> <span class="${this.$style['tribute-item__title']}">${item.original.title}</span>`),
 					// Hide if no results
@@ -651,7 +643,13 @@ export default {
 				})
 			}
 
-			this.tribute = new Tribute({ collection: tributesCollection })
+			this.tribute = new Tribute({
+				collection: tributesCollection,
+				// Allow spaces in the middle of mentions
+				allowSpaces: true,
+				// Where to inject the menu popup
+				menuContainer: this.menuContainer,
+			})
 			this.tribute.attach(this.$refs.contenteditable)
 		},
 
@@ -1093,6 +1091,9 @@ export default {
 .tribute-container {
 	z-index: 9000;
 	overflow: auto;
+	// Hide container root element while initialising
+	position: absolute;
+	left: -10000px;
 	// Space it out a bit from the text
 	margin: var(--default-grid-baseline) 0;
 	padding: var(--default-grid-baseline);


### PR DESCRIPTION
### ☑️ Resolves

- Fix regression from #4904 
  - documentation on https://github.com/zurb/tribute#a-collection claims props such as `allowSpaces` and `menuContainer` to be a part of `Collection`, although they should be registered globally, if there are a collections array
  - modify initial styles for root element, so it will be rendered outside of viewport and won't break layout

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-02-20 11-53-44](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/efc96e5b-6307-41f0-a7bb-a6a12d13891b) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/fbf26d65-339d-44a1-807d-d4d8a7b4596f)

🏚️ Before 

[Screencast from 20.02.2024 12:35:34.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/12e27b36-a933-4389-a427-0d5e8578ee37)

🏡 After

[Screencast from 20.02.2024 12:59:51.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/b066da53-dd8b-49c7-905d-b27e4f03afe2)

### 🚧 Tasks

- [ ] Check other props

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
