### PR TITLE
fix: Revert "fix(NcAppNavigation): Wrap app navigation default slot with scrollable container"

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -64,11 +64,7 @@ emit('toggle-navigation', {
 			class="app-navigation__content"
 			:inert="!open || undefined"
 			@keydown.esc="handleEsc">
-			<div v-if="$scopedSlots.default" class="app-navigation__body">
-				<!-- @slot Content within the nav, do NOT add NcModal/NcDialog inside this slot -->
-				<slot />
-			</div>
-
+			<slot />
 			<!-- List for Navigation li-items -->
 			<ul v-if="$scopedSlots.list" class="app-navigation__list">
 				<slot name="list" />
@@ -257,17 +253,6 @@ export default {
 	&--close {
 		transform: translateX(-100%);
 		position: absolute;
-	}
-
-	&__body {
-		position: relative;
-		height: 100%;
-		width: 100%;
-		overflow-x: hidden;
-		overflow-y: auto;
-		box-sizing: border-box;
-		display: flex;
-		flex-direction: column;
 	}
 
 	&__content > ul,

--- a/src/components/NcAppNavigationList/NcAppNavigationList.vue
+++ b/src/components/NcAppNavigationList/NcAppNavigationList.vue
@@ -63,11 +63,17 @@ ul.app-navigation-list { // Increase specificity over NcAppNavigation styles
 	position: relative;
 	height: fit-content;
 	width: 100%;
-	overflow: visible;
+	overflow: unset;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	gap: var(--default-grid-baseline, 4px);
 	padding: var(--app-navigation-padding);
+
+	&:nth-last-of-type(2) {
+		// Fill remaining space before NcAppNavigation footer
+		height: 100%;
+		overflow: auto;
+	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- Revert https://github.com/nextcloud-libraries/nextcloud-vue/pull/5347

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade