### PR TITLE
feat(app-sidebar): allow to define inline for secondary buttons

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -468,7 +468,8 @@ A working alternative would be using an icon together with an `aria-label`:
 								<!-- header main menu -->
 								<NcActions v-if="$slots['secondary-actions']"
 									class="app-sidebar-header__menu"
-									:force-menu="forceMenu">
+									:force-menu="forceMenu"
+									:inline="secondaryInline">
 									<slot name="secondary-actions" />
 								</NcActions>
 							</div>
@@ -651,6 +652,14 @@ export default {
 		forceMenu: {
 			type: Boolean,
 			default: false,
+		},
+		/**
+		 * Display x items inline out of the dropdown menu
+		 * Will be ignored if `forceMenu` is set
+		 */
+		 secondaryInline: {
+			type: Number,
+			default: 0,
 		},
 		/**
 		 * Linkify the name


### PR DESCRIPTION
- For https://github.com/nextcloud/calendar/pull/5907

| Before | After |
|---|---|
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/42591237/10c8c672-0a58-4741-a985-8ee552101fe3) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/42591237/bb1df75f-e19b-4f48-866c-3b55df160fca) |