### PR TITLE
fix(NcDialog): Actions should not overflow the action container

### DIFF
--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -531,11 +531,17 @@ export default defineComponent({
 	}
 
 	&__actions {
+		box-sizing: border-box;
+
 		display: flex;
 		gap: 6px;
 		align-content: center;
-		width: fit-content;
-		margin-inline: auto 12px; // 12px to align with the overall modal padding
+		justify-content: end;
+
+		width: 100%;
+		max-width: 100%;
+		padding-inline: 0 12px; // 12px to align with the overall modal padding
+		margin-inline: 0;
 		margin-block: 0;
 
 		&:not(:empty) {


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/forms/issues/2064

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2024-04-15 at 19-13-24 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/7a079fe1-353a-41ac-8611-20fafe5862e4)|![Screenshot 2024-04-15 at 19-12-38 Nextcloud Vue Style Guide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/14f1d52d-b591-4ca3-a5ef-59afd9cf97ba)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
