### PR TITLE
fix(NcActions): clear focus trap and move focus only if elements are existing in the DOM

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1316,7 +1316,7 @@ export default {
 
 			this.opened = false
 
-			this.$refs.popover.clearFocusTrap({ returnFocus })
+			this.$refs.popover?.clearFocusTrap({ returnFocus })
 
 			/**
 			 * Event emitted when the popover menu open state is changed
@@ -1335,7 +1335,7 @@ export default {
 
 			if (returnFocus) {
 				// Focus back the menu button
-				this.$refs.menuButton.$el.focus()
+				this.$refs.menuButton?.$el.focus()
 			}
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

- Regression from #5219
- Fix #5292 
- Also fix issues like https://github.com/nextcloud/spreed/issues/9725

There are couple of places, where triggering an action in NcActions (by click, for example) leads to unmounting / breaking re-rendering of NcActions immediately. (Examples in Talk: stop the screensharing (stable28), end the call (main)). In such cases, after `nextTick` ref elements (popover, menuButton) are no longer present in the DOM (`undefined`), thus attempt to call methods on them lead to an error (see issues).

Popover has `clearFocusTrap` in beforeDestroy hook, so changes should be safe to apply (regarding previous PR)


### 🖼️ Screenshots

No behaviour change, just clean console :broom: 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
