### PR TITLE
feat(mobile): restore hiding the appnavigation on mobile

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -307,4 +307,12 @@ export default {
 		position: absolute;
 	}
 }
+
+// Put the toggle behind appsidebar on small screens
+@media only screen and (max-width: $breakpoint-small-mobile) {
+	.app-navigation {
+		z-index: 1400;
+	}
+}
+
 </style>


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud-libraries/nextcloud-vue/pull/2747

| Before | After |
|---|---|
| ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/42591237/dd28fcf7-30ec-4939-b1bd-a0c121948675) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/42591237/08ec8628-401e-405f-ac2e-8e3642564d74) |