### PR TITLE
fix(NcListItem): decrease font-weight, restore contrast color for subname

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -778,14 +778,15 @@ export default {
 	min-width: 100px;
 	max-width: 300px;
 	flex: 1 1 10%;
-	font-weight: bold;
+	font-weight: 500;
 }
 
 .list-item-content__subname {
 	flex: 1 0;
 	min-width: 0;
+	color: var(--color-text-maxcontrast);
 	&--bold {
-		font-weight: bold;
+		font-weight: 500;
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix regression from recent component rework (subname color was `max-contrast`)
- Decrease font-weight from bold `700` to medium `500`
  - Numeric value is used because linter complained about it (see https://developer.mozilla.org/en-US/docs/web/css/font-weight#common_weight_name_mapping)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/0a986a09-c7a4-4fd1-a6a1-098312fc7ad7) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/95f56445-bc51-4463-b8cc-ac8ab88d671a)
Talk | --
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/602f7e80-ce6b-4fed-ab75-c3d2f333a6dd) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/98cfb329-15fb-45df-9e64-251e80f1a056)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
