### PR TITLE
fix(NcRichText): Allow to pass interactive widget toggle

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -23,7 +23,7 @@
 				</p>
 			</div>
 		</component>
-		<NcButton v-if="hasInteractiveView && !isInteractive" class="toggle-interactive--button" @click="enableInteractive">
+		<NcButton v-if="interactiveOptIn && hasInteractiveView && !isInteractive" class="toggle-interactive--button" @click="enableInteractive">
 			{{ enableLabel }}
 		</NcButton>
 	</div>

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -324,6 +324,10 @@ export default {
 			type: Number,
 			default: 0,
 		},
+		referenceInteractive: {
+			type: Boolean,
+			default: true,
+		},
 		/** Provide data upfront to avoid extra http request */
 		references: {
 			type: Object,
@@ -401,7 +405,13 @@ export default {
 				h('div', {}, placeholders.flat()),
 				this.referenceLimit > 0
 					? h('div', { class: 'rich-text--reference-widget' }, [
-						h(NcReferenceList, { props: { text: this.text, referenceData: this.references } }),
+						h(NcReferenceList, {
+							props: {
+								text: this.text,
+								referenceData: this.references,
+								interactive: this.referenceInteractive,
+							},
+						}),
 					])
 					: null,
 			])
@@ -511,7 +521,13 @@ export default {
 				renderedMarkdown,
 				this.referenceLimit > 0
 					? h('div', { class: 'rich-text--reference-widget' }, [
-						h(NcReferenceList, { props: { text: this.text, referenceData: this.references } }),
+						h(NcReferenceList, {
+							props: {
+								text: this.text,
+								referenceData: this.references,
+								interactive: this.referenceInteractive,
+							},
+						}),
 					])
 					: null,
 			])


### PR DESCRIPTION
In Talk we need to pass the interactive widget property over from NcRichText to be able to toggle it.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
