### PR TITLE
fix(a11y): Revert "fix(NcAppNav): changed h2 to span"

### DIFF
--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -100,9 +100,9 @@
 <template>
 	<li class="app-navigation-caption">
 		<!-- Name of the caption -->
-		<span class="app-navigation-caption__name">
+		<h2 class="app-navigation-caption__name">
 			{{ name }}
-		</span>
+		</h2>
 
 		<!-- Actions -->
 		<div v-if="hasActions"
@@ -172,7 +172,6 @@ export default {
 		flex-shrink: 0;
 		// padding to align the name with the icon of app navigation items
 		padding: 0 calc(var(--default-grid-baseline, 4px) * 2) 0 calc(var(--default-grid-baseline, 4px) * 3);
-		margin-bottom: 12px;
 	}
 
 	&__actions {


### PR DESCRIPTION
### Summary

- Revert https://github.com/nextcloud-libraries/nextcloud-vue/pull/5020 as the original implementation was already correct 🙈

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade