### PR TITLE
fix(NcColorPicker): Allow to submit selected color in simple-view

### DIFF
--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -89,7 +89,7 @@ export default {
 <template>
 	<div class="container1">
 		<NcButton @click="open = !open"> Click Me </NcButton>
-		<NcColorPicker :value="color" @input="updateColor" :shown.sync="open" v-slot="{ attrs }">
+		<NcColorPicker :value="color" @input="updateColor" :shown.sync="open" @submit="open = false" v-slot="{ attrs }">
 			<div v-bind="attrs" :style="{'background-color': color}" class="color1" />
 		</NcColorPicker>
 	</div>
@@ -205,7 +205,7 @@ export default {
 						<ArrowLeft :size="20" />
 					</template>
 				</NcButton>
-				<NcButton v-if="!advanced"
+				<NcButton v-else
 					type="tertiary"
 					:aria-label="ariaMore"
 					@click="handleMoreSettings">
@@ -213,8 +213,7 @@ export default {
 						<DotsHorizontal :size="20" />
 					</template>
 				</NcButton>
-				<NcButton v-if="advanced"
-					type="primary"
+				<NcButton type="primary"
 					@click="handleConfirm">
 					{{ t('Choose') }}
 				</NcButton>


### PR DESCRIPTION
### ☑️ Resolves

Also show the `Choose` button for the simple select view to allow triggering the `submit` event.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
