### PR TITLE
chore(widgets): remove unneeded nullish coalescing

### DIFF
--- a/src/functions/reference/widgets.ts
+++ b/src/functions/reference/widgets.ts
@@ -41,7 +41,7 @@ const hasInteractiveView = (id: string) => {
 }
 
 export const hasFullWidth = (id: string) => {
-	return !!window._vue_richtext_widgets[id]?.fullWidth ?? false
+	return !!window._vue_richtext_widgets[id]?.fullWidth
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
### ☑️ Resolves

`!!expression` returns boolean and cannot return `undefined`/`null` anyway. And if it is `falsy`, then it is `false` already.

```
[plugin:vite:esbuild] [plugin vite:esbuild] src/functions/reference/widgets.ts: The "??" operator here will always return the left operand
42 |  
43 |  export const hasFullWidth = (id: string) => {
44 |    return !!window._vue_richtext_widgets[id]?.fullWidth ?? false
   |                                                        ^
45 |  }
46 | 
```