### PR TITLE
feat(NcRichContenteditable): programmatically show tributes

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -210,6 +210,48 @@ export default {
 </style>
 ```
 
+### Using public methods
+
+```vue
+<template>
+	<div>
+		<div class="buttons-wrapper">
+			<NcButton class="show-slash-button" @click="showSlashCommands">Slash commands</NcButton>
+			<NcButton class="focus-button" @click="focus">Focus on input</NcButton>
+		</div>
+		<NcRichContenteditable
+			ref="contenteditable"
+			label="Write a comment"
+			:value.sync="message"
+			:maxlength="100"/>
+	</div>
+</template>
+<script>
+export default {
+	data() {
+		return {
+			message: '**Lorem ipsum** dolor sit amet. ',
+		}
+	},
+	methods: {
+		showSlashCommands() {
+			this.$refs.contenteditable.showTribute('/')
+		},
+		focus() {
+			this.$refs.contenteditable.focus()
+		},
+	},
+}
+</script>
+<style lang="scss" scoped>
+	.buttons-wrapper {
+		display: flex;
+		gap: 10px;
+		margin-bottom: 20px;
+	}
+</style>
+```
+
 </docs>
 
 <template>
@@ -922,6 +964,8 @@ export default {
 				this.getTributeContainer().setAttribute('class', this.tribute.current.collection.containerClass || this.$style['tribute-container'])
 
 				this.setupTributeIntegration()
+				// Remove the event handler if any
+				document.removeEventListener('click', this.hideTribute, true)
 			} else {
 				// Cancel loading data for autocomplete
 				// Otherwise it could be received when another autocomplete is already opened
@@ -1000,6 +1044,28 @@ export default {
 			} else {
 				this.getTributeContainer().classList.remove(this.$style['tribute-container--focus-visible'])
 			}
+		},
+
+		/**
+		 * Show tribute menu programmatically.
+		 * @param {string} trigger - trigger character, can be '/', '@', or ':'
+		 *
+		 * @public
+		 */
+		showTribute(trigger) {
+			this.focus()
+			const index = this.tribute.collection.findIndex(collection => collection.trigger === trigger)
+			this.tribute.showMenuForCollection(this.$refs.contenteditable, index)
+			document.addEventListener('click', this.hideTribute, true)
+		},
+
+		/**
+		 * Hide tribute menu programmatically
+		 *
+		 */
+		hideTribute() {
+			this.tribute.hideMenu()
+			document.removeEventListener('click', this.hideTribute, true)
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

- Required for #https://github.com/nextcloud/spreed/issues/12250



- The added methods will be used to programmatically show slash commands by clicking on a button. 

### 🖼️ Screenshots

![slash-command](https://github.com/nextcloud-libraries/nextcloud-vue/assets/84044328/677826bb-7e90-4061-8ebb-08232bb168ef)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
