### PR TITLE
fix(NcIconSvgWrapper): Fix icon size variable being undefined

### DIFF
--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -206,6 +206,9 @@ export default {
 		attributes() {
 			return {
 				class: ['icon-vue', { 'icon-vue--inline': this.inline }],
+				style: {
+					' --icon-size': this.iconSize,
+				},
 				role: 'img',
 				'aria-hidden': !this.name ? true : undefined,
 				'aria-label': this.name || undefined,
@@ -233,10 +236,10 @@ export default {
 
 	&:deep(svg) {
 		fill: currentColor;
-		width: v-bind('iconSize');
-		height: v-bind('iconSize');
-		max-width: v-bind('iconSize');
-		max-height: v-bind('iconSize');
+		width: var(--icon-size, 20px);
+		height: var(--icon-size, 20px);
+		max-width: var(--icon-size, 20px);
+		max-height: var(--icon-size, 20px);
 	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

Use CSS variable with `style` binding instead, as the `v-bind` generated an undefined CSS variable. (Yet for the next branch, Vue 3, it seems to work).

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/48cba3b3-b75c-4c5f-9409-40066a8e6a4b)|![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/1855448/fc9b89ef-8fda-4b28-afe2-60765d1f8ac5)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ <del>Backport to `next` requested with a Vue 3 upgrade</del>
