### PR TITLE
fix(NcReferenceWidget): set timeout to destroy idle widgets outside of viewports

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -39,6 +39,8 @@ import { renderWidget, isWidgetRegistered, destroyWidget, hasInteractiveView, ha
 
 import NcButton from '../../components/NcButton/index.js'
 
+const IDLE_TIMEOUT = 3 * 60 * 1000 // 3 minutes outside of viewport before widget is removed from the DOM
+
 export default {
 	name: 'NcReferenceWidget',
 	components: {
@@ -92,6 +94,7 @@ export default {
 		return {
 			showInteractive: false,
 			rendered: false,
+			idleTimeout: null,
 		}
 	},
 
@@ -154,10 +157,23 @@ export default {
 		isVisible: {
 			handler(val) {
 				if (!val) {
-					this.destroyWidget()
+					this.idleTimeout = setTimeout(() => {
+						// If the widget is still outside of viewport after timeout, destroy it
+						if (!this.isVisible) {
+							this.destroyWidget()
+						}
+					}, IDLE_TIMEOUT)
 					return
 				}
-				this.renderWidget()
+
+				if (this.idleTimeout) {
+					clearTimeout(this.idleTimeout)
+					this.idleTimeout = null
+				}
+
+				if (!this.rendered) {
+					this.renderWidget()
+				}
 			},
 			immediate: true,
 		},


### PR DESCRIPTION
### ☑️ Resolves

- Fix flickering widgets moving in an out of viewport (Talk chat)
  - When widget is out if view, a timer is set for 3 minutes (in case user scrolls back to it). If after timeout widget is still not visible, we destroy it, and it has to be rendered again
  - If widget is already rendered, we don't trigger the render method

### 🖼️ Screenshots

Sorry for bad sccreencast:
🏚️ Before - re-rendered each time

[before.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/953f2e05-ad68-43f2-99d9-1e6e928cb80e)


 🏡 After - re-rendered only if new or after 3 minutes

[after.webm](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/86758813-056d-4333-8dcc-bc75e1b0d15d)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
