### PR TITLE
NcListItem - change padding for one-line layout

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -818,7 +818,7 @@ export default {
 		justify-content: end;
 	}
 	&--one-line {
-		padding: 10px;
+		padding: 0 9px;
 		margin: 2px;
 		.list-item-content__main {
 			display: flex;


### PR DESCRIPTION
### ☑️ Resolves

- Ref https://github.com/nextcloud/mail/pull/9285

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-03-11 10-52-43](https://github.com/nextcloud-libraries/nextcloud-vue/assets/12728974/e64ed6bc-c52a-45fd-baeb-c96b7abd0bc5) | ![Screenshot from 2024-03-11 10-51-21](https://github.com/nextcloud-libraries/nextcloud-vue/assets/12728974/65acb22f-30f6-49f3-89aa-75497cb73cc8)


### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
