### PR TITLE
fix: scope component breaking NcModal and NcDateTimePickers

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -111,7 +111,7 @@ export default defineConfig((env) => {
 		libraryFormats: ['es', 'cjs'],
 		replace: {
 			PRODUCTION: JSON.stringify(env.mode === 'production'),
-			SCOPE_VERSION: JSON.stringify(SCOPE_VERSION),
+			SCOPE_VERSION,
 		},
 	})
 


### PR DESCRIPTION
- Regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/5328

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
