### PR TITLE
fix(NcResource): use RouterLink where possible for internal shared resources

### DIFF
--- a/src/components/NcRelatedResourcesPanel/NcResource.vue
+++ b/src/components/NcRelatedResourcesPanel/NcResource.vue
@@ -25,7 +25,8 @@
 		<NcButton class="resource__button"
 			:aria-label="labelTranslated"
 			type="tertiary"
-			:href="url">
+			:to="route"
+			:href="route ? null : url">
 			<template #icon>
 				<div class="resource__icon">
 					<img :src="icon">
@@ -39,6 +40,7 @@
 <script>
 import NcButton from '../NcButton/index.js'
 
+import { getRoute } from '../NcRichText/autolink.js'
 import { t } from '../../l10n.js'
 
 export default {
@@ -67,6 +69,12 @@ export default {
 		return {
 			labelTranslated: t('Open link to "{resourceName}"', { resourceName: this.name }),
 		}
+	},
+
+	computed: {
+		route() {
+			return getRoute(this.$router, this.url)
+		},
 	},
 
 	methods: {


### PR DESCRIPTION
### ☑️ Resolves

- Reuse logic introduced in #5246 for Resource panel
  - Allows to navigate between shared sources within one app (Talk on example)
  - As logic is alreasy presented (`getRoute()` + `NcButton::to`), not considering it as breaking / feature for minor release

### 🖼️ Screenshots

[Screencast from 21.02.2024 17:44:23.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/5345d971-6289-4e87-8e61-464b8ad2decd)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade