### PR TITLE
release: v8.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v8.11.2](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.11.2) (2024-04-10)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.11.1...v8.11.2)
+
+## What's Changed
+### 🐛 Fixed bugs
+* fix(NcBreadcrumbs): Only render existing hidden breadcrumbs by @Pytal in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5441
+* fix(NcAppNavigationItem): Fix uncollapsible entry by @Pytal in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5456
+* fix(NcRichText): include all label items by @DorraJaouad in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5455
+* fix(sidebar): propagate keydown unless mobile by @pulsejet in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5451
+* fix(NcActions): Show last action entry only partial to make it discoverable by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5448
+* fix(NcDialog): Set font size to make dialog compatible with Nextcloud 30 by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5463
+* fix(NcRichText): more strictly resolve vue router's path by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5419
+* fix(NcAvatar): support in-app router links for contact menu by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5477
+### Other Changes
+* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5447
+* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5478
+
+## New Contributors
+* @DorraJaouad made their first contribution in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5455
+
 ## [v8.11.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.11.1) (2024-03-21)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.11.0...v8.11.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.11.1",
+  "version": "8.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.11.1",
+      "version": "8.11.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.11.1",
+  "version": "8.11.2",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## [v8.11.2](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.11.2) (2024-04-09)
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.11.1...v8.11.2)

## What's Changed
### 🐛 Fixed bugs
* fix(NcBreadcrumbs): Only render existing hidden breadcrumbs by @Pytal in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5441
* fix(NcAppNavigationItem): Fix uncollapsible entry by @Pytal in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5456
* fix(NcRichText): include all label items by @DorraJaouad in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5455
* fix(sidebar): propagate keydown unless mobile by @pulsejet in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5451
* fix(NcActions): Show last action entry only partial to make it discoverable by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5448
* fix(NcDialog): Set font size to make dialog compatible with Nextcloud 30 by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5463
* fix(NcRichText): more strictly resolve vue router's path by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5419
* fix(NcAvatar): support in-app router links for contact menu by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5477
### Other Changes
* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5447
* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5478

## New Contributors
* @DorraJaouad made their first contribution in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5455
