### PR TITLE
Fix scroll to elements with sticky header

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -430,6 +430,8 @@ export default {
 
 		&-details {
 			overflow-y: auto;
+			scroll-padding-top: 60px;
+			scroll-behavior: smooth;
 
 			@media only screen and (width < $breakpoint-mobile) {
 				min-width: 100%;


### PR DESCRIPTION
### ☑️ Resolves

- Dependency for https://github.com/nextcloud/collectives/pull/1150

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/191082/c9070d39-4051-4700-84cb-f7923a596d89) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/191082/a3a073c9-2b93-41da-96f5-b22be4a26ab9)

### 🚧 Tasks
- [ ] Backport to 8.x

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
