### PR TITLE
fix(NcAppNavigation): stretch the main content when there is no list slot

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -64,13 +64,17 @@ emit('toggle-navigation', {
 			class="app-navigation__content"
 			:inert="!open || undefined"
 			@keydown.esc="handleEsc">
-			<slot />
-			<!-- List for Navigation li-items -->
-			<ul v-if="$scopedSlots.list" class="app-navigation__list">
-				<slot name="list" />
-			</ul>
+			<div class="app-navigation__body" :class="{ 'app-navigation__body--no-list': !$scopedSlots.list }">
+				<!-- The main content of the navigation. If no list is passed to the #list slot, stretched vertically. -->
+				<slot />
+			</div>
 
-			<!-- Footer for e.g. AppNavigationSettings -->
+			<NcAppNavigationList v-if="$scopedSlots.list" class="app-navigation__list">
+				<!-- List for Navigation list items. Stretched between the main content and the footer -->
+				<slot name="list" />
+			</NcAppNavigationList>
+
+			<!-- Footer for e.g. NcAppNavigationSettings -->
 			<slot name="footer" />
 		</nav>
 		<NcAppNavigationToggle :open="open" @update:open="toggleNavigation" />
@@ -84,12 +88,14 @@ import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { createFocusTrap } from 'focus-trap'
 
 import NcAppNavigationToggle from '../NcAppNavigationToggle/index.js'
+import NcAppNavigationList from '../NcAppNavigationList/index.js'
 import Vue from 'vue'
 
 export default {
 	name: 'NcAppNavigation',
 
 	components: {
+		NcAppNavigationList,
 		NcAppNavigationToggle,
 	},
 
@@ -255,10 +261,10 @@ export default {
 		position: absolute;
 	}
 
-	&__content > ul,
-	&__list {
+	// For legacy purposes support passing a bare list to the content in #default slot and including #footer slot
+	// Same styles as NcAppNavigationList
+	&__content > ul {
 		position: relative;
-		height: 100%;
 		width: 100%;
 		overflow-x: hidden;
 		overflow-y: auto;
@@ -268,6 +274,19 @@ export default {
 		gap: var(--default-grid-baseline, 4px);
 		padding: var(--app-navigation-padding);
 	}
+
+	// Always stretch the navigation list
+	& &__list {
+		height: 100%;
+	}
+
+	// Stretch the main content if there is no stretched list
+	&__body--no-list {
+		flex: 1 1 auto;
+		overflow: auto;
+		height: 100%;
+	}
+
 	&__content {
 		height: 100%;
 		display: flex;

--- a/src/components/NcAppNavigationList/NcAppNavigationList.vue
+++ b/src/components/NcAppNavigationList/NcAppNavigationList.vue
@@ -59,21 +59,15 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-ul.app-navigation-list { // Increase specificity over NcAppNavigation styles
+.app-navigation-list {
 	position: relative;
-	height: fit-content;
 	width: 100%;
-	overflow: unset;
+	overflow-x: hidden;
+	overflow-y: auto;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	gap: var(--default-grid-baseline, 4px);
 	padding: var(--app-navigation-padding);
-
-	&:nth-last-of-type(2) {
-		// Fill remaining space before NcAppNavigation footer
-		height: 100%;
-		overflow: auto;
-	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- Alternative for reverted https://github.com/nextcloud-libraries/nextcloud-vue/pull/5347
- Users tested with https://github.com/nextcloud/server/pull/43804, where no #list slot is used

### 🖼️ Screenshots

Files | Users | Talk | Mail | Contacts
---|---|---|---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/3cfa581c-dc51-4526-bb99-868d4b30feb2) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/fd6f7943-1ef5-4258-bb57-fada4052f095) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/3abc6a5f-e7a6-4923-ae9d-549740e19262) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a6ac2366-a9c9-46f6-8c6e-2f6d25432acc) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/ced5ea88-dcd1-4b4b-a006-2cf4327f1a1f)
![Files](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/b16d1dcd-63aa-4433-ae9e-bc6a5b9323e7) | ![Users](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/ac98f92f-3270-4bc8-8da2-a0a092349ca8) | ![Talk](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/41e5e519-08ba-453f-ba9e-59ebd3a3e805) | ![Mail](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/3ac97a0d-e575-4c74-a403-363316d2b66c) | ![Contacts](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/54b14813-1b6a-4c50-bb47-4452ab7e47cc)

<details>

![css](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/7a108b71-f547-42f3-a72e-8f553817953d)

</details>

### 🚧 Tasks

- [x] Revert some changes from https://github.com/nextcloud/server/pull/43804 for simplicity
- [x] Reuse new `<NcAppNavigationList>` for `#list` slot
- [x] Always stretch the `#list` slot between the main content and the footer
- [x] Wrap the main content into a new `div` like in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5347
  - [x] But ONLY change styles and stretch the main content when there is no list

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
