### PR TITLE
fix(NcRichText): include all label items

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -449,10 +449,19 @@ export default {
 
 						if (!tag.startsWith('#')) {
 							if (this.useExtendedMarkdown) {
+								let nestedList
 								if (tag === 'li' && Array.isArray(children)
 									&& children[0].tag === 'input'
 									&& children[0].data.attrs.type === 'checkbox') {
 									const [inputNode, ...labelParts] = children
+
+									const nestedListIndex = labelParts.findIndex((child) => child.tag === 'ul' || child.tag === 'li')
+									if (nestedListIndex !== -1) {
+										nestedList = labelParts[nestedListIndex]
+										nestedList.data.attrs.style = 'margin-inline-start: 20px;'
+										labelParts.splice(nestedListIndex)
+									}
+
 									const id = 'markdown-input-' + GenRandomId(5)
 									const inputComponent = h(NcCheckboxRadioSwitch, {
 										attrs: {
@@ -465,8 +474,10 @@ export default {
 												this.$emit('interact:todo', { id, label: labelParts.join(''), value })
 											},
 										},
-									}, [labelParts])
-									return h(tag, attrs, [inputComponent])
+									}, labelParts)
+
+									return h(tag, attrs, [inputComponent, nestedListIndex ? [nestedList] : []])
+
 								}
 							}
 

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -452,7 +452,7 @@ export default {
 								if (tag === 'li' && Array.isArray(children)
 									&& children[0].tag === 'input'
 									&& children[0].data.attrs.type === 'checkbox') {
-									const [inputNode, , label] = children
+									const [inputNode, ...labelParts] = children
 									const id = 'markdown-input-' + GenRandomId(5)
 									const inputComponent = h(NcCheckboxRadioSwitch, {
 										attrs: {
@@ -462,10 +462,10 @@ export default {
 										},
 										on: {
 											'update:checked': (value) => {
-												this.$emit('interact:todo', { id, label, value })
+												this.$emit('interact:todo', { id, label: labelParts.join(''), value })
 											},
 										},
-									}, [label])
+									}, [labelParts])
 									return h(tag, attrs, [inputComponent])
 								}
 							}
@@ -546,5 +546,9 @@ export default {
 
 a:not(.rich-text--component) {
 	text-decoration: underline;
+}
+
+:deep(.checkbox-content__text) {
+	gap: 4px;
 }
 </style>

--- a/src/components/NcRichText/richtext.scss
+++ b/src/components/NcRichText/richtext.scss
@@ -2,6 +2,16 @@
  * Styles are extracted to extract scss to dist folder, too.
  */
 
+li.task-list-item > ul,
+li.task-list-item > ol,
+li.task-list-item > li,
+li.task-list-item > blockquote,
+li.task-list-item > pre {
+	margin-inline-start: 15px;
+	margin-block-end: 0;
+ }
+
+
 .rich-text--wrapper {
 	word-break: break-word;
 	line-height: 1.5;

--- a/tests/unit/components/NcRichText/NcRichText.spec.js
+++ b/tests/unit/components/NcRichText/NcRichText.spec.js
@@ -201,10 +201,5 @@ describe('Foo', () => {
 		expect(checkbox.exists()).toBeTruthy()
 		await checkbox.vm.$emit('update:checked', true)
 		expect(wrapper.emitted()['interact:todo']).toBeTruthy()
-		expect(wrapper.emitted()['interact:todo'][0][0]).toMatchObject({
-			id: expect.anything(),
-			label: 'task item',
-			value: true,
-		})
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

### Breaking change:
event `'interact:todo'` now returns a string (id of the affected checkbox) instead of an object.

- Fix https://github.com/nextcloud/spreed/issues/12009

* Checkbox includes different elements in its label
* Added explicit indentation for nested lists
* Interactivity: used the DOM to calculate the position of the element and then use it in the string

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/84044328/31fe5421-7766-413c-8b03-51d8ce464163) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/84044328/a70c6e34-79c9-47ae-a727-e5bd5fb31585)

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/84044328/940645d3-c0f2-437a-8004-940c59ad7a3b)

Interactivity: 

https://github.com/nextcloud-libraries/nextcloud-vue/assets/84044328/130eee3e-5532-4b1b-92b3-8efa1a702a72




### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
