### PR TITLE
[next] feat(NcAppNavigationCaption): Add `heading-id` prop

### DIFF
--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -1,4 +1,6 @@
 <docs>
+### Basic usage
+
 ```vue
 	<template>
 		<ul class="nav">
@@ -95,6 +97,23 @@
 	</style>
 ```
 
+### Element used as a heading
+```vue
+	<template>
+		<!-- e.g. NcAppNavigation-->
+		<div style="display: flex; flex-direction: column;">
+			<NcAppNavigationCaption heading-id="mylist-heading"
+				is-heading
+				name="My navigation list" />
+			<NcAppNavigationList aria-labelledby="mylist-heading">
+				<NcAppNavigationItem name="First" />
+				<NcAppNavigationItem name="Second" />
+				<NcAppNavigationItem name="Third" />
+			</NcAppNavigationList>
+		</div>
+	</template>
+```
+
 </docs>
 
 <template>
@@ -102,7 +121,9 @@
 		class="app-navigation-caption"
 		:class="{ 'app-navigation-caption--heading': isHeading }">
 		<!-- Name of the caption -->
-		<component :is="captionTag" class="app-navigation-caption__name">
+		<component :is="captionTag"
+			:id="headingId"
+			class="app-navigation-caption__name">
 			{{ name }}
 		</component>
 
@@ -136,6 +157,15 @@ export default {
 		name: {
 			type: String,
 			required: true,
+		},
+
+		/**
+		 * `id` to set on the inner caption
+		 * Can be used for connecting the `NcActionCaption` with `NcActionList` using `aria-labelledby`.
+		 */
+		headingId: {
+			type: String,
+			default: null,
 		},
 
 		/**

--- a/tests/unit/components/NcAppNavigation/NcAppNavigation.spec.js
+++ b/tests/unit/components/NcAppNavigation/NcAppNavigation.spec.js
@@ -19,7 +19,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { emit } from '@nextcloud/event-bus'

--- a/tests/unit/components/NcAppNavigation/NcAppNavigationCaption.spec.ts
+++ b/tests/unit/components/NcAppNavigation/NcAppNavigationCaption.spec.ts
@@ -22,6 +22,18 @@ describe('NcAppNavigationCaption.vue', () => {
 		expect(wrapper.findComponent({ name: 'NcActions' }).attributes('forcemenu')).toBe('true')
 	})
 
+	test('can set id on the caption', async () => {
+		const wrapper = shallowMount(NcAppNavigationCaption, {
+			props: {
+				name: 'The name',
+				isHeading: true,
+				headingId: 'my-heading-id',
+			},
+		})
+
+		expect(wrapper.find('h2').attributes('id')).toBe('my-heading-id')
+	})
+
 	test('component is a list entry by default', async () => {
 		const wrapper = shallowMount(NcAppNavigationCaption, {
 			props: {
@@ -44,31 +56,5 @@ describe('NcAppNavigationCaption.vue', () => {
 
 		expect(wrapper.element.tagName).toBe('DIV')
 		expect(wrapper.find('h2').exists()).toBe(true)
-	})
-
-	test('can set the heading level', async () => {
-		const wrapper = shallowMount(NcAppNavigationCaption, {
-			props: {
-				name: 'The name',
-				isHeading: true,
-				headingLevel: 3,
-			},
-		})
-
-		expect(wrapper.find('h3').exists()).toBe(true)
-		expect(wrapper.find('h2').exists()).toBe(false)
-	})
-
-	test('does not set the heading level to h1', async () => {
-		const wrapper = shallowMount(NcAppNavigationCaption, {
-			props: {
-				name: 'The name',
-				isHeading: true,
-				headingLevel: 1,
-			},
-		})
-
-		expect(wrapper.find('h2').exists()).toBe(true)
-		expect(wrapper.find('h1').exists()).toBe(false)
 	})
 })


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud-libraries/nextcloud-vue/pull/5565