### PR TITLE
fix(NcReferenceWidget): use requestAnimationFrame in observers

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -62,7 +62,7 @@ export default {
 	},
 
 	setup() {
-		const width = ref(700)
+		const width = ref(0)
 		const isVisible = ref(false)
 		// This is the widget root node
 		const widgetRoot = ref()

--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -62,29 +62,25 @@ export default {
 	},
 
 	setup() {
-		const compact = ref(3)
+		const width = ref(700)
 		const isVisible = ref(false)
 		// This is the widget root node
 		const widgetRoot = ref()
 
 		useIntersectionObserver(widgetRoot, (entries) => {
-			isVisible.value = entries[0]?.isIntersecting ?? false
+			window.requestAnimationFrame(() => {
+				isVisible.value = entries[0]?.isIntersecting ?? false
+			})
 		})
 
 		useResizeObserver(widgetRoot, (entries) => {
-			if (entries[0].contentRect.width < 450) {
-				compact.value = 0
-			} else if (entries[0].contentRect.width < 550) {
-				compact.value = 1
-			} else if (entries[0].contentRect.width < 650) {
-				compact.value = 2
-			} else {
-				compact.value = 3
-			}
+			window.requestAnimationFrame(() => {
+				width.value = entries[0].contentRect.width
+			})
 		})
 
 		return {
-			compact,
+			width,
 			isVisible,
 			widgetRoot,
 		}
@@ -115,17 +111,21 @@ export default {
 			return this.reference && !this.reference.accessible
 		},
 		descriptionStyle() {
-			if (this.compact === 0) {
+			if (this.numberOfLines === 0) {
 				return {
 					display: 'none',
 				}
 			}
-
-			const lineClamp = this.compact < 4 ? this.compact : 3
+			const lineClamp = this.numberOfLines
 			return {
 				lineClamp,
 				webkitLineClamp: lineClamp,
 			}
+		},
+		numberOfLines() {
+			// no description for width < 450, one line until 550 and so on
+			const lineCountOffsets = [450, 550, 650, Infinity]
+			return lineCountOffsets.findIndex(max => this.width.value < max)
 		},
 		compactLink() {
 			const link = this.reference.openGraphObject.link


### PR DESCRIPTION
Without `requestAnimationFrame` resize observer causes cypress to crash.

Also use a ref for the width and a computed for the resulting number of lines.

### ☑️ Resolves

- Fixes cypress failures such as https://github.com/nextcloud/text/actions/runs/8976130504/job/24652414376?pr=5772

### 🖼️ Screenshots

![grafik](https://github.com/nextcloud-libraries/nextcloud-vue/assets/97337118/1c69f3e1-1069-4310-a94d-98f990ab47c3)

### 🏁 Checklist

- [x] ⛑️ Tests are not applicable
- [x] 📘 Component documentation is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
