### PR TITLE
feat: add title slot for NcItemList component

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -35,6 +35,11 @@
 			<template #icon>
 				<NcAvatar disable-menu :size="44" user="janedoe" display-name="Jane Doe" />
 			</template>
+			<template #name>
+				<span style="display: flex; color: var(--color-primary);">
+					Name of the element with content
+				</span>
+			</template>
 			<template #subname>
 				In this slot you can put both text and other components such as icons
 			</template>
@@ -192,6 +197,14 @@
 			:bold="false">
 			<template #icon>
 				<NcAvatar disable-menu :size="44" user="janedoe" display-name="Jane Doe" />
+			</template>
+			<template #name>
+				<span style="display: flex; gap: 0.5rem; color: var(--color-primary);">
+					Flexible styling within the first line of the component
+					<div style="color: var(--color-secondary);">
+						like this.
+					</div>
+				</span>
 			</template>
 			<template #subname>
 				In this slot you can put both text and other components such as icons
@@ -386,10 +399,8 @@
 					<div class="list-item-content">
 						<div class="list-item-content__main">
 							<div class="list-item-content__name">
-								{{ name }}
-								<template v-if="hasNameSideContent">
-									<slot name="namesidecontent" />
-								</template>
+								<!-- @slot Slot for the first line of the component. prop 'name' is used as a fallback is no slots are provided -->
+								<slot name="name">{{ name }}</slot>
 							</div>
 							<div v-if="hasSubname"
 								class="list-item-content__subname"
@@ -601,7 +612,6 @@ export default {
 			hovered: false,
 			hasActions: false,
 			hasSubname: false,
-			hasNameSideContent: false,
 			displayActionsOnHoverFocus: false,
 			menuOpen: false,
 			hasIndicator: false,
@@ -717,9 +727,6 @@ export default {
 			}
 			if (this.hasSubname !== !!this.$slots.subname) {
 				this.hasSubname = !!this.$slots.subname
-			}
-			if (this.hasNameSideContent !== !!this.$slots.namesidecontent) {
-				this.hasNameSideContent = !!this.$slots.namesidecontent
 			}
 			if (this.hasIndicator !== !!this.$slots.indicator) {
 				this.hasIndicator = !!this.$slots.indicator

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -387,6 +387,9 @@
 						<div class="list-item-content__main">
 							<div class="list-item-content__name">
 								{{ name }}
+								<template v-if="hasNameSideContent">
+									<slot name="namesidecontent" />
+								</template>
 							</div>
 							<div v-if="hasSubname"
 								class="list-item-content__subname"
@@ -598,6 +601,7 @@ export default {
 			hovered: false,
 			hasActions: false,
 			hasSubname: false,
+			hasNameSideContent: false,
 			displayActionsOnHoverFocus: false,
 			menuOpen: false,
 			hasIndicator: false,
@@ -713,6 +717,9 @@ export default {
 			}
 			if (this.hasSubname !== !!this.$slots.subname) {
 				this.hasSubname = !!this.$slots.subname
+			}
+			if (this.hasNameSideContent !== !!this.$slots.namesidecontent) {
+				this.hasNameSideContent = !!this.$slots.namesidecontent
 			}
 			if (this.hasIndicator !== !!this.$slots.indicator) {
 				this.hasIndicator = !!this.$slots.indicator


### PR DESCRIPTION
* For nextcloud/server#44109
## Summary
To extend component flexibility, allow component to be able to render content to the side of name. For instance, in my case, I need to be able to add content to the side of the name for a customer request feature. However, the current implementation keeps the whole line one bolded, and for design reasons, it would be better to allow users of the library to manually style their side content.

Any input on how to better name the slot is appreciate as well :) I did not have any good naming convention to describe `content that aligns right to the name of line one`

### 🖼️ Screenshots

🏡 New extension
---|
![Code_Ek3YHm9VcZ](https://github.com/nextcloud-libraries/nextcloud-vue/assets/110193237/4647f14e-a09f-4147-bc80-86c6b5868ef5)|

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
