### PR TITLE
fix(richEditor): reference server-scoped regular expression to match complex user mentions + fix(richText): when parse HTML content collapse consecutive spaces

### DIFF
--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -27,12 +27,18 @@ import escapeHtml from 'escape-html'
 import stripTags from 'striptags'
 import Vue from 'vue'
 
-// Beginning or whitespace. Non-capturing group
-const MENTION_START = '(?:^|\\s)'
-// Anything that is not text or end-of-line. Non-capturing group
-const MENTION_END = '(?:[^a-z]|$)'
-export const USERID_REGEX = new RegExp(`${MENTION_START}(@[a-zA-Z0-9_.@\\-']+)(${MENTION_END})`, 'gi')
-export const USERID_REGEX_WITH_SPACE = new RegExp(`${MENTION_START}(@&quot;[a-zA-Z0-9 _/.@\\-']+&quot;)(${MENTION_END})`, 'gi')
+// Referenced from public function getMentions(): https://github.com/nextcloud/server/blob/master/lib/private/Comments/Comment.php
+// Beginning or whitespace. Non-capturing group within word boundary
+const MENTION_START = /\B(?<![^a-z0-9_\-@.'\s])/.source
+// Capturing groups like: @user-id, @"guest/abc16def", @"federated_user/user-id", @"user-id with space"
+const MENTION_SIMPLE = /(@[a-z0-9_\-@.']+)/.source
+const MENTION_GUEST = /@&quot;guest\/[a-f0-9]+&quot;/.source
+const MENTION_PREFIXED = /@&quot;(?:federated_)?(?:group|team|user){1}\/[a-z0-9_\-@.' /:]+&quot;/.source
+const MENTION_WITH_SPACE = /@&quot;[a-z0-9_\-@.' ]+&quot;/.source
+const MENTION_COMPLEX = `(${MENTION_GUEST}|${MENTION_PREFIXED}|${MENTION_WITH_SPACE})`
+// Concatenated regular expressions
+export const USERID_REGEX = new RegExp(`${MENTION_START}${MENTION_SIMPLE}`, 'gi')
+export const USERID_REGEX_WITH_SPACE = new RegExp(`${MENTION_START}${MENTION_COMPLEX}`, 'gi')
 
 export default {
 	props: {
@@ -60,7 +66,7 @@ export default {
 			return splitValue
 				.map(part => {
 					// When splitting, the string is always putting the userIds
-					// on the the uneven indexes. We only want to generate the mentions html
+					// on the uneven indexes. We only want to generate the mentions html
 					if (!part.startsWith('@')) {
 						// This part doesn't contain a mention, let's make sure links are parsed
 						return Linkify(part)
@@ -69,7 +75,7 @@ export default {
 					// Extracting the id, nuking the leading @ and all "
 					const id = part.slice(1).replace(/&quot;/gi, '')
 					// Compiling template and prepend with the space we removed during the split
-					return ' ' + this.genSelectTemplate(id)
+					return this.genSelectTemplate(id)
 				})
 				.join('')
 				.replace(/\n/gmi, '<br>')
@@ -115,8 +121,8 @@ export default {
 
 			// Fallback to @mention in case no data matches
 			if (!data) {
-				// return `@${value}`
-				return !value.includes(' ') && !value.includes('/')
+				// return @value if matches MENTION_SIMPLE, @"value" otherwise
+				return [' ', '/', ':'].every(char => !value.includes(char))
 					? `@${value}`
 					: `@"${value}"`
 			}

--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -89,7 +89,12 @@ export default {
 		 * @return {string}
 		 */
 		parseContent(content) {
-			let text = content.replace(/<br>/gmi, '\n')
+			let text = content
+			// Consecutive spaces in HTML tags should collapse
+			text = text.replace(/>\s+</g, '><')
+			// Replace break lines with new lines
+			text = text.replace(/<br>/gmi, '\n')
+			// Replace some html special characters
 			text = text.replace(/&nbsp;/gmi, ' ')
 			text = text.replace(/&amp;/gmi, '&')
 

--- a/tests/unit/mixins/richEditor.spec.js
+++ b/tests/unit/mixins/richEditor.spec.js
@@ -85,10 +85,27 @@ describe('richEditor.js', () => {
 
 		it('keep mentions with special characters', () => {
 			const editor = shallowMount(TestEditor, { propsData: { userData: {} } })
-			const input = 'hello @foo@bar - hello @"bar @ foo"'
-			const output = editor.vm.renderContent(input)
+			const inputs = [
+				'hello @foo@bar - hello @"bar @ foo"',
+				'hello @foo@bar @"bar @ foo" @foobar @foo-bar',
+				'hello foo@bar - hello @@foobar',
+				'@foobar no space - \n\n@foobar  @foobar',
+				'hello @"guest/47e0a7cf"',
+				'hello @"group/group-id" @"federated_user/user-id"',
+			]
+			const outputs = [
+				'hello @foo@bar - hello @"bar @ foo"',
+				'hello @foo@bar  @"bar @ foo" @foobar  @foo-bar',
+				'hello foo@bar - hello @@foobar',
+				' @foobar no space - <br> @foobar  @foobar',
+				'hello @"guest/47e0a7cf"',
+				'hello @"group/group-id"  @"federated_user/user-id"',
+			]
 
-			expect(output).toEqual('hello @foo@bar - hello @"bar @ foo"')
+			for (const i in inputs) {
+				const output = editor.vm.renderContent(inputs[i])
+				expect(output).toEqual(outputs[i])
+			}
 		})
 	})
 })

--- a/tests/unit/mixins/richEditor.spec.js
+++ b/tests/unit/mixins/richEditor.spec.js
@@ -92,14 +92,16 @@ describe('richEditor.js', () => {
 				'@foobar no space - \n\n@foobar  @foobar',
 				'hello @"guest/47e0a7cf"',
 				'hello @"group/group-id" @"federated_user/user-id"',
+				'hello @"federated_user/user-id@server.com:8080"',
 			]
 			const outputs = [
 				'hello @foo@bar - hello @"bar @ foo"',
-				'hello @foo@bar  @"bar @ foo" @foobar  @foo-bar',
+				'hello @foo@bar @"bar @ foo" @foobar @foo-bar',
 				'hello foo@bar - hello @@foobar',
-				' @foobar no space - <br> @foobar  @foobar',
+				'@foobar no space - <br><br>@foobar  @foobar',
 				'hello @"guest/47e0a7cf"',
-				'hello @"group/group-id"  @"federated_user/user-id"',
+				'hello @"group/group-id" @"federated_user/user-id"',
+				'hello @"federated_user/user-id@server.com:8080"',
 			]
 
 			for (const i in inputs) {


### PR DESCRIPTION
### ☑️ Resolves

- Ref https://github.com/nextcloud/server/blob/master/lib/private/Comments/Comment.php#L223
  - use the same regex as backend code uses for parsing comments / messages
- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/4127
  - In `parseContent` when HTML is transformed into text, content collapses whitespace

### 🖼️ Screenshots

Before | After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/38a31d2d-77a4-4ba2-a41c-516c5bf56be5) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/5a11a72b-9e8e-4c49-b597-fe6dd0e97a3a)

### 🚧 Tasks

- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
