### PR TITLE
fix(NcActions): correct dialog a11y attrs place

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1126,11 +1126,18 @@ export default {
 		'click',
 	],
 
+	setup() {
+		const randomId = `menu-${GenRandomId()}`
+		return {
+			randomId,
+			triggerRandomId: `trigger-${randomId}`,
+		}
+	},
+
 	data() {
 		return {
 			opened: this.open,
 			focusIndex: 0,
-			randomId: `menu-${GenRandomId()}`,
 			/**
 			 * @type {'menu'|'navigation'|'dialog'|'tooltip'|'unknown'}
 			 */
@@ -1155,6 +1162,10 @@ export default {
 			/**
 			 * Accessibility notes:
 			 *
+			 * "aria-haspopup" and "aria-expanded" are managed by NcPopover via `popupRole`
+			 *
+			 * "aria-controls" should only present together with a valid aria-haspopup
+			 *
 			 * There is no valid popup role for navigation and tooltip in `aria-haspopup`.
 			 * aria-haspopup="true" is equivalent to aria-haspopup="menu".
 			 * They must not be treated as menus.
@@ -1164,6 +1175,11 @@ export default {
 			 * Or the menu is an expanded list of UI elements.
 			 *
 			 * Navigation type is just an "expanded" block, similar to native <details> element.
+			 *
+			 * Arrow and Tab navigation should not be used together:
+			 * - Arrow navigation is used to navigate between items of UI element
+			 * - Tab navigation is used to navigate between UI elements on the page
+			 * - Menu is either an atomic UI element of just an expanded block of elements
 			 */
 			const configs = {
 				menu: {
@@ -1171,24 +1187,47 @@ export default {
 					withArrowNavigation: true,
 					withTabNavigation: false,
 					withFocusTrap: false,
+					triggerA11yAttr: {
+						'aria-controls': this.opened ? this.randomId : null,
+					},
+					popoverContainerA11yAttrs: {},
+					popoverUlA11yAttrs: {
+						role: 'menu',
+					},
 				},
 				navigation: {
 					popupRole: undefined,
 					withArrowNavigation: false,
 					withTabNavigation: true,
 					withFocusTrap: false,
+					triggerA11yAttr: {},
+					popoverContainerA11yAttrs: {},
+					popoverUlA11yAttrs: {},
 				},
 				dialog: {
 					popupRole: 'dialog',
 					withArrowNavigation: false,
 					withTabNavigation: true,
 					withFocusTrap: true,
+					triggerA11yAttr: {
+						'aria-controls': this.opened ? this.randomId : null,
+					},
+					popoverContainerA11yAttrs: {},
+					popoverUlA11yAttrs: {
+						role: 'dialog',
+						// Dialog must have a label
+						'aria-labelledby': this.triggerRandomId,
+						'aria-modal': 'true',
+					},
 				},
 				tooltip: {
 					popupRole: undefined,
 					withArrowNavigation: false,
 					withTabNavigation: false,
 					withFocusTrap: false,
+					triggerA11yAttr: {},
+					popoverContainerA11yAttrs: {},
+					popoverUlA11yAttrs: {},
 				},
 				// Due to Vue limitations, we sometimes cannot determine the true type
 				// As a fallback use both arrow navigation and focus trap
@@ -1198,13 +1237,12 @@ export default {
 					withArrowNavigation: true,
 					withTabNavigation: false,
 					withFocusTrap: true,
+					triggerA11yAttr: {},
+					popoverContainerA11yAttrs: {},
+					popoverUlA11yAttrs: {},
 				},
 			}
 			return configs[this.actionsMenuSemanticType]
-		},
-
-		withFocusTrap() {
-			return this.config.withFocusTrap
 		},
 	},
 
@@ -1725,7 +1763,6 @@ export default {
 						},
 					})
 			)
-			const triggerRandomId = `${this.randomId}-trigger`
 			return h('NcPopover',
 				{
 					ref: 'popover',
@@ -1769,10 +1806,9 @@ export default {
 						slot: 'trigger',
 						ref: 'menuButton',
 						attrs: {
-							id: triggerRandomId,
+							id: this.triggerRandomId,
 							'aria-label': this.menuName ? null : this.ariaLabel,
-							// 'aria-controls' should only present together with a valid aria-haspopup
-							'aria-controls': this.opened && this.config.popupRole ? this.randomId : null,
+							...this.config.triggerA11yAttr,
 						},
 						on: {
 							focus: this.onFocus,
@@ -1790,6 +1826,7 @@ export default {
 						},
 						attrs: {
 							tabindex: '-1',
+							...this.config.popoverContainerA11yAttrs,
 						},
 						on: {
 							keydown: this.onKeydown,
@@ -1801,10 +1838,7 @@ export default {
 							attrs: {
 								id: this.randomId,
 								tabindex: '-1',
-								role: this.config.popupRole,
-								// Dialog must have a label
-								'aria-labelledby': this.actionsMenuSemanticType === 'dialog' ? triggerRandomId : undefined,
-								'aria-modal': this.actionsMenuSemanticType === 'dialog' ? 'true' : undefined,
+								...this.config.popoverUlA11yAttrs,
 							},
 						}, [
 							actions,

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1192,6 +1192,7 @@ export default {
 					},
 					popoverContainerA11yAttrs: {},
 					popoverUlA11yAttrs: {
+						id: this.randomId,
 						role: 'menu',
 					},
 				},
@@ -1212,13 +1213,14 @@ export default {
 					triggerA11yAttr: {
 						'aria-controls': this.opened ? this.randomId : null,
 					},
-					popoverContainerA11yAttrs: {},
-					popoverUlA11yAttrs: {
+					popoverContainerA11yAttrs: {
+						id: this.randomId,
 						role: 'dialog',
 						// Dialog must have a label
 						'aria-labelledby': this.triggerRandomId,
 						'aria-modal': 'true',
 					},
+					popoverUlA11yAttrs: {},
 				},
 				tooltip: {
 					popupRole: undefined,
@@ -1836,7 +1838,6 @@ export default {
 					}, [
 						h('ul', {
 							attrs: {
-								id: this.randomId,
 								tabindex: '-1',
 								...this.config.popoverUlA11yAttrs,
 							},


### PR DESCRIPTION
### ☑️ Resolves

- In `dialog`, `role="dialog"` should be not a replacement of `UL`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/16091819-6fce-4850-8f8f-30599f29078f) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/620b35e8-8347-420e-96b9-d77981c34ad6)

### 🚧 Tasks

- [x] Refactor: move a11y attrs to config
  - So now almost everything that changes a11y stuff depending on a11y semantic role is moved to one place
- [x] Move a11y attributes for dialog from UL to its container
  - `role`, `aria-labelledby`, `aria-modal` and `id` to connect with `aria-controls`

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
