### PR TITLE
chore: Remove GitHub Package Registry from publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -53,17 +53,3 @@ jobs:
           npm publish --tag $RELEASE_GROUP
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Set up Github Package Registry ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v3
-        with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-          registry-url: https://npm.pkg.github.com/
-          scope: nextcloud-libraries
-
-      - name: Publish package on Github Package Registry
-        run: |
-          npm config set registry=https://npm.pkg.github.com/
-          npm publish --tag $RELEASE_GROUP
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### ☑️ Resolves

- Fix publish CI failures https://github.com/nextcloud-libraries/nextcloud-vue/actions/workflows/npm-publish.yml

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade