### PR TITLE
fix(NcAppSidebar): remove hidden navigation toggle from focus trap

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -908,9 +908,6 @@ export default {
 				this.$refs.sidebar,
 				// Nextcloud Server header navigarion
 				document.querySelector('#header'),
-				// The app navigation toggle. Navigation can be opened above the sidebar
-				// Take the parent element, because the focus-trap requires a container with elements, not the element itself
-				document.querySelector('[aria-controls="app-navigation-vue"]')?.parentElement,
 			], {
 				allowOutsideClick: true,
 				fallbackFocus: this.$refs.closeButton,


### PR DESCRIPTION
### ☑️ Resolves

- Regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/5603
- App navigation toggle was visible "intentionally" and also was a part of keyboard navigation. Now it is hidden, but still a part of keyboard navigation in the focus trap on mobile.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [x] Remove from the focus trap

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
