### PR TITLE
fix(NcUserStatusicon): set status icons size explicitly

### DIFF
--- a/src/assets/status-icons/user-status-away.svg
+++ b/src/assets/status-icons/user-status-away.svg
@@ -1,5 +1,5 @@
 <!-- This icon is part of Material UI Icons. Copyright 2020 Google Inc., Apache-2.0 License -->
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 16" width="16" height="16" xmlns="http://www.w3.org/2000/svg">
 	<path fill="none" d="M-4-4h24v24H-4z" />
 	<path fill="var(--color-warning)" d="M6.9.1C3 .6-.1 4-.1 8c0 4.4 3.6 8 8 8 4 0 7.4-3 8-6.9-1.2 1.3-2.9 2.1-4.7 2.1-3.5 0-6.4-2.9-6.4-6.4 0-1.9.8-3.6 2.1-4.7z" />
 </svg>

--- a/src/assets/status-icons/user-status-dnd.svg
+++ b/src/assets/status-icons/user-status-dnd.svg
@@ -1,5 +1,5 @@
 <!-- This icon is part of Material UI Icons. Copyright 2020 Google Inc., Apache-2.0 License -->
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 16" width="16" height="16" xmlns="http://www.w3.org/2000/svg">
 	<path fill="none" d="M-4-4h24v24H-4V-4z" />
 	<path fill="var(--color-error)" d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8z" />
 	<path fill="#fdffff" d="M5 6.5h6c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5H5c-.8 0-1.5-.7-1.5-1.5S4.2 6.5 5 6.5z" />

--- a/src/assets/status-icons/user-status-invisible.svg
+++ b/src/assets/status-icons/user-status-invisible.svg
@@ -1,5 +1,5 @@
 <!-- This icon is part of Material UI Icons. Copyright 2020 Google Inc., Apache-2.0 License -->
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 16" width="16" height="16" xmlns="http://www.w3.org/2000/svg">
 	<path fill="none" d="M-4-4h24v24H-4V-4z" />
 	<path d="M8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm0 3.2c2.7 0 4.8 2.1 4.8 4.8s-2.1 4.8-4.8 4.8S3.2 10.7 3.2 8 5.3 3.2 8 3.2z" />
 </svg>

--- a/src/assets/status-icons/user-status-online.svg
+++ b/src/assets/status-icons/user-status-online.svg
@@ -1,4 +1,4 @@
 <!-- This icon is part of Material UI Icons. Copyright 2020 Google Inc., Apache-2.0 License -->
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 16 16" width="16" height="16" xmlns="http://www.w3.org/2000/svg">
 	<path fill="var(--color-success)" d="M4.8 11.2h6.4V4.8H4.8v6.4zM8 0C3.6 0 0 3.6 0 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8z" />
 </svg>


### PR DESCRIPTION
### ☑️ Resolves

- Fix #5386
  - As SVG is inserted as plain HTML into DOM, all styles should be provided from parent elements (Vue component) or by SVG itself
  - Turns out Safari doesn't adjust SVG element sizes to fit content inside of it
  - P.S Screenshots are mocked, but output is the same

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/b02df79d-97cf-43c8-8381-9ef1d123e204) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/e6d473a9-3365-404e-9b95-ea1e3e2108ac)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
