### PR TITLE
fix(NcDialog): Set font size to make dialog compatible with Nextcloud 30

### DIFF
--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -505,12 +505,14 @@ export default defineComponent({
 	}
 
 	&__name {
+		font-size: 21px;
+
 		text-align: center;
 		height: fit-content;
 		min-height: var(--default-clickable-area);
 		line-height: var(--default-clickable-area);
 		overflow-wrap: break-word;
-		margin-block-end: 12px;
+		margin-block: 0 12px;
 	}
 
 	&__content {


### PR DESCRIPTION
### ☑️ Resolves

- Fix Dialog compatibility with NC30

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2024-04-09 at 22-15-33 Files - Nextcloud](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/4f611fff-4ed7-460a-a7b2-c38ba70f3ccd)|![Screenshot 2024-04-09 at 22-15-21 Files - Nextcloud](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/208e00e9-defd-4c22-8e19-62cb8e7543b1)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
