### PR TITLE
fix(NcBreadcrumbs): Only render existing hidden breadcrumbs

### DIFF
--- a/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
+++ b/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
@@ -582,7 +582,7 @@ export default {
 					},
 				},
 			// Add all hidden breadcrumbs as ActionRouter or ActionLink
-			}, this.hiddenIndices.map(index => {
+			}, this.hiddenIndices.filter(index => index <= breadcrumbs.length - 1).map(index => {
 				const crumb = breadcrumbs[index]
 				// Get the parameters from the breadcrumb component props
 				const to = crumb.componentOptions.propsData.to


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/server/issues/44005

- When some breadcrumbs are hidden and the user tries to navigate to a breadcrumb that comes before the hidden one the component attempts to render a no longer existing crumb so we filter out the indices are no longer present before rendering

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade