### PR TITLE
Reduce border radius of components

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -8,7 +8,7 @@
 	min-height: $clickable-area;
 	transition: background-color var(--animation-quick) ease-in-out;
 	transition: background-color 200ms ease-in-out;
-	border-radius: var(--border-radius-pill);
+	border-radius: var(--border-radius-new-design, var(--border-radius-pill));
 
 	&-wrapper {
 		position: relative;
@@ -117,7 +117,7 @@
 		&:focus-visible {
 			box-shadow: 0 0 0 4px var(--color-main-background);
 			outline: 2px solid var(--color-main-text);
-			border-radius: var(--border-radius-pill);
+			border-radius: var(--border-radius-new-design, var(--border-radius-pill));
 		}
 	}
 }

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -738,7 +738,7 @@ export default {
 	span {
 		cursor: pointer;
 	}
-	border-radius: math.div($clickable-area, 2);
+	border-radius: var(--border-radius-new-design, math.div($clickable-area, 2));
 	transition-property: color, border-color, background-color;
 	transition-duration: 0.1s;
 	transition-timing-function: linear;
@@ -841,7 +841,7 @@ export default {
 		box-shadow: 0 0 0 4px var(--color-main-background) !important;
 		&.button-vue--vue-tertiary-on-primary {
 			outline: 2px solid var(--color-primary-element-text);
-			border-radius: var(--border-radius);
+			border-radius: var(--border-radius-new-design, var(--border-radius));
 			background-color: transparent;
 		}
 	}

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -801,9 +801,7 @@ export default {
 	// 4px padding for the focus-visible styles. Width is reduced to compensate it
 	margin: 4px;
 	width: calc(100% - 8px);
-	// Fix for border-radius being too large for 3-line entries like in Mail
-	// 44px avatar size / 2 + 8px padding, and 2px for better visual quality
-	border-radius: 32px;
+	border-radius: var(--border-radius-new-design, 32px);
 	cursor: pointer;
 	transition: background-color var(--animation-quick) ease-in-out;
 	list-style: none;


### PR DESCRIPTION
Use border radius large for NcAppNavigationItem, NcListItem and NcButton

<img width="1058" alt="Screenshot 2024-04-11 at 10 23 56" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/26852655/7660604c-2727-44e1-a305-8f5dbc62b4ab">
<img width="1058" alt="Screenshot 2024-04-11 at 10 23 05" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/26852655/9ec6e2e5-afa9-427b-9e7f-8c2823085875">
<img width="744" alt="Screenshot 2024-04-11 at 10 32 12" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/26852655/9ebbec0d-60a0-411c-9492-8c67fac76cb3">


<img width="751" alt="Screenshot 2024-04-11 at 10 37 48" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/26852655/27d3dd89-aebe-4d61-ab6b-2b36ebff7836">
