### PR TITLE
[next] fix(NcBreadcrumbs): Only render existing hidden breadcrumbs

### DIFF
--- a/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
+++ b/src/components/NcBreadcrumbs/NcBreadcrumbs.vue
@@ -554,7 +554,7 @@ export default {
 					},
 				// Add all hidden breadcrumbs as ActionRouter or ActionLink
 				}, {
-					default: () => this.hiddenIndices.map(index => {
+					default: () => this.hiddenIndices.filter(index => index <= breadcrumbs.length - 1).map(index => {
 						const crumb = breadcrumbs[index]
 						const {
 							// Get the parameters from the breadcrumb component props


### PR DESCRIPTION
Backport https://github.com/nextcloud-libraries/nextcloud-vue/pull/5441