### PR TITLE
fix(NcListItem): open _blank link by Enter and allow prevent

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -345,7 +345,6 @@
 					@focus="showActions"
 					@focusout="handleBlur"
 					@click="onClick($event, navigate, routerLinkHref)"
-					@keydown.enter="onClick($event, navigate, routerLinkHref)"
 					@keydown.esc="hideActions">
 					<!-- @slot This slot is used for the NcAvatar or icon, the content of this slot must not be interactive -->
 					<slot name="icon" />
@@ -630,8 +629,6 @@ export default {
 			if (routerLinkHref) {
 				navigate?.(event)
 				event.preventDefault()
-			} else {
-				window.location = this.href
 			}
 		},
 


### PR DESCRIPTION
I don't understand what that line is intended to do.
1. It prevents `target=_blank` above from working at all
2. You can't call `preventDefault` on the event anymore

~~This just makes zero sense to me.~~

My guess is, this is for the keyboard event? (even then, enter always triggers click if `href` is present, which should always be)

~Regardless, switched that to a explicit trigger.~