### PR TITLE
release: v8.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v8.8.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.8.1) (2024-02-29)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.8.0...v8.8.1)
+
+### 🐛 Fixed bugs
+* fix(NcSelect): handle text overflow in NcSelect by @hamza221 in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5325
+* fix: scope component breaking NcModal and NcDateTimePickers by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5331
+
 ## [v8.8.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.8.0) (2024-02-29)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.7.1...v8.8.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.8.0",
+      "version": "8.8.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.8.0",
+  "version": "8.8.1",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v8.8.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.8.1) (2024-02-29)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.8.0...v8.8.1)

### 🐛 Fixed bugs
* fix(NcSelect): handle text overflow in NcSelect by @hamza221 in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5325
* fix: scope component breaking NcModal and NcDateTimePickers by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5331