### PR TITLE
chore(NcAppContent): rename NcAppDetailsContent to remove from docs

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -81,7 +81,7 @@ The list size must be between the min and the max width value.
 			<div v-if="isMobile"
 				:class="showDetails ? 'app-content-wrapper--show-details' : 'app-content-wrapper--show-list'"
 				class="app-content-wrapper app-content-wrapper--mobile">
-				<NcAppDetailsToggle v-if="hasList && showDetails" @click.native.stop.prevent="hideDetails" />
+				<NcAppContentDetailsToggle v-if="hasList && showDetails" @click.native.stop.prevent="hideDetails" />
 
 				<slot name="list" />
 				<slot />
@@ -115,7 +115,7 @@ The list size must be between the min and the max width value.
 </template>
 
 <script>
-import NcAppDetailsToggle from './NcAppDetailsToggle.vue'
+import NcAppContentDetailsToggle from './NcAppContentDetailsToggle.vue'
 import { useIsMobile } from '../../composables/useIsMobile/index.js'
 
 import { getBuilder } from '@nextcloud/browser-storage'
@@ -135,7 +135,7 @@ export default {
 	name: 'NcAppContent',
 
 	components: {
-		NcAppDetailsToggle,
+		NcAppContentDetailsToggle,
 		Pane,
 		Splitpanes,
 	},

--- a/src/components/NcAppContent/NcAppContentDetailsToggle.vue
+++ b/src/components/NcAppContent/NcAppContentDetailsToggle.vue
@@ -38,7 +38,7 @@ import { emit } from '@nextcloud/event-bus'
 import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 
 export default {
-	name: 'NcAppDetailsToggle',
+	name: 'NcAppContentDetailsToggle',
 
 	directives: {
 		tooltip: Tooltip,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -144,7 +144,8 @@ module.exports = async () => {
 							{
 								name: 'NcAppContent',
 								components: [
-									'src/components/NcAppContent*/*.vue',
+									'src/components/NcAppContent/NcAppContent.vue',
+									'src/components/NcAppContent[A-Z]*/*.vue',
 								],
 							},
 							{


### PR DESCRIPTION
`NcAppDetailsToggle` in internal component of `NcAppContent` and is not exported.

- Rename to `NcAppContentDetailsToggle` to follow naming guidelines
- Remove from docs

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
