### PR TITLE
fix(NcListItem): align indicators at the element bottom

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -63,7 +63,6 @@
 			:name="'This is an active element with outlined counter'"
 			:bold="false"
 			:active="true"
-			:details="'1h'"
 			:counter-number="44"
 			counterType="outlined">
 			<template #icon>
@@ -147,7 +146,6 @@
 			:name="'Name of the element with outlined counter'"
 			:bold="false"
 			:force-display-actions="true"
-			:details="'1h'"
 			:counter-number="44"
 			counterType="outlined">
 			<template #icon>
@@ -832,6 +830,7 @@ export default {
 	.list-item-content__details {
 		display: flex;
 		flex-direction: column;
+		justify-content: end;
 		align-items: end;
 	}
 	&--one-line {


### PR DESCRIPTION
### ☑️ Resolves

- Fix small regression from  #5400
- fix issues, when details are not provided

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/cb1d784b-2511-4eef-8f9f-6306e2ce600e) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/cc9e7eb7-6927-4ddc-965a-cb60dae78915)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
