### PR TITLE
fix(NcRichContenteditable): capture and stop `Esc` keydown event when closing tribute

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -242,6 +242,7 @@ export default {
 			@compositionstart="isComposing = true"
 			@compositionend="isComposing = false"
 			@keydown.delete="onDelete"
+			@keydown.esc.capture="onKeyEsc"
 			@keydown.enter.exact="onEnter"
 			@keydown.ctrl.enter.exact.stop.prevent="onCtrlEnter"
 			@paste="onPaste"
@@ -873,6 +874,14 @@ export default {
 		onKeyUp(event) {
 			// prevent tribute from opening on keyup
 			event.stopImmediatePropagation()
+		},
+
+		onKeyEsc(event) {
+			// prevent event from bubbling when tribute is open
+			if (this.tribute && this.isAutocompleteOpen) {
+				event.stopImmediatePropagation()
+				this.tribute.hideMenu()
+			}
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

- Fix #5352

### 🖼️ Screenshots
Tested against Talk (we handle Esc keyup depending whether tribute state is open or not 

Before (event isn't emitted -> blur input)

[Screencast from 06.03.2024 12:57:48.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/b388d058-63a8-4931-a902-509675c8fe31)

After (Esc doesn't blur the input)

[Screencast from 06.03.2024 12:53:54.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/7bff85ed-83e2-4571-af53-28398e72829d)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
