### PR TITLE
fix(NcListItem): bring back old styling for two-line list items

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -27,7 +27,7 @@
 	<ul>
 		<NcListItem
 			:name="'This is an active element with highlighted counter'"
-			:bold="false"
+			:bold="true"
 			:active="true"
 			:details="'1h'"
 			:counter-number="44"
@@ -115,7 +115,7 @@
 		</NcListItem>
 		<NcListItem
 			:name="'Name of the element with highlighted counter'"
-			:bold="false"
+			:bold="true"
 			:force-display-actions="true"
 			:details="'1h'"
 			:counter-number="44"
@@ -390,7 +390,7 @@
 							</div>
 							<div v-if="hasSubname"
 								class="list-item-content__subname"
-								:class="{'line-two--bold': bold}">
+								:class="{'list-item-content__subname--bold': bold}">
 								<!-- @slot Slot for the second line of the component -->
 								<slot name="subname" />
 							</div>
@@ -766,12 +766,15 @@ export default {
 	min-width: 100px;
 	max-width: 300px;
 	flex: 1 1 10%;
-	text-overflow: ellipsis;
+	font-weight: bold;
 }
 
 .list-item-content__subname {
 	flex: 1 0;
 	min-width: 0;
+	&--bold {
+		font-weight: bold;
+	}
 }
 
 // NcListItem
@@ -814,8 +817,8 @@ export default {
 	}
 	.list-item-content__details {
 		display: flex;
-		flex-direction: row;
-		justify-content: end;
+		flex-direction: column;
+		align-items: end;
 	}
 	&--one-line {
 		padding: 0 9px;
@@ -827,8 +830,8 @@ export default {
 			min-width: 0;
 		}
 		.list-item-content__details {
-			display: flex;
 			flex-direction: row;
+			align-items: unset;
 			justify-content: end;
 		}
 	}
@@ -873,7 +876,7 @@ export default {
 	&-details {
 		&__details {
 			color: var(--color-text-maxcontrast);
-			margin: 0 9px;
+			margin: 0 9px !important;
 			font-weight: normal;
 		}
 		&__extra {


### PR DESCRIPTION
### ☑️ Resolves

- Fix regression from #5209

### 🖼️ Screenshots

🏡 Old Before | 🏚️ Before | 🏡 After
---|---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/b8b2f015-13db-4164-afb1-745685c6ece0) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/78ff7a82-24c0-458e-98bb-8faa6300483e) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/85e760c3-b6a7-4d43-a357-5b27cf9b7847)

>[!TIP]
>As name is bold in one-line, you might have to use `:deep` selector to overwrite this or use a name slot (#5388)
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/650acfc8-3f22-46c5-9d87-ffd36b917e40)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
