### PR TITLE
[next] fix: re-export `NcEllipsisedOption` and `NcInputField` in root export 

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -63,9 +63,7 @@ export { default as NcDateTimePicker } from './NcDateTimePicker/index.js'
 export { default as NcDateTimePickerNative } from './NcDateTimePickerNative/index.js'
 export { default as NcDialog } from './NcDialog/index.js'
 export { default as NcDialogButton } from './NcDialogButton/index.js'
-// Not exported on purpose
-// export { default as NcEllipsisedOption } from './NcEllipsisedOption/index.js'
-
+export { default as NcEllipsisedOption } from './NcEllipsisedOption/index.js'
 export { default as NcEmojiPicker } from './NcEmojiPicker/index.js'
 export { default as NcEmptyContent } from './NcEmptyContent/index.js'
 export { default as NcGuestContent } from './NcGuestContent/index.js'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -70,9 +70,7 @@ export { default as NcGuestContent } from './NcGuestContent/index.js'
 export { default as NcHeaderMenu } from './NcHeaderMenu/index.js'
 export { default as NcHighlight } from './NcHighlight/index.js'
 export { default as NcIconSvgWrapper } from './NcIconSvgWrapper/index.js'
-// Not exported on purpose as it is only meant as a base component
-// export { default as NcInputField } from './NcInputField/index.js'
-
+export { default as NcInputField } from './NcInputField/index.js'
 export { default as NcListItem } from './NcListItem/index.js'
 export { default as NcListItemIcon } from './NcListItemIcon/index.js'
 export { default as NcLoadingIcon } from './NcLoadingIcon/index.js'


### PR DESCRIPTION
### ☑️ Resolves

- Manual backport of https://github.com/nextcloud-libraries/nextcloud-vue/pull/5666/