### PR TITLE
fix(NcRichText): adjust display so long texts in checkboxes can be shown correctly

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -224,8 +224,6 @@ export default {
 
 	&__text {
 		flex: 1 0;
-		display: flex;
-		align-items: center;
 
 		&:empty {
 			// hide text if empty to ensure checkbox outline is a circle instead of oval

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -782,6 +782,8 @@ export default {
 	}
 	&--button-variant-h-grouped :deep(.checkbox-radio-switch__text) {
 		text-align: center;
+		display: flex;
+		align-items: center;
 	}
 	&--button-variant-h-grouped &__content {
 		flex-direction: column;

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -583,7 +583,4 @@ a:not(.rich-text--component) {
 	text-decoration: underline;
 }
 
-:deep(.checkbox-content__text) {
-	gap: 4px;
-}
 </style>


### PR DESCRIPTION
### ☑️ Resolves

At least for checkboxes in `RichText`, it makes sense to have inline display. 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/84044328/24cd6e2e-e3c4-4a63-8a87-d56236f51795)| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/84044328/3646d0be-7fbf-4b51-ba71-57a2bfbea3c3)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
