### PR TITLE
chore(deps): bump @nextcloud/calendar-js to ^7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nextcloud/auth": "^2.2.1",
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/browser-storage": "^0.4.0",
-        "@nextcloud/calendar-js": "^6.1.0",
+        "@nextcloud/calendar-js": "^7.0.0",
         "@nextcloud/capabilities": "^1.1.0",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/initial-state": "^2.1.0",
@@ -4015,15 +4015,15 @@
       }
     },
     "node_modules/@nextcloud/calendar-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-6.1.0.tgz",
-      "integrity": "sha512-thVS6Bz+TV7rUB+LO5yFbOhdm65zICDRKcHDUquaZiWL9r6TyV9hCYDcP7cDRV+62wZJh8QPmf1E+d7ZFUOVeA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-7.0.0.tgz",
+      "integrity": "sha512-CvCcO4hFPjMfIB2AKW0QLNYukGoHFS7QQVvIC8khJjzNfVGS6qMJd2oaZtD9Q9w1fLpvwp1X7orcYGYmosDkAA==",
       "engines": {
         "node": "^20.0.0",
-        "npm": "^9.0.0"
+        "npm": "^10.0.0"
       },
       "peerDependencies": {
-        "ical.js": "^1.5.0",
+        "ical.js": "^2.0.1",
         "uuid": "^9.0.0"
       }
     },
@@ -14962,9 +14962,9 @@
       "dev": true
     },
     "node_modules/ical.js": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.5.0.tgz",
-      "integrity": "sha512-7ZxMkogUkkaCx810yp0ZGKvq1ZpRgJeornPttpoxe6nYZ3NLesZe1wWMXDdwTkj/b5NtXT+Y16Aakph/ao98ZQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.0.1.tgz",
+      "integrity": "sha512-uYYb1CwTXbd9NP/xTtgQZ5ivv6bpUjQu9VM98s3X78L3XRu00uJW5ZtmnLwyxhztpf5fSiRyDpFW7ZNCePlaPw==",
       "peer": true
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@nextcloud/auth": "^2.2.1",
     "@nextcloud/axios": "^2.4.0",
     "@nextcloud/browser-storage": "^0.4.0",
-    "@nextcloud/calendar-js": "^6.1.0",
+    "@nextcloud/calendar-js": "^7.0.0",
     "@nextcloud/capabilities": "^1.1.0",
     "@nextcloud/event-bus": "^3.1.0",
     "@nextcloud/initial-state": "^2.1.0",


### PR DESCRIPTION
I checked all usages for breaking changes and we are good.

### ☑️ Resolves

- Fix _none_

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
