### PR TITLE
add fallBackFocus to NcPopover

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -327,6 +327,7 @@ export default {
 			}
 
 			const el = this.getPopoverContentElement()
+			el.tabIndex = -1
 
 			if (!el) {
 				return
@@ -340,6 +341,7 @@ export default {
 				allowOutsideClick: true,
 				setReturnFocus: this.setReturnFocus,
 				trapStack: getTrapStack(),
+				fallBackFocus: el,
 			})
 			this.$focusTrap.activate()
 		},


### PR DESCRIPTION
The Focus-Trap library will throw an error if a trap does not have any elements it can focus. Therefore we need something to set focus on if there's nothing else to use. In the documentation it is recommended to give the container a tab-index of -1 to make it focusable but not appear in the tab flow, and then set that as the fallBack to focus on when theres nothing else in the container.