### PR TITLE
[next] fix(NcRichText): crash on router links rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "unist-util-visit": "^5.0.0",
         "vue": "^3.4.27",
         "vue-datepicker-next": "^1.0.3",
+        "vue-router": "^4.3.2",
         "vue-select": "^4.0.0-beta.6"
       },
       "devDependencies": {
@@ -86,7 +87,6 @@
         "vitest": "^1.6.0",
         "vue-eslint-parser": "^9.4.2",
         "vue-material-design-icons": "^5.3.0",
-        "vue-router": "^4.3.2",
         "vue-styleguidist": "^4.72.4",
         "webpack": "^5.91.0",
         "webpack-merge": "^5.10.0"
@@ -4992,10 +4992,9 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.1.tgz",
-      "integrity": "sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA==",
-      "dev": true
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.3.tgz",
+      "integrity": "sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw=="
     },
     "node_modules/@vue/eslint-config-typescript": {
       "version": "13.0.0",
@@ -25793,7 +25792,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.2.tgz",
       "integrity": "sha512-hKQJ1vDAZ5LVkKEnHhmm1f9pMiWIBNGF5AwU67PdH7TyXCj/a4hTccuUuYCAMgJK6rO/NVYtQIEN3yL8CECa7Q==",
-      "dev": true,
       "dependencies": {
         "@vue/devtools-api": "^6.5.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "unified": "^11.0.4",
         "unist-builder": "^4.0.0",
         "unist-util-visit": "^5.0.0",
+        "vue": "^3.4.27",
         "vue-datepicker-next": "^1.0.3",
         "vue-select": "^4.0.0-beta.6"
       },
@@ -93,9 +94,6 @@
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"
-      },
-      "peerDependencies": {
-        "vue": "^3.4.27"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "unist-util-visit": "^5.0.0",
     "vue": "^3.4.27",
     "vue-datepicker-next": "^1.0.3",
+    "vue-router": "^4.3.2",
     "vue-select": "^4.0.0-beta.6"
   },
   "engines": {
@@ -145,7 +146,6 @@
     "vitest": "^1.6.0",
     "vue-eslint-parser": "^9.4.2",
     "vue-material-design-icons": "^5.3.0",
-    "vue-router": "^4.3.2",
     "vue-styleguidist": "^4.72.4",
     "webpack": "^5.91.0",
     "webpack-merge": "^5.10.0"

--- a/package.json
+++ b/package.json
@@ -100,11 +100,9 @@
     "unified": "^11.0.4",
     "unist-builder": "^4.0.0",
     "unist-util-visit": "^5.0.0",
+    "vue": "^3.4.27",
     "vue-datepicker-next": "^1.0.3",
     "vue-select": "^4.0.0-beta.6"
-  },
-  "peerDependencies": {
-    "vue": "^3.4.27"
   },
   "engines": {
     "node": "^20.0.0",

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -531,7 +531,7 @@ export default {
 							'onUpdate:modelValue': () => {
 								this.$emit('interact:todo', id)
 							},
-						}, labelParts)
+						}, { default: () => labelParts })
 
 						return h(type, props, [inputComponent, nestedNode])
 					}
@@ -546,7 +546,7 @@ export default {
 						return h(RouterLink, {
 							...props,
 							to: route,
-						}, children)
+						}, { default: () => children })
 					}
 				}
 				return h(type, props, children)
@@ -568,7 +568,7 @@ export default {
 					...placeholder.props,
 					class: 'rich-text--component',
 				},
-				children,
+				{ default: () => children },
 			)
 		},
 	},


### PR DESCRIPTION
### ☑️ Resolves

- Talk is broken when there is a link to another chat in the chat
- Fix warnings and errors

To test:
1. Checkout https://github.com/nextcloud/spreed/tree/vue3
2. Before linking `nextcloud-vue` - remove `rm -rf node_modules/vue-router` from nextcloud-vue repo (or use `npm pack` instead of `npm link`)
3. Send a link to another chat in a chat

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/bff181bb-c07f-4445-a22b-f28bf1d46462) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/6623c2cd-12a2-48c6-9fc2-8e186243b26c)

### 🚧 Tasks

- [x] move `vue-router` from `devDeps` to `deps` to externalize it. Otherwise it is built in and we have 2 routers. We should take router from package users, not during the build.
  Fixes:
  ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/0262cb31-be23-4b8c-9e47-b66f253093a1)
- [x] move `vue` from peer to deps (no changes, just make it correct)
- [x] use function slot in render
  Fixes:
  ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/fbb972cd-4a1a-4479-a812-eb9a702cced7)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
