### PR TITLE
fix(NcReferenceWidget): do not try to render widget when there is no widget

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -189,12 +189,16 @@ export default {
 			this.renderWidget()
 		},
 		renderWidget() {
-			if (this.$refs.customWidget) {
-				this.$refs.customWidget.innerHTML = ''
+			if (!this.$refs.customWidget) {
+				return
 			}
+
 			if (this?.reference?.richObjectType === 'open-graph') {
 				return
 			}
+
+			this.$refs.customWidget.innerHTML = ''
+
 			// create a separate element so we can rerender on the ref again
 			const widget = document.createElement('div')
 			this.$refs.customWidget.appendChild(widget)


### PR DESCRIPTION
### ☑️ Resolves

`NcReferenceWidget` always tries to render the widget into `ref="customWidget"`, but `ref="customWidget"` exists only when there is a custom widget (`reference && hasCustomWidget`), for example, if the widget is not registered yet there is no div to render the widget.

It doesn't look like a bug for the end user, but spams with errors on the console.

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/6abd892c-39b1-43b8-be59-9ac12e60fa8d)
