### PR TITLE
fix: Center dashboard list items when there is no subtext

### DIFF
--- a/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
+++ b/src/components/NcDashboardWidgetItem/NcDashboardWidgetItem.vue
@@ -52,7 +52,7 @@ This component is meant to be used inside a DashboardWidget component.
 				<h3 :title="mainText">
 					{{ mainText }}
 				</h3>
-				<span class="message" :title="subText">
+				<span v-if="subText !== ''" class="message" :title="subText">
 					{{ subText }}
 				</span>
 			</div>
@@ -219,6 +219,8 @@ export default {
 		overflow: hidden;
 		display: flex;
 		flex-direction: column;
+		justify-content: center;
+		min-height: 44px;
 
 		h3,
 		.message {


### PR DESCRIPTION
If we have no subtext the title shall be centered to the image

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2024-02-20 at 18 45 46](https://github.com/nextcloud-libraries/nextcloud-vue/assets/3404133/5978a61d-8034-4ca4-8e1b-141ddb0439f0) | ![Screenshot 2024-02-20 at 18 45 24](https://github.com/nextcloud-libraries/nextcloud-vue/assets/3404133/5161f0d8-f1fd-4874-a1de-8c40f65e3046)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
