### PR TITLE
fix: Adjust Typescript definition export

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"extends": "../tsconfig.json",
+	"exclude": [],
 	"include": ["./**/*.ts"],
 	"compilerOptions": {
 		"rootDir": "..",

--- a/package.json
+++ b/package.json
@@ -39,22 +39,27 @@
       "require": "./dist/index.cjs"
     },
     "./dist/Components/*.js": {
+      "types": "./dist/components/*/index.d.ts",
       "import": "./dist/Components/*.mjs",
       "require": "./dist/Components/*.cjs"
     },
     "./dist/Directives/*.js": {
+      "types": "./dist/directives/*/index.d.ts",
       "import": "./dist/Directives/*.mjs",
       "require": "./dist/Directives/*.cjs"
     },
     "./dist/Functions/*.js": {
+      "types": "./dist/functions/*/index.d.ts",
       "import": "./dist/Functions/*.mjs",
       "require": "./dist/Functions/*.cjs"
     },
     "./dist/Mixins/*.js": {
+      "types": "./dist/mixins/*/index.d.ts",
       "import": "./dist/Mixins/*.mjs",
       "require": "./dist/Mixins/*.cjs"
     },
     "./dist/Composables/*.js": {
+      "types": "./dist/composables/*/index.d.ts",
       "import": "./dist/Composables/*.mjs",
       "require": "./dist/Composables/*.cjs"
     }

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -607,7 +607,7 @@ export default defineComponent({
 		},
 
 		ncPopoverTriggerAttrs() {
-			return this.getNcPopoverTriggerAttrs()
+			return (this.getNcPopoverTriggerAttrs as () => Record<string, string|undefined>)()
 		},
 	},
 

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -3,5 +3,5 @@
 	"compilerOptions": {
 		"rootDir": ".."
 	},
-	"include": ["./**/*.ts"],
+	"exclude": [],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
   "extends": "@vue/tsconfig/tsconfig.json",
-  "include": ["./src/**/*.ts", "./src/**/*.vue", "**/*.ts"],
-  "exclude": ["./src/**/*.cy.ts"],
+  "include": ["./src/**/*.js","./src/**/*.ts", "./src/**/*.vue", "**/*.ts"],
+  "exclude": ["./src/**/*.cy.ts", "cypress", "tests"],
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "Bundler",
     "target": "ESNext",
     "module": "ESNext",
-    "declaration": true,
-    "strict": true,
+    "moduleResolution": "Bundler",
     "noImplicitAny": false,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
+    "strict": true,
+    "noEmit": true,
   },
 
   "vueCompilerOptions": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite'
 
 import md5 from 'md5'
 
-import l10nPlugin from './build/l10n-plugin.mts'
+import l10nPlugin from './build/l10n-plugin.mjs'
 
 const appVersion = JSON.stringify(process.env.npm_package_version || 'nextcloud-vue')
 const versionHash = md5(appVersion).slice(0, 7) as string
@@ -94,6 +94,15 @@ export default defineConfig((env) => {
 	const createConfig = createLibConfig(entryPoints, {
 		// Add our overrides to the config
 		config: overrides,
+		// Only create declarations for source files
+		DTSPluginOptions: {
+			include: ['src/**/*.ts', 'src/**/*.js', 'src/**/*.vue'],
+			compilerOptions: {
+				declaration: true,
+				rootDir: 'src',
+				noEmit: false,
+			},
+		},
 		// By default all dependencies are external, but no path imports
 		nodeExternalsOptions: {
 			// Packages with paths imports should be added here to mark them as external as well
@@ -104,7 +113,7 @@ export default defineConfig((env) => {
 		// For backwards compatibility we include the css within the js files
 		inlineCSS: true,
 		// Build CommonJS files for backwards compatibility
-		libraryFormats: ['es', 'cjs'],
+		libraryFormats: ['cjs', 'es'],
 		replace: {
 			PRODUCTION: JSON.stringify(env.mode === 'production'),
 			SCOPE_VERSION,


### PR DESCRIPTION
### ☑️ Resolves

Make sure Typescript definitions are correctly exported. Also export them from the package.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot_20240511_153835](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/38379afa-6ad7-4de9-89c9-9964e10667c8)|![Screenshot_20240511_151519](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/0f4fde85-6076-43fc-85b9-fd161a2de087)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
