### PR TITLE
fix(NcAppNavigation): Wrap app navigation default slot with scrollable container

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -64,7 +64,11 @@ emit('toggle-navigation', {
 			class="app-navigation__content"
 			:inert="!open || undefined"
 			@keydown.esc="handleEsc">
-			<slot />
+			<div v-if="$scopedSlots.default" class="app-navigation__body">
+				<!-- @slot Content within the nav, do NOT add NcModal/NcDialog inside this slot -->
+				<slot />
+			</div>
+
 			<!-- List for Navigation li-items -->
 			<ul v-if="$scopedSlots.list" class="app-navigation__list">
 				<slot name="list" />
@@ -253,6 +257,17 @@ export default {
 	&--close {
 		transform: translateX(-100%);
 		position: absolute;
+	}
+
+	&__body {
+		position: relative;
+		height: 100%;
+		width: 100%;
+		overflow-x: hidden;
+		overflow-y: auto;
+		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
 	}
 
 	&__content > ul,

--- a/src/components/NcAppNavigationList/NcAppNavigationList.vue
+++ b/src/components/NcAppNavigationList/NcAppNavigationList.vue
@@ -63,17 +63,11 @@ ul.app-navigation-list { // Increase specificity over NcAppNavigation styles
 	position: relative;
 	height: fit-content;
 	width: 100%;
-	overflow: unset;
+	overflow: visible;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	gap: var(--default-grid-baseline, 4px);
 	padding: var(--app-navigation-padding);
-
-	&:nth-last-of-type(2) {
-		// Fill remaining space before NcAppNavigation footer
-		height: 100%;
-		overflow: auto;
-	}
 }
 </style>


### PR DESCRIPTION
- Fix https://github.com/nextcloud/server/pull/43804#issuecomment-1977005782

### ☑️ Resolves

- To fix the unscrollable content in NcAppNavigationList we wrap the entire default slot with a container
- The `div.app-navigation__body` now fills the height with `height: 100%`
  - Remove the redundant `&:nth-last-of-type(2)` fill styles
- NcAppNavigationList now has `height: fit-content` in all contexts and is itself not scrollable now that scrolling is delegated to the container similar to the `ul.app-navigation__list` list slot behaviour

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/24800714/9d62d1a5-fbe5-46f7-b24a-587f7516f557) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/24800714/2d22b4be-2708-4f05-9ec6-9b3631975b81)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade