### PR TITLE
fix(NcAvatar): rendering user status emoji in the menu

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -153,6 +153,9 @@ export default {
 				:key="key"
 				:href="item.href"
 				:icon="item.icon">
+				<template v-if="item.iconSvg" #icon>
+					<NcIconSvgWrapper :svg="item.iconSvg" />
+				</template>
 				{{ item.text }}
 			</NcActionLink>
 			<template v-if="contactsMenuLoading" #icon>
@@ -184,6 +187,7 @@ export default {
 import NcActions from '../NcActions/index.js'
 import NcActionLink from '../NcActionLink/index.js'
 import NcButton from '../NcButton/index.js'
+import NcIconSvgWrapper from '../NcIconSvgWrapper/index.js'
 import NcLoadingIcon from '../NcLoadingIcon/index.js'
 import NcUserStatusIcon from '../NcUserStatusIcon/index.js'
 import usernameToColor from '../../functions/usernameToColor/index.js'
@@ -234,6 +238,7 @@ export default {
 		NcActions,
 		NcActionLink,
 		NcButton,
+		NcIconSvgWrapper,
 		NcLoadingIcon,
 		NcUserStatusIcon,
 	},
@@ -511,9 +516,13 @@ export default {
 			}
 
 			if (this.showUserStatus && (this.userStatus.icon || this.userStatus.message)) {
+				// NcAction's URL icons are inverted in dark mode, so we need to pass SVG image in the icon slot
+				const emojiIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+					<text x="50%" y="50%" text-anchor="middle" style="dominant-baseline: central; font-size: 85%">${escape(this.userStatus.icon)}</text>
+				</svg>`
 				return [{
 					href: '#',
-					icon: `data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><text x='0' y='14' font-size='14'>${escape(this.userStatus.icon)}</text></svg>`,
+					iconSvg: this.userStatus.icon ? emojiIcon : undefined,
 					text: `${this.userStatus.message}`,
 				}].concat(actions)
 			}


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/talk-desktop/issues/548#issuecomment-1999608706
- Emoji status in NcAvatar's menu didn't work:
  - URL was not correct, quotes were missing in `background-image: url()` which is required for data URL
  - Emoji status was inverted in dark mode because NcAction's url icons are inverted if dark

### 🖼️ Screenshots

To test - add icon to the `icon` property.

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e46f0d5c-dc45-4799-914a-979cac53b879) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/d5c1c04e-5639-4dae-9896-5c28faae5065)
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/e0704b7c-d9ad-4094-b01e-d80612ac6188) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/14df60b7-8b9b-4b2d-8268-e870f08a00e2)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
