### PR TITLE
fix(emoji): index emoji data once for search functions

### DIFF
--- a/src/functions/emoji/emoji.ts
+++ b/src/functions/emoji/emoji.ts
@@ -27,6 +27,10 @@ import data from 'emoji-mart-vue-fast/data/all.json'
 
 const storage = getBuilder('nextcloud-vue').persist(true).build()
 
+// Shared emoji index and skinTone for all emojiSearch function calls
+// Will be initialized on the first call
+let emojiIndex
+
 /**
  * Skin tones supported by Unicode Emojis (Fitzpatrick scale)
  * The numeric values align with `emoji-mart-vue`
@@ -46,17 +50,20 @@ export enum EmojiSkinTone {
  * @return {Array} list of found emojis
  */
 export const emojiSearch = (query: string, maxResults: number = 10) => {
-	const index = new EmojiIndex(data)
+	// If this is the first call of function - initialize EmojiIndex
+	if (!emojiIndex) {
+		emojiIndex = new EmojiIndex(data)
+	}
 	const currentSkinTone = getCurrentSkinTone()
 
 	let results
 	if (query) {
-		results = index.search(`:${query}`, maxResults)
+		results = emojiIndex.search(`:${query}`, maxResults)
 		if (results.length < maxResults) {
-			results = results.concat(index.search(query, maxResults - results.length))
+			results = results.concat(emojiIndex.search(query, maxResults - results.length))
 		}
 	} else {
-		results = frequently.get(maxResults).map((id: number) => index.emoji(id)) || []
+		results = frequently.get(maxResults).map((id: number) => emojiIndex.emoji(id)) || []
 	}
 
 	return results.map((emoji) => emoji.getSkin(currentSkinTone))


### PR DESCRIPTION
### ☑️ Resolves

- Index emoji 'database' only when first time calling a function (like `emojiSearch()`)
- Apply method similar to what is used in EmojiPicker

### 🖼️ Screenshots

Tested with:
```js
	console.time('emoji')
	for (let i = 0; i < N; i ++) {
		const em1 = emojiSearch(text, 10)
	}
	console.timeEnd('emoji')
```

🏚️ Before (N = 10) | 🏚️ Before (N = 1000) | 🏡 After (N = 1000)
---|---|---
![Screenshot from 2024-05-06 17-53-05](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/8aef8a56-9e56-4ae2-8518-558785a62e74) | ![Screenshot from 2024-05-06 17-51-53](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/ee078522-0c5d-47cf-9eca-69f662736240) | ![Screenshot from 2024-05-06 17-49-27](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/4f9c625b-723e-45d9-bd97-2b11ffd0a2cd)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
