### PR TITLE
8.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v8.7.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.7.1) (2024-02-21)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.7.0...v8.7.1)
+
+## What's Changed
+
+### 🐛 Fixed bugs
+* fix(NcRichContenteditable): register props globally for new Tribute by @Antreesy in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5268
+* fix(NcReferenceList): Resolve relative URLs before fetching references by @mejo- in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5272
+* fix(NcDashboardWidgetItem): Center dashboard list items when there is no subtext by @juliushaertl in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5271
+
 ## [v8.7.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.7.0) (2024-02-20)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.6.2...v8.7.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v8.7.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.7.1) (2024-02-21)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.7.0...v8.7.1)

## What's Changed

### 🐛 Fixed bugs
* fix(NcRichContenteditable): register props globally for new Tribute by @Antreesy in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5268
* fix(NcReferenceList): Resolve relative URLs before fetching references by @mejo- in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5272
* fix(NcDashboardWidgetItem): Center dashboard list items when there is no subtext by @juliushaertl in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5271

