### PR TITLE
fix(NcRichContenteditable): disable global allowSpaces tribute option

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -645,8 +645,9 @@ export default {
 
 			this.tribute = new Tribute({
 				collection: tributesCollection,
-				// Allow spaces in the middle of mentions
-				allowSpaces: true,
+				// FIXME: tributejs doesn't support allowSpaces as a collection option, only as a global one
+				// Requires to fork a library to allow spaces only in the middle of mentions ('@' trigger)
+				allowSpaces: false,
 				// Where to inject the menu popup
 				menuContainer: this.menuContainer,
 			})


### PR DESCRIPTION
### ☑️ Resolves

- Fix regression from #5268
- tributejs library doesn't support allowSpaces as a collection option, only as a global one. As we need it only for mentions ('@' trigger), the best option for now is to disable it completely

>[!IMPORTANT]
> Mentions couldn't be searched with spaces in uid or as a `name surname`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/a6ce3e00-e4e4-4a54-ad04-479b1fcd7cbb) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/365fa1d1-6760-49a2-a752-cd90e9a0995b)
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/071f52f5-76d3-4959-b381-af253809dafb) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/dba74037-5b47-4b99-8931-94572a0295e7)
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/bd891b6e-defd-4ebe-862c-edcd479a8ce1) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/0a2c87a1-06a4-4a53-bcf1-0177a0c1002a)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
