### PR TITLE
fix(NcCheckboxRadioSwitch): Add background color for button style

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -693,6 +693,7 @@ export default {
 	$border-radius-outer: calc($border-radius + 2px);
 
 	&--button-variant.checkbox-radio-switch {
+		background-color: var(--color-main-background);
 		border: 2px solid var(--color-border-maxcontrast);
 		overflow: hidden;
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/forms/issues/2089

### ☑️ Resolves

On forms we use the button style for the views-toggle (view edit results), we noticed the background is not set to it will leak the background e.g. when scrolling.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screen Shot 2024-04-20 at 22 13 55](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/326bfd84-7cae-4b92-b136-039e8fb5235e)|![Screen Shot 2024-04-20 at 22 14 26](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/2a27391d-f2a1-4875-a082-98a57a866f06)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
