### PR TITLE
fix(NcRichContentEditable): require leading space to open tributes

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -561,6 +561,7 @@ export default {
 				fillAttr: 'id',
 				// Search against id and label (display name) (fallback to title for v8.0.0..8.6.1 compatibility)
 				lookup: result => `${result.id} ${result.label ?? result.title}`,
+				requireLeadingSpace: true,
 				// Popup mention autocompletion templates
 				menuItemTemplate: item => renderMenuItem(this.renderComponentHtml(item.original, NcAutoCompleteResult)),
 				// Hide if no results
@@ -582,6 +583,7 @@ export default {
 					// Don't use the tribute search function at all
 					// We pass search results as values (see below)
 					lookup: (result, query) => query,
+					requireLeadingSpace: true,
 					// Popup mention autocompletion templates
 					menuItemTemplate: item => {
 						if (textSmiles.includes(item.original)) {
@@ -630,6 +632,7 @@ export default {
 					// Don't use the tribute search function at all
 					// We pass search results as values (see below)
 					lookup: (result, query) => query,
+					requireLeadingSpace: true,
 					// Popup mention autocompletion templates
 					menuItemTemplate: item => renderMenuItem(`<img class="${this.$style['tribute-item__icon']}" src="${item.original.icon_url}"> <span class="${this.$style['tribute-item__title']}">${item.original.title}</span>`),
 					// Hide if no results


### PR DESCRIPTION
### ☑️ Resolves

- Fix #5351 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A
![Screenshot from 2024-03-08 10-37-54](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/f991336a-7a91-4cef-b1da-a488eec2c86b) | ![Screenshot from 2024-03-08 10-39-17](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/7d87af28-6349-4075-88bb-bb8519abb29d)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
