### PR TITLE
fix(NcAppNavigationItem): Fix popper boundary element

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -629,6 +629,10 @@ export default {
 		}
 	},
 
+	mounted() {
+		this.actionsBoundariesElement = document.querySelector('#content-vue') || undefined
+	},
+
 	data() {
 		return {
 			editingValue: '',
@@ -641,6 +645,7 @@ export default {
 			menuOpenLocalValue: false,
 			focused: false,
 			collapsible: false,
+			actionsBoundariesElement: undefined,
 		}
 	},
 
@@ -672,9 +677,6 @@ export default {
 
 		undoButtonAriaLabel() {
 			return t('Undo changes')
-		},
-		actionsBoundariesElement() {
-			return document.querySelector('#content-vue') || undefined
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

- For https://github.com/nextcloud/mail/issues/8474

The query selector in the computed prop ran too early, before the element existed. There is no reactivity. Now the boundary element is set very late at mount, when the boundary element does exist in the DOM.

There are a few edge cases, but the menu positions better than before when the boundary fell back to the `body`.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
