### PR TITLE
fix(NcActionInput): Add label to sample

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -89,7 +89,10 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				</template>
 				Please pick a date
 			</NcActionInput>
-			<NcActionInput type="multiselect" :options="['Apple', 'Banana', 'Cherry']">
+			<NcActionInput
+				type="multiselect"
+				input-label="Fruit selection"
+				:options="['Apple', 'Banana', 'Cherry']">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
@@ -98,7 +101,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 			<NcActionInput
 				v-model="multiSelected"
 				type="multiselect"
-				label="label"
+				input-label="Fruit selection"
 				track-by="id"
 				:append-to-body="true"
 				:multiple="true"


### PR DESCRIPTION
### ☑️ Resolves

Before https://nextcloud-vue-components.netlify.app/#/Components/NcActions?id=ncactioninput yields an error in the console and leads to bad examples:

![Bildschirmfoto vom 2024-03-21 11-20-45](https://github.com/nextcloud-libraries/nextcloud-vue/assets/213943/97d864ac-1d39-4a39-9bb2-49f166258bad)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
