### PR TITLE
fix: Adjust styling of team resource images

### DIFF
--- a/src/components/NcRelatedResourcesPanel/NcTeamResources.vue
+++ b/src/components/NcRelatedResourcesPanel/NcTeamResources.vue
@@ -46,7 +46,7 @@
 									class="resource__icon"
 									:svg="resource.iconSvg"
 									:size="20" />
-								<span v-else-if="resource.iconUrl" class="resource__icon">
+								<span v-else-if="resource.iconURL" class="resource__icon">
 									<img :src="resource.iconURL" alt="">
 								</span>
 								<span class="resource__name">
@@ -248,6 +248,13 @@ export default {
 			align-items: center;
 			justify-content: center;
 			text-align: center;
+
+			& > img {
+				border-radius: var(--border-radius-pill);
+				overflow: hidden;
+				width: 32px;
+				height: 32px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### ☑️ Resolves

Limit images provided by the backend in size, otherwise they might just overflow the list items

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="402" alt="Screenshot 2024-03-07 at 16 35 50" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/3404133/a4a8ed13-d3f9-47fd-9b5c-b8610970cb2d"> | <img width="398" alt="Screenshot 2024-03-07 at 16 36 10" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/3404133/40e1b470-ab1a-4b64-bd7f-61764b8c6915">


### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
