### PR TITLE
fix(docs): Add missing file extensions to vue-material-design-icons imports

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -54,8 +54,8 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 		</NcActions>
 	</template>
 	<script>
-	import Delete from 'vue-material-design-icons/Delete'
-	import Plus from 'vue-material-design-icons/Plus'
+	import Delete from 'vue-material-design-icons/Delete.vue'
+	import Plus from 'vue-material-design-icons/Plus.vue'
 
 	export default {
 		components: {
@@ -91,8 +91,8 @@ If you're using a long text you can specify a name
 		</NcActions>
 	</template>
 	<script>
-	import Delete from 'vue-material-design-icons/Delete'
-	import Plus from 'vue-material-design-icons/Plus'
+	import Delete from 'vue-material-design-icons/Delete.vue'
+	import Plus from 'vue-material-design-icons/Plus.vue'
 
 	export default {
 		components: {
@@ -123,7 +123,7 @@ Action icon attribute with a single action
 		</NcActions>
 	</template>
 	<script>
-	import Plus from 'vue-material-design-icons/Plus'
+	import Plus from 'vue-material-design-icons/Plus.vue'
 
 	export default {
 		components: {
@@ -159,8 +159,8 @@ You can also use a custom icon, for example from the vue-material-design-icons l
 	</NcActions>
 </template>
 <script>
-import HandBackLeft from 'vue-material-design-icons/HandBackLeft'
-import HandBackRight from 'vue-material-design-icons/HandBackRight'
+import HandBackLeft from 'vue-material-design-icons/HandBackLeft.vue'
+import HandBackRight from 'vue-material-design-icons/HandBackRight.vue'
 
 export default {
 	components: {

--- a/src/components/NcActionLink/NcActionLink.vue
+++ b/src/components/NcActionLink/NcActionLink.vue
@@ -64,8 +64,8 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 	</div>
 </template>
 <script>
-import Download from 'vue-material-design-icons/Download'
-import OpenInNew from 'vue-material-design-icons/OpenInNew'
+import Download from 'vue-material-design-icons/Download.vue'
+import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
 
 export default {
 	components: {

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -41,7 +41,7 @@ https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-action
 	</NcActions>
 </template>
 <script>
-import Delete from 'vue-material-design-icons/Delete'
+import Delete from 'vue-material-design-icons/Delete.vue'
 
 export default {
 	components: {
@@ -82,9 +82,9 @@ export default {
 	</NcActions>
 </template>
 <script>
-import Delete from 'vue-material-design-icons/Delete'
-import OpenInNew from 'vue-material-design-icons/OpenInNew'
-import Pencil from 'vue-material-design-icons/Pencil'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 export default {
 	components: {
@@ -133,10 +133,10 @@ export default {
 	</NcActions>
 </template>
 <script>
-import Plus from 'vue-material-design-icons/Plus'
-import Delete from 'vue-material-design-icons/Delete'
-import OpenInNew from 'vue-material-design-icons/OpenInNew'
-import Pencil from 'vue-material-design-icons/Pencil'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 export default {
 	components: {
@@ -186,10 +186,10 @@ export default {
 	</NcActions>
 </template>
 <script>
-import Plus from 'vue-material-design-icons/Plus'
-import Delete from 'vue-material-design-icons/Delete'
-import OpenInNew from 'vue-material-design-icons/OpenInNew'
-import Pencil from 'vue-material-design-icons/Pencil'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
 export default {
 	components: {
 		Delete,
@@ -235,9 +235,9 @@ export default {
 	</NcActions>
 </template>
 <script>
-import Delete from 'vue-material-design-icons/Delete'
-import OpenInNew from 'vue-material-design-icons/OpenInNew'
-import Pencil from 'vue-material-design-icons/Pencil'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 export default {
 	components: {
@@ -289,10 +289,10 @@ export default {
 	</NcActions>
 </template>
 <script>
-import ArrowRight from 'vue-material-design-icons/ArrowRight'
-import Delete from 'vue-material-design-icons/Delete'
-import Download from 'vue-material-design-icons/Download'
-import Pencil from 'vue-material-design-icons/Pencil'
+import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import Download from 'vue-material-design-icons/Download.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 export default {
 	components: {
@@ -324,8 +324,8 @@ export default {
 	</NcActions>
 </template>
 <script>
-import Delete from 'vue-material-design-icons/Delete'
-import Pencil from 'vue-material-design-icons/Pencil'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 export default {
 	components: {
@@ -369,11 +369,11 @@ export default {
 	</NcActions>
 </template>
 <script>
-import ArrowRight from 'vue-material-design-icons/ArrowRight'
-import Delete from 'vue-material-design-icons/Delete'
-import Download from 'vue-material-design-icons/Download'
-import Pencil from 'vue-material-design-icons/Pencil'
-import Plus from 'vue-material-design-icons/Plus'
+import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import Download from 'vue-material-design-icons/Download.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
 
 export default {
 	components: {
@@ -414,9 +414,9 @@ It can be used with one or multiple actions.
 	</div>
 </template>
 <script>
-import Delete from 'vue-material-design-icons/Delete'
-import DotsHorizontalCircleOutline from 'vue-material-design-icons/DotsHorizontalCircleOutline'
-import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import DotsHorizontalCircleOutline from 'vue-material-design-icons/DotsHorizontalCircleOutline.vue'
+import MicrophoneOff from 'vue-material-design-icons/MicrophoneOff.vue'
 
 export default {
 	components: {
@@ -452,8 +452,8 @@ export default {
 	</NcActions>
 </template>
 <script>
-import Delete from 'vue-material-design-icons/Delete'
-import Magnify from 'vue-material-design-icons/Magnify'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import Magnify from 'vue-material-design-icons/Magnify.vue'
 
 export default {
 	components: {
@@ -531,10 +531,10 @@ export default {
 </template>
 
 <script>
-import Delete from 'vue-material-design-icons/Delete'
-import Palette from 'vue-material-design-icons/Palette'
-import SelectColor from 'vue-material-design-icons/SelectColor'
-import CheckboxMarkedCircleOutline from 'vue-material-design-icons/CheckboxMarkedCircleOutline'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import Palette from 'vue-material-design-icons/Palette.vue'
+import SelectColor from 'vue-material-design-icons/SelectColor.vue'
+import CheckboxMarkedCircleOutline from 'vue-material-design-icons/CheckboxMarkedCircleOutline.vue'
 
 export default {
 	components: {
@@ -733,18 +733,18 @@ export default {
 
 <script>
 // Common icons
-import Pencil from 'vue-material-design-icons/Pencil'
-import Delete from 'vue-material-design-icons/Delete'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
 
 // Email icons
-import StarOutline from 'vue-material-design-icons/StarOutline'
-import EmailUnread from 'vue-material-design-icons/Email'
-import Bookmark from 'vue-material-design-icons/Bookmark'
-import ClockOutlineIcon from 'vue-material-design-icons/ClockOutline'
-import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagon'
-import CheckIcon from 'vue-material-design-icons/Check'
-import OpenInNewIcon from 'vue-material-design-icons/OpenInNew'
-import DownloadIcon from 'vue-material-design-icons/Download'
+import StarOutline from 'vue-material-design-icons/StarOutline.vue'
+import EmailUnread from 'vue-material-design-icons/Email.vue'
+import Bookmark from 'vue-material-design-icons/Bookmark.vue'
+import ClockOutlineIcon from 'vue-material-design-icons/ClockOutline.vue'
+import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagon.vue'
+import CheckIcon from 'vue-material-design-icons/Check.vue'
+import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
+import DownloadIcon from 'vue-material-design-icons/Download.vue'
 
 // Formating icons
 import FormatTitle from 'vue-material-design-icons/FormatTitle.vue'

--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -42,7 +42,7 @@
 		</ul>
 	</template>
 	<script>
-	import Check from 'vue-material-design-icons/Check'
+	import Check from 'vue-material-design-icons/Check.vue'
 
 	export default {
 		components: {
@@ -102,10 +102,10 @@ button will be automatically created.
 		</div>
 	</template>
 	<script>
-	import Check from 'vue-material-design-icons/Check'
-	import Delete from 'vue-material-design-icons/Delete'
-	import OpenInNew from 'vue-material-design-icons/OpenInNew'
-	import Pencil from 'vue-material-design-icons/Pencil'
+	import Check from 'vue-material-design-icons/Check.vue'
+	import Delete from 'vue-material-design-icons/Delete.vue'
+	import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+	import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 	export default {
 		components: {
@@ -137,7 +137,7 @@ Just nest the counter in a template within `<NcAppNavigationItem>` and add `#cou
 		</ul>
 	</template>
 	<script>
-	import Folder from 'vue-material-design-icons/Folder'
+	import Folder from 'vue-material-design-icons/Folder.vue'
 
 	export default {
 		components: {
@@ -193,10 +193,10 @@ prevent the user from collapsing the items.
 		</ul>
 	</template>
 	<script>
-	import Folder from 'vue-material-design-icons/Folder'
-	import Delete from 'vue-material-design-icons/Delete'
-	import OpenInNew from 'vue-material-design-icons/OpenInNew'
-	import Pencil from 'vue-material-design-icons/Pencil'
+	import Folder from 'vue-material-design-icons/Folder.vue'
+	import Delete from 'vue-material-design-icons/Delete.vue'
+	import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
+	import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 	export default {
 		components: {
@@ -225,7 +225,7 @@ the placeholder is the previous name of the element.
 		</ul>
 	</template>
 	<script>
-	import Folder from 'vue-material-design-icons/Folder'
+	import Folder from 'vue-material-design-icons/Folder.vue'
 
 	export default {
 		components: {

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -56,9 +56,9 @@ include a standard-header like it's used by the files app.
 	</NcAppSidebar>
 </template>
 <script>
-	import Magnify from 'vue-material-design-icons/Magnify'
-	import Cog from 'vue-material-design-icons/Cog'
-	import ShareVariant from 'vue-material-design-icons/ShareVariant'
+	import Magnify from 'vue-material-design-icons/Magnify.vue'
+	import Cog from 'vue-material-design-icons/Cog.vue'
+	import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 
 	export default {
 		components: {
@@ -95,7 +95,7 @@ Single tab is rendered without navigation.
 	</div>
 </template>
 <script>
-import Cog from 'vue-material-design-icons/Cog'
+import Cog from 'vue-material-design-icons/Cog.vue'
 
 export default {
 	components: {
@@ -138,9 +138,9 @@ export default {
 	</div>
 </template>
 <script>
-import Magnify from 'vue-material-design-icons/Magnify'
-import Cog from 'vue-material-design-icons/Cog'
-import ShareVariant from 'vue-material-design-icons/ShareVariant'
+import Magnify from 'vue-material-design-icons/Magnify.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
+import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 
 export default {
 	components: {
@@ -185,9 +185,9 @@ export default {
 	</NcAppSidebar>
 </template>
 <script>
-import Magnify from 'vue-material-design-icons/Magnify'
-import Cog from 'vue-material-design-icons/Cog'
-import ShareVariant from 'vue-material-design-icons/ShareVariant'
+import Magnify from 'vue-material-design-icons/Magnify.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
+import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 
 export default {
 	components: {
@@ -231,9 +231,9 @@ export default {
 	</div>
 </template>
 <script>
-import Magnify from 'vue-material-design-icons/Magnify'
-import Cog from 'vue-material-design-icons/Cog'
-import ShareVariant from 'vue-material-design-icons/ShareVariant'
+import Magnify from 'vue-material-design-icons/Magnify.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
+import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 
 export default {
 	components: {
@@ -357,7 +357,7 @@ A working alternative would be using an icon together with an `aria-label`:
 		</NcAppSidebar>
 	</template>
 	<script>
-	import Magnify from 'vue-material-design-icons/Magnify'
+	import Magnify from 'vue-material-design-icons/Magnify.vue'
 
 	export default {
 		components: {

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -45,7 +45,7 @@
 	</NcAvatar>
 </template>
 <script>
-import AccountMultiple from 'vue-material-design-icons/AccountMultiple'
+import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 
 export default {
 	components: {

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -150,7 +150,7 @@ It can be used with one or multiple actions.
 
 </template>
 <script>
-import Video from 'vue-material-design-icons/Video'
+import Video from 'vue-material-design-icons/Video.vue'
 
 export default {
 	components: {

--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -37,7 +37,7 @@ Providing an icon, name, and a description is strongly advised.
 </template>
 
 <script>
-import Comment from 'vue-material-design-icons/Comment'
+import Comment from 'vue-material-design-icons/Comment.vue'
 
 export default {
 	components: {
@@ -99,7 +99,7 @@ consider only using header elements as the root elements for the name slot.
 </template>
 
 <script>
-import Comment from 'vue-material-design-icons/Comment'
+import Comment from 'vue-material-design-icons/Comment.vue'
 
 export default {
 	components: {
@@ -127,7 +127,7 @@ like a link.
 </template>
 
 <script>
-import Comment from 'vue-material-design-icons/Comment'
+import Comment from 'vue-material-design-icons/Comment.vue'
 
 export default {
 	components: {

--- a/src/components/NcListItemIcon/NcListItemIcon.vue
+++ b/src/components/NcListItemIcon/NcListItemIcon.vue
@@ -38,7 +38,7 @@ It might be used for list rendering or within the multiselect for example
 		</NcListItemIcon>
 	</template>
 	<script>
-	import Account from 'vue-material-design-icons/Account'
+	import Account from 'vue-material-design-icons/Account.vue'
 
 	export default {
 		components: {
@@ -58,7 +58,7 @@ It might be used for list rendering or within the multiselect for example
 		</NcListItemIcon>
 	</template>
 	<script>
-	import AccountMultiple from 'vue-material-design-icons/AccountMultiple'
+	import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 
 	export default {
 		components: {
@@ -80,7 +80,7 @@ It might be used for list rendering or within the multiselect for example
 		</NcListItemIcon>
 	</template>
 	<script>
-	import AccountMultiple from 'vue-material-design-icons/AccountMultiple'
+	import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 
 	export default {
 		components: {
@@ -111,8 +111,8 @@ It might be used for list rendering or within the multiselect for example
 		</NcListItemIcon>
 	</template>
 	<script>
-	import Delete from 'vue-material-design-icons/Delete'
-	import Pencil from 'vue-material-design-icons/Pencil'
+	import Delete from 'vue-material-design-icons/Delete.vue'
+	import Pencil from 'vue-material-design-icons/Pencil.vue'
 
 	export default {
 		components: {


### PR DESCRIPTION
### ☑️ Resolves

Fix missing file extensions on imports.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
