### PR TITLE
Remove `aria-haspopup` and `aria-controls` from navigation menu

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1521,8 +1521,8 @@ export default {
 		const actionsRoleToHtmlPopupRole = {
 			dialog: 'dialog',
 			menu: 'menu',
-			navigation: 'true',
-			tooltip: 'true',
+			navigation: undefined,
+			tooltip: undefined,
 		}
 		const popupRole = actionsRoleToHtmlPopupRole[this.actionsMenuSemanticType]
 
@@ -1662,7 +1662,8 @@ export default {
 						ref: 'menuButton',
 						attrs: {
 							'aria-label': this.menuName ? null : this.ariaLabel,
-							'aria-controls': this.opened ? this.randomId : null,
+							// 'aria-controls' is not needed for navigation menu
+							'aria-controls': this.opened && popupRole ? this.randomId : null,
 						},
 						on: {
 							focus: this.onFocus,
@@ -1690,7 +1691,7 @@ export default {
 							attrs: {
 								id: this.randomId,
 								tabindex: '-1',
-								role: popupRole !== 'true' ? popupRole : undefined,
+								role: popupRole,
 								// TODO: allow to provide dialog aria-label
 							},
 						}, [

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -209,10 +209,11 @@ export default {
 		/**
 		 * Popup role
 		 * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup#values
+		 * By default undefined because popup can't be always as menu
 		 */
 		popupRole: {
 			type: String,
-			default: 'true',
+			default: undefined,
 			validator: (value) => ['menu', 'listbox', 'tree', 'grid', 'dialog', 'true'].includes(value),
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

- Resolves:  "More apps" action button have two unneeded attrs: `aria-haspopup` and `aria-controls`. It is enough to have only `aria-expanded` in this case.

Every navigation "menu" which contains only links should not have additional attributes `aria-haspopup` and `aria-controls`.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-02-23 17-36-57](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/fcd74a7f-4062-49d2-bb2d-51aaf05cdfa6) | ![Screenshot from 2024-02-23 17-38-08](https://github.com/nextcloud-libraries/nextcloud-vue/assets/6078378/8df9845e-3dd3-491a-adad-028c4d5dc67c)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
