### PR TITLE
[next] fix(NcAppNavigationCaption): Only pass needed props to NcActions

### DIFF
--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -135,7 +135,7 @@
 		<!-- Actions -->
 		<div v-if="!!$slots.actions"
 			class="app-navigation-caption__actions">
-			<NcActions v-bind="$attrs">
+			<NcActions v-bind="actionsProps">
 				<!-- @slot Slot for the actions menu -->
 				<slot name="actions" />
 				<template #icon>
@@ -147,7 +147,7 @@
 </template>
 
 <script>
-import NcActions from '../NcActions/index.js'
+import NcActions from '../NcActions/NcActions.vue'
 
 export default {
 	name: 'NcAppNavigationCaption',
@@ -155,8 +155,6 @@ export default {
 	components: {
 		NcActions,
 	},
-
-	inheritAttrs: false,
 
 	props: {
 		name: {
@@ -195,10 +193,18 @@ export default {
 		 */
 		// Not an actual prop but needed to show in vue-styleguidist docs
 		// eslint-disable-next-line
-		' ': {},
+		...NcActions.props,
 	},
 
 	computed: {
+		actionsProps() {
+			const actionProps = Object.keys(NcActions.props)
+			const props = Object
+				.entries(this.$props)
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				.filter(([key, _value]) => actionProps.includes(key))
+			return Object.fromEntries(props)
+		},
 		wrapperTag() {
 			return this.isHeading ? 'div' : 'li'
 		},

--- a/tests/unit/components/NcAppNavigation/NcAppNavigationCaption.spec.ts
+++ b/tests/unit/components/NcAppNavigation/NcAppNavigationCaption.spec.ts
@@ -7,13 +7,11 @@ import { describe, expect, test } from 'vitest'
 import NcAppNavigationCaption from '../../../../src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue'
 
 describe('NcAppNavigationCaption.vue', () => {
-	test('attributes are passed to actions', async () => {
+	test('NcActions attributes are passed to actions', async () => {
 		const wrapper = shallowMount(NcAppNavigationCaption, {
 			props: {
 				name: 'The name',
-			},
-			attrs: {
-				forceMenu: 'true',
+				forceMenu: true,
 			},
 			slots: {
 				actions: [
@@ -24,6 +22,25 @@ describe('NcAppNavigationCaption.vue', () => {
 		})
 
 		expect(wrapper.findComponent({ name: 'NcActions' }).attributes('forcemenu')).toBe('true')
+	})
+
+	test('Other attributes are kept on the caption', async () => {
+		const wrapper = shallowMount(NcAppNavigationCaption, {
+			props: {
+				name: 'The name',
+			},
+			attrs: {
+				'data-test': 'test',
+			},
+			slots: {
+				actions: [
+					'<NcActionButton>Button 1</NcActionButton>',
+					'<NcActionButton>Button 2</NcActionButton>',
+				],
+			},
+		})
+
+		expect(wrapper.attributes('data-test')).toBe('test')
 	})
 
 	test('can set id on the caption', async () => {


### PR DESCRIPTION
### ☑️ Resolves

Only forward the real props and not all attributes, for Vue3 this fixes the forwarding of `class` and `style`.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
