### PR TITLE
fix(NcReferenceList): Resolve relative URLs before fetching references

### DIFF
--- a/src/components/NcRichText/NcReferenceList.vue
+++ b/src/components/NcRichText/NcReferenceList.vue
@@ -82,6 +82,9 @@ export default {
 				richObjectType: 'open-graph',
 			}
 		},
+		fullUrl() {
+			return new URL(this.text.trim(), window.location)
+		},
 	},
 	watch: {
 		text: 'fetch',
@@ -97,7 +100,7 @@ export default {
 				return
 			}
 
-			if (!(new RegExp(URL_PATTERN).exec(this.text))) {
+			if (!(new RegExp(URL_PATTERN).exec(this.fullUrl.href))) {
 				this.loading = false
 				return
 			}
@@ -113,7 +116,7 @@ export default {
 			})
 		},
 		resolve() {
-			const match = (new RegExp(URL_PATTERN).exec(this.text.trim()))
+			const match = (new RegExp(URL_PATTERN).exec(this.fullUrl.href))
 			if (this.limit === 1 && match) {
 				return axios.get(generateOcsUrl('references/resolve', 2) + `?reference=${encodeURIComponent(match[0])}`)
 			}


### PR DESCRIPTION
Resolve relative URLs and those without a location using `window.location` before fetching references for them. This fixes e.g. getting references for relative links to other pages in Collectives.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
