### PR TITLE
feat(NcActions): Allow to manually specify the semantic menu type

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1002,7 +1002,7 @@ export default {
 			/**
 			 * NcActions can be used as:
 			 * - Application menu (has menu role)
-			 * - Navigation (has no specific role, should be used an element with navigation role)
+			 * - Expanded block (has no specific role, should be used an element with expanded role)
 			 * - Popover with plain text or text inputs (has no specific role)
 			 * Depending on the usage (used items), the menu and its items should have different roles for a11y.
 			 * Provide the role for NcAction* components in the NcActions content.
@@ -1060,26 +1060,27 @@ export default {
 		 * NcActions can be used as:
 		 *
 		 * - Application menu (has menu role)
-		 * - Navigation (has no specific role, should be used an element with navigation role)
+		 * - Navigation (has no specific role, should be used an element with expanded role)
 		 * - Popover with plain text or text inputs (has no specific role)
 		 *
 		 * By default the used type is automatically detected by components used in the default slot.#
 		 *
-		 * With Vue 2 this is limited to direct children of the NcActions component.
+		 * With Vue this is limited to direct children of the NcActions component.
 		 * So if you use a wrapper, you have to provide the semantic type yourself (see Example)
 		 *
 		 * Choose:
 		 *
 		 * - 'dialog' if you use any of these components: NcActionInput', 'NcActionTextEditable'
 		 * - 'menu' if you use any of these components: 'NcActionButton', 'NcActionButtonGroup', 'NcActionCheckbox', 'NcActionRadio'
-		 * - 'navigation' if using one of these: 'NcActionLink', 'NcActionRouter'
+		 * - 'expanded' if using one of these: 'NcActionLink', 'NcActionRouter'. This represents an expanded block.
+		 * - 'tooltip' only to be used when a text without any interactive elements is used.
 		 * - Leave this property unset otherwise
 		 */
 		forceSemanticType: {
 			type: String,
 			default: null,
 			validator(value) {
-				return ['dialog', 'menu', 'navigation'].includes(value)
+				return ['dialog', 'menu', 'expanded', 'tooltip'].includes(value)
 			},
 		},
 
@@ -1200,7 +1201,7 @@ export default {
 			opened: this.open,
 			focusIndex: 0,
 			/**
-			 * @type {'menu'|'navigation'|'dialog'|'tooltip'|'unknown'}
+			 * @type {'menu'|'expanded'|'dialog'|'tooltip'|'unknown'}
 			 */
 			actionsMenuSemanticType: 'unknown',
 			externalFocusTrapStack: [],
@@ -1227,7 +1228,7 @@ export default {
 			 *
 			 * "aria-controls" should only present together with a valid aria-haspopup
 			 *
-			 * There is no valid popup role for navigation and tooltip in `aria-haspopup`.
+			 * There is no valid popup role for expanded and tooltip in `aria-haspopup`.
 			 * aria-haspopup="true" is equivalent to aria-haspopup="menu".
 			 * They must not be treated as menus.
 			 *
@@ -1257,7 +1258,7 @@ export default {
 						role: 'menu',
 					},
 				},
-				navigation: {
+				expanded: {
 					popupRole: undefined,
 					withArrowNavigation: false,
 					withTabNavigation: true,
@@ -1717,7 +1718,7 @@ export default {
 			} else if (hasMenuItemAction) {
 				this.actionsMenuSemanticType = 'menu'
 			} else if (hasLinkAction) {
-				this.actionsMenuSemanticType = 'navigation'
+				this.actionsMenuSemanticType = 'expanded'
 			} else {
 				// (!) Hotfix (!)
 				// In Vue 2 it is not easy to search for NcAction* in sub-component of a slot.

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -45,7 +45,7 @@ module.exports = async () => {
 			},
 			resolve: {
 				alias: {
-					vue: 'vue/dist/vue.js',
+					vue$: 'vue/dist/vue.js',
 				},
 			},
 		}),

--- a/tests/unit/components/NcActions/NcActions.spec.ts
+++ b/tests/unit/components/NcActions/NcActions.spec.ts
@@ -57,7 +57,7 @@ describe('NcActions.vue', () => {
 		it('Can set the type manually', () => {
 			const wrapper = mount(NcActions, {
 				propsData: {
-					menuSemanticType: 'dialog',
+					forceSemanticType: 'dialog',
 				},
 				slots: {
 					default: [

--- a/tests/unit/components/NcActions/NcActions.spec.ts
+++ b/tests/unit/components/NcActions/NcActions.spec.ts
@@ -22,13 +22,57 @@
  */
 
 import { mount } from '@vue/test-utils'
+import { Fragment } from 'vue-frag'
 
 import NcActions from '../../../../src/components/NcActions/NcActions.vue'
 import NcActionButton from '../../../../src/components/NcActionButton/NcActionButton.vue'
+import NcActionInput from '../../../../src/components/NcActionInput/NcActionInput.vue'
 import TestCompositionApi from './TestCompositionApi.vue'
+import { defineComponent } from 'vue'
 
 describe('NcActions.vue', () => {
-	'use strict'
+
+	describe('semantic menu type', () => {
+		const MyWrapper = defineComponent({
+			template: '<Fragment><NcActionInput /></Fragment>',
+			components: { Fragment, NcActionInput },
+		})
+
+		// This currently fails due to limitations of Vue 2
+		it.failing('Can auto detect semantic menu type in wrappers', () => {
+			const wrapper = mount(NcActions, {
+				slots: {
+					default: [
+						'<MyWrapper />',
+					],
+				},
+				stubs: {
+					MyWrapper,
+				},
+			})
+
+			expect(wrapper.vm.$data.actionsMenuSemanticType).toBe('dialog')
+		})
+
+		it('Can set the type manually', () => {
+			const wrapper = mount(NcActions, {
+				propsData: {
+					menuSemanticType: 'dialog',
+				},
+				slots: {
+					default: [
+						'<MyWrapper />',
+					],
+				},
+				stubs: {
+					MyWrapper,
+				},
+			})
+
+			expect(wrapper.vm.$data.actionsMenuSemanticType).toBe('dialog')
+		})
+	})
+
 	describe('when using the component with', () => {
 		it('no actions elements', () => {
 			const wrapper = mount(NcActions, {
@@ -178,7 +222,7 @@ describe('NcActions.vue', () => {
 					inline: 1,
 				},
 			})
-		
+
 			expect(wrapper.find('img[src="http://example.com/image.png"').exists()).toBe(true)
 		})
 	})


### PR DESCRIPTION
### ☑️ Resolves

So we can make use of `NcActions` even when wrapping common groups of actions in components.


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
