### PR TITLE
fix(NcAppSidebar): remove always hover styles from actions in non-compact mode

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -1178,7 +1178,6 @@ $top-buttons-spacing: 6px;
 						height: $clickable-area;
 						width: $clickable-area;
 						border-radius: math.div($clickable-area, 2);
-						background-color: $action-background-hover;
 						margin-left: 5px;
 					}
 				}

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -1045,7 +1045,6 @@ $top-buttons-spacing: 6px;
 					.app-sidebar-header__menu {
 						top: $top-buttons-spacing;
 						right: $clickable-area + $top-buttons-spacing; // left of the close button
-						background-color: transparent;
 						position: absolute;
 					}
 				}
@@ -1175,9 +1174,6 @@ $top-buttons-spacing: 6px;
 
 					// main menu
 					.app-sidebar-header__menu {
-						height: $clickable-area;
-						width: $clickable-area;
-						border-radius: math.div($clickable-area, 2);
 						margin-left: 5px;
 					}
 				}


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/5363
- Remove unneeded background with hover-like styles from `NcAction` in `NcAppSidebar` for non-compact mode without figure
- Make this button always looks the same
- Small refactoring — remove other non-needed styles from actions. NcActions has these styles already.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/174d930d-df49-4661-be6d-901e350ab316) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/3ff520fd-1963-454a-88ce-8637eb911ae9)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
