### PR TITLE
fix(NcAvatar): render # links as plain text

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -506,20 +506,35 @@ export default {
 		},
 		menu() {
 			const actions = this.contactsMenuActions.map((item) => {
+				if (item.hyperlink === '#') {
+					// Not a real link
+					return {
+						ncActionComponent: NcActionText,
+						ncActionComponentProps: {
+							icon: item.icon,
+						},
+						text: item.title,
+					}
+				}
+
 				const route = getRoute(this.$router, item.hyperlink)
-				return {
-					ncActionComponent: route ? NcActionRouter : NcActionLink,
-					ncActionComponentProps: route
-						? {
+				return route
+					? {
+						ncActionComponent: NcActionRouter,
+						ncActionComponentProps: {
 							to: route,
 							icon: item.icon,
-						}
-						: {
+						},
+						text: item.title,
+					}
+					: {
+						ncActionComponent: NcActionLink,
+						ncActionComponentProps: {
 							href: item.hyperlink,
 							icon: item.icon,
 						},
-					text: item.title,
-				}
+						text: item.title,
+					}
 			})
 
 			/**


### PR DESCRIPTION
### ☑️ Resolves

- For links like https://github.com/nextcloud/server/blob/9f2487d14b4fbf8a5ec58a74bc6db5eb5cd27bc1/lib/private/Contacts/ContactsMenu/Providers/LocalTimeProvider.php#L63
- Fix #…

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
