### PR TITLE
fix(NcActions): focus first checked item on open

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1504,11 +1504,13 @@ export default {
 		focusFirstAction(event) {
 			if (this.opened) {
 				this.preventIfEvent(event)
-				// In case a button is considered aria-selected we will use this one as a initial focus
-				const firstSelectedIndex = [...this.getFocusableMenuItemElements()].findIndex((button) => {
-					return button.parentElement.getAttribute('aria-selected')
+				// In case a NcActionButton is considered checked we will use this one as a initial focus
+				// Having aria-checked is the simplest way to determine the checked state of a button
+				// TODO: determine when we need to focus the first checked item and when we not, for example, if menu has many radio groups
+				const firstCheckedIndex = [...this.getFocusableMenuItemElements()].findIndex((button) => {
+					return button.getAttribute('aria-checked') === 'true' && button.getAttribute('role') === 'menuitemradio'
 				})
-				this.focusIndex = firstSelectedIndex > -1 ? firstSelectedIndex : 0
+				this.focusIndex = firstCheckedIndex > -1 ? firstCheckedIndex : 0
 				this.focusAction()
 			}
 		},


### PR DESCRIPTION
### ☑️ Resolves

- Brings back https://github.com/nextcloud-libraries/nextcloud-vue/pull/4678 after changes in the component
- `aria-selected` should be `aria-checked`
- `aria-checked` should not only present, but be `'true'`
- `aria-checked` must be on the focusable element itself (otherwise there is an a11y issue)
- New possibility — check only radio buttons

IMO, this should happen only when ALL the buttons are one radio button group. But it is required even for heading in Text, where we have "Show outline" button together with heading radio buttons.

The solution is still not reliable, but I don't see any other simple solution... 

### 🖼️ Screenshots

![focus-first-action](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/36813107-067c-49d0-b3a8-3a1825d90f17)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
