### PR TITLE
[next] refactor!: Drop CJS entry points, only provide ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,37 +31,30 @@
     "cypress:gui": "TZ=UTC cypress open --component",
     "cypress:update-snapshots": "TZ=UTC cypress run --component --spec \"cypress/visual/**/*.cy.{t,j}s\" --env type=base --config screenshotsFolder=cypress/snapshots/base"
   },
-  "main": "dist/index.cjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs"
     },
     "./dist/Components/*.js": {
       "types": "./dist/components/*/index.d.ts",
-      "import": "./dist/Components/*.mjs",
-      "require": "./dist/Components/*.cjs"
+      "import": "./dist/Components/*.mjs"
     },
     "./dist/Directives/*.js": {
       "types": "./dist/directives/*/index.d.ts",
-      "import": "./dist/Directives/*.mjs",
-      "require": "./dist/Directives/*.cjs"
+      "import": "./dist/Directives/*.mjs"
     },
     "./dist/Functions/*.js": {
       "types": "./dist/functions/*/index.d.ts",
-      "import": "./dist/Functions/*.mjs",
-      "require": "./dist/Functions/*.cjs"
+      "import": "./dist/Functions/*.mjs"
     },
     "./dist/Mixins/*.js": {
       "types": "./dist/mixins/*/index.d.ts",
-      "import": "./dist/Mixins/*.mjs",
-      "require": "./dist/Mixins/*.cjs"
+      "import": "./dist/Mixins/*.mjs"
     },
     "./dist/Composables/*.js": {
       "types": "./dist/composables/*/index.d.ts",
-      "import": "./dist/Composables/*.mjs",
-      "require": "./dist/Composables/*.cjs"
+      "import": "./dist/Composables/*.mjs"
     }
   },
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -112,8 +112,8 @@ export default defineConfig((env) => {
 		},
 		// For backwards compatibility we include the css within the js files
 		inlineCSS: true,
-		// Build CommonJS files for backwards compatibility
-		libraryFormats: ['cjs', 'es'],
+		// Only standard ESM
+		libraryFormats: ['es'],
 		replace: {
 			PRODUCTION: JSON.stringify(env.mode === 'production'),
 			SCOPE_VERSION,


### PR DESCRIPTION
### ☑️ Resolves

* Resolves #4899

There is very little need for the CJS built anymore as any modern bundler can handle ESM (webpack, vite).
This not only reduces the package size and prevents tree-shaking issues if the CJS entry is used, but also reduces potential pitfalls with maintaining two module formats.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
