### PR TITLE
fix(NcPopover): make popupRole non-required

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -209,7 +209,6 @@ export default {
 		/**
 		 * Popup role
 		 * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup#values
-		 * By default undefined because popup can't be always as menu
 		 */
 		popupRole: {
 			type: String,
@@ -283,7 +282,7 @@ export default {
 				// TODO: Vue 3: should be
 				// this.$refs.popover.$refs.popper.$refs.reference
 				const triggerContainer = this.$refs.popover.$refs.reference
-				const requiredTriggerButton = triggerContainer.querySelector('[aria-expanded][aria-haspopup]')
+				const requiredTriggerButton = triggerContainer.querySelector('[aria-expanded]')
 				if (!requiredTriggerButton) {
 					Vue.util.warn('It looks like you are using a custom button as a <NcPopover> or other popover #trigger. If you are not using <NcButton> as a trigger, you need to bind attrs from the #trigger slot props to your custom button. See <NcPopover> docs for an example.')
 				}

--- a/src/components/NcPopover/NcPopoverTriggerProvider.vue
+++ b/src/components/NcPopover/NcPopoverTriggerProvider.vue
@@ -18,7 +18,7 @@ export default defineComponent({
 		},
 		popupRole: {
 			type: String,
-			required: true,
+			default: undefined,
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

- A small regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/5300
- `popupRole` was made non-required in `NcPopover` but then it should also be non-required in `NcPopoverTriggerProvider`

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/9e74bbb5-2153-4f1d-aa69-fbf24c99c063)

- And because `aria-haspopup` is not required now, it should not be checked when checking for required attrs

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/4e2ab5ff-ad25-466a-8312-a745464f6055)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
