### PR TITLE
feat: add v-model support for input-like components

### DIFF
--- a/src/components/NcActionCheckbox/NcActionCheckbox.vue
+++ b/src/components/NcActionCheckbox/NcActionCheckbox.vue
@@ -7,12 +7,30 @@
 This component is made to be used inside of the [NcActions](#NcActions) component slots.
 
 ```vue
+<template>
 	<NcActions>
 		<NcActionCheckbox @change="alert('(un)checked !')">First choice</NcActionCheckbox>
-		<NcActionCheckbox value="second" @change="alert('(un)checked !')">Second choice</NcActionCheckbox>
+		<NcActionCheckbox value="second" v-model="checkboxValue" @change="alert('(un)checked !')">Second choice (v-model)</NcActionCheckbox>
 		<NcActionCheckbox :checked="true" @change="alert('(un)checked !')">Third choice (checked)</NcActionCheckbox>
-		<NcActionCheckbox :disabled="true" @change="alert('(un)checked !')">Second choice (disabled)</NcActionCheckbox>
+		<NcActionCheckbox :disabled="true" @change="alert('(un)checked !')">Fourth choice (disabled)</NcActionCheckbox>
 	</NcActions>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			checkboxValue: false,
+		}
+	},
+
+	methods: {
+		alert(message) {
+			alert(message)
+		}
+	}
+}
+</script>
 ```
 </docs>
 

--- a/src/components/NcActionCheckbox/NcActionCheckbox.vue
+++ b/src/components/NcActionCheckbox/NcActionCheckbox.vue
@@ -53,6 +53,11 @@ export default {
 		},
 	},
 
+	model: {
+		prop: 'checked',
+		event: 'update:checked',
+	},
+
 	props: {
 		/**
 		 * id attribute of the checkbox element

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -24,7 +24,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 					<Pencil :size="20" />
 				</template>
 			</NcActionInput>
-			<NcActionInput :value.sync="text" label="Input with placeholder">
+			<NcActionInput v-model="text" label="Input with placeholder">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -268,6 +268,11 @@ export default {
 
 	mixins: [ActionGlobalMixin],
 
+	model: {
+		prop: 'value',
+		event: 'update:value',
+	},
+
 	props: {
 		/**
 		 * id attribute of the checkbox element

--- a/src/components/NcActionRadio/NcActionRadio.vue
+++ b/src/components/NcActionRadio/NcActionRadio.vue
@@ -9,12 +9,30 @@ Usually, you will provide a name prop to bind the radio together.
 So that only one of each name set can be selected at the same time.
 
 ```vue
+<template>
 	<NcActions>
 		<NcActionRadio @change="alert('(un)checked !')" name="uniqueId">First choice</NcActionRadio>
-		<NcActionRadio value="second" name="uniqueId" @change="alert('(un)checked !')">Second choice</NcActionRadio>
+		<NcActionRadio value="second" v-model="radioValue" name="uniqueId" @change="alert('(un)checked !')">Second choice (v-model)</NcActionRadio>
 		<NcActionRadio :checked="true" name="uniqueId" @change="alert('(un)checked !')">Third choice (checked)</NcActionRadio>
-		<NcActionRadio :disabled="true" name="uniqueId" @change="alert('(un)checked !')">Second choice (disabled)</NcActionRadio>
+		<NcActionRadio :disabled="true" name="uniqueId" @change="alert('(un)checked !')">Fourth choice (disabled)</NcActionRadio>
 	</NcActions>
+</template>
+
+<script>
+	export default {
+		data() {
+			return {
+				radioValue: false,
+			}
+		},
+
+		methods: {
+			alert(message) {
+				alert(message)
+			}
+		}
+	}
+</script>
 ```
 </docs>
 

--- a/src/components/NcActionRadio/NcActionRadio.vue
+++ b/src/components/NcActionRadio/NcActionRadio.vue
@@ -56,6 +56,11 @@ export default {
 		},
 	},
 
+	model: {
+		prop: 'checked',
+		event: 'update:checked',
+	},
+
 	props: {
 		/**
 		 * id attribute of the radio element

--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -96,6 +96,11 @@ export default {
 
 	mixins: [ActionTextMixin],
 
+	model: {
+		prop: 'value',
+		event: 'update:value',
+	},
+
 	props: {
 		/**
 		 * id attribute of the checkbox element

--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -20,7 +20,7 @@ All undocumented attributes will be bound to the textarea. e.g. `maxlength`
 				<Pencil :size="20" />
 			</template>
 		</NcActionTextEditable>
-		<NcActionTextEditable name="Please edit the text" value="This is a textarea with name">
+		<NcActionTextEditable name="Please edit the text" v-model="value">
 			<template #icon>
 				<Pencil :size="20" />
 			</template>
@@ -33,6 +33,11 @@ import Pencil from 'vue-material-design-icons/Pencil'
 export default {
 	components: {
 		Pencil,
+	},
+	data () {
+		return {
+			value: 'This is a textarea with name',
+		}
 	},
 }
 </script>

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -18,6 +18,7 @@ Note: All attributes on the element are passed to the inner input element - exce
 	<div>
 		<NcCheckboxRadioSwitch :checked.sync="sharingEnabled">Enable sharing</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch :checked.sync="sharingEnabled" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled">Enable sharing (v-model)</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch :checked="sharingEnabled" :loading="loading" @update:checked="onToggle">Enable sharing (with request loading)</NcCheckboxRadioSwitch>
 		<br>
 		sharingEnabled: {{ sharingEnabled }}
@@ -51,6 +52,7 @@ export default {
 	<div>
 		<NcCheckboxRadioSwitch :checked.sync="sharingPermission" value="r" name="sharing_permission_radio" type="radio">Default permission read</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch :checked.sync="sharingPermission" value="rw" name="sharing_permission_radio" type="radio">Default permission read+write</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingPermission" value="rwx" name="sharing_permission_radio" type="radio">Default permission read+write+execute</NcCheckboxRadioSwitch>
 		<br>
 		sharingPermission: {{ sharingPermission }}
 	</div>
@@ -203,6 +205,7 @@ export default {
 		<NcCheckboxRadioSwitch :disabled="true" :checked.sync="sharingPermission" value="r" name="sharing_permission">Permission read</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch :checked.sync="sharingPermission" value="w" name="sharing_permission">Permission write</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch :checked.sync="sharingPermission" value="d" name="sharing_permission">Permission delete</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingPermission" value="x" name="sharing_permission">Permission execute</NcCheckboxRadioSwitch>
 		<br>
 		sharingPermission: {{ sharingPermission }}
 	</div>
@@ -223,6 +226,7 @@ export default {
 <template>
 	<div>
 		<NcCheckboxRadioSwitch :checked.sync="sharingEnabled" type="switch">Enable sharing</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">Enable sharing (v-model)</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch :checked.sync="sharingEnabled" type="switch" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
 		<br>
 		sharingEnabled: {{ sharingEnabled }}

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -297,9 +297,9 @@ export default {
 </template>
 
 <script>
-import NcCheckboxContent, { TYPE_BUTTON, TYPE_CHECKBOX, TYPE_RADIO, TYPE_SWITCH } from './NcCheckboxContent.vue'
+import { n, t } from '../../l10n.js'
 import GenRandomId from '../../utils/GenRandomId.js'
-import { t, n } from '../../l10n.js'
+import NcCheckboxContent, { TYPE_BUTTON, TYPE_CHECKBOX, TYPE_RADIO, TYPE_SWITCH } from './NcCheckboxContent.vue'
 
 export default {
 	name: 'NcCheckboxRadioSwitch',
@@ -310,6 +310,11 @@ export default {
 
 	// We need to pass attributes to the input element
 	inheritAttrs: false,
+
+	model: {
+		prop: 'checked',
+		event: 'update:checked',
+	},
 
 	props: {
 		/**

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -109,6 +109,11 @@ export default {
 
 	inheritAttrs: false,
 
+	model: {
+		prop: 'value',
+		event: 'update:value',
+	},
+
 	props: {
 		/**
 		 * The value of the input field

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -17,7 +17,7 @@ General purpose password field component.
 		<div class="external-label">
 			<label for="textField">New password</label>
 			<NcPasswordField id="textField"
-				:value.sync="text2"
+				v-model="text2"
 				:label-outside="true"
 				placeholder="Min. 12 characters" />
 		</div>

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -146,6 +146,11 @@ export default {
 	// Allow forwarding all attributes
 	inheritAttrs: false,
 
+	model: {
+		prop: 'value',
+		event: 'update:value',
+	},
+
 	props: {
 		/**
 		 * Any [NcInputField](#/Components/NcFields?id=ncinputfield) props

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -320,6 +320,11 @@ export default {
 
 	inheritAttrs: false,
 
+	model: {
+		prop: 'value',
+		event: 'update:value',
+	},
+
 	props: {
 		/**
 		 * The ID attribute of the content editable

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -26,7 +26,7 @@ Try mentioning user @Test01 or inserting emoji :smile
 		<br>
 
 		<NcRichContenteditable
-			:value.sync="message"
+			v-model="message"
 			:auto-complete="autoComplete"
 			:maxlength="400"
 			:multiline="true"

--- a/src/components/NcSettingsInputText/NcSettingsInputText.vue
+++ b/src/components/NcSettingsInputText/NcSettingsInputText.vue
@@ -6,8 +6,22 @@
 <docs>
 
 ```vue
-<NcSettingsInputText label="Label" hint="Hint" />
-<NcSettingsInputText label="Label" value="Value" hint="Hint" disabled />
+<template>
+	<div>
+		<NcSettingsInputText v-model="value" label="Label" hint="Hint" />
+		<NcSettingsInputText label="Label" value="Value" hint="Hint" disabled />
+	</div>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			value: ''
+		}
+	},
+}
+</script>
 ```
 
 </docs>

--- a/src/components/NcSettingsInputText/NcSettingsInputText.vue
+++ b/src/components/NcSettingsInputText/NcSettingsInputText.vue
@@ -41,6 +41,12 @@ import GenRandomId from '../../utils/GenRandomId.js'
 
 export default {
 	name: 'NcSettingsInputText',
+
+	model: {
+		prop: 'value',
+		event: 'update:value',
+	},
+
 	props: {
 		/**
 		 * label of the select group element

--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -123,6 +123,11 @@ export default {
 
 	inheritAttrs: false,
 
+	model: {
+		prop: 'value',
+		event: 'update:value',
+	},
+
 	props: {
 		/**
 		 * The value of the input field

--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -71,7 +71,6 @@ It extends and styles an HTMLTextAreaElement.
 				:id="computedId"
 				ref="input"
 				class="textarea__input"
-				:type="type"
 				:disabled="disabled"
 				:placeholder="computedPlaceholder"
 				:aria-describedby="ariaDescribedby"

--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -13,34 +13,57 @@ It extends and styles an HTMLTextAreaElement.
 <template>
 	<div class="wrapper">
 		<NcTextArea label="Text area"
+			:value.sync="text1"
 			placeholder="Placeholders are possible"
 			helper-text="This is a regular helper text." >
 		</NcTextArea>
 		<NcTextArea label="Success state"
+			v-model="text2"
 			:success="true">
 		</NcTextArea>
 		<NcTextArea label="Error state"
+			:value.sync="text3"
 			placeholder="Enter something valid"
 			helper-text="Helper texts will be styled accordingly."
 			:error="true">
 		</NcTextArea>
 		<NcTextArea label="Disabled"
+			:value.sync="text4"
 			:disabled="true" />
 		<NcTextArea label="Disabled + Success"
+			:value.sync="text5"
 			:success="true"
 			:disabled="true" />
 		<div class="external-label">
 			<label for="textField">External label</label>
 			<NcTextArea id="textField"
+				:value.sync="text6"
 				:label-outside="true"
 				placeholder="Text area with external label" />
 		</div>
 		<NcTextArea label="Custom size and no resize"
+			:value.sync="text7"
 			resize="none"
 			rows="5" />
 		</NcTextArea>
 	</div>
 </template>
+
+<script>
+	export default {
+		data() {
+			return {
+				text1: '',
+				text2: '',
+				text3: '',
+				text4: '',
+				text5: '',
+				text6: '',
+				text7: '',
+			}
+		},
+	}
+</script>
 
 <style lang="scss" scoped>
 .wrapper {

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -160,6 +160,11 @@ export default {
 	// Allow forwarding all attributes
 	inheritAttrs: false,
 
+	model: {
+		prop: 'value',
+		event: 'update:value',
+	},
+
 	props: {
 		/**
 		 * Any [NcInputField](#/Components/NcFields?id=ncinputfield) props

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -25,7 +25,7 @@ and `minlength`.
 			@trailing-button-click="clearText">
 			<Magnify :size="20" />
 		</NcTextField>
-		<NcTextField :value.sync="text4"
+		<NcTextField v-model="text4"
 			label="Internal label"
 			placeholder="That can be used together with placeholder"
 			trailing-button-icon="close"
@@ -51,8 +51,10 @@ and `minlength`.
 			@trailing-button-click="clearText">
 		</NcTextField>
 		<NcTextField label="Disabled"
+			:value="text1"
 			:disabled="true" />
 		<NcTextField label="Disabled + Success"
+			:value="text2"
 			:success="true"
 			:disabled="true" />
 		<div class="external-label">


### PR DESCRIPTION
Can we get this in nc/vue 8.x or does it not matter since it was added in vue9 recently (#4994)? Would be a nice QOL improvement still.


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
