### PR TITLE
fix(NcAppSidebar): restore attrs and classes inheritance

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -455,8 +455,6 @@ export default {
 		</NcButton>
 		<transition appear
 			name="slide-right"
-			v-bind="$attrs"
-			v-on="$listeners"
 			@before-enter="onBeforeEnter"
 			@after-enter="onAfterEnter"
 			@before-leave="onBeforeLeave"
@@ -465,7 +463,12 @@ export default {
 				id="app-sidebar-vue"
 				ref="sidebar"
 				class="app-sidebar"
+				:class="getClassAttr()"
+				:style="getStyleAttr()"
 				:aria-labelledby="`app-sidebar-vue-${uid}__header`"
+				:[getParentsDataVScopeId()]="true"
+				v-bind="$attrs"
+				v-on="$listeners"
 				@keydown.esc="onKeydownEsc">
 				<header :class="{
 						'app-sidebar-header--with-figure': hasFigure,
@@ -1050,6 +1053,31 @@ export default {
 			this.preserveElementToReturnFocus()
 
 			this.$refs.tabs.focusActiveTabContent()
+		},
+
+		/**
+		 * Get classes passed by parent to <NcAppSidebar> node
+		 */
+		getClassAttr() {
+			// In Vue 2 there is no other way - classes and styles are not a part of the $attrs and cannot be defined as props.
+			// Having Fragment as root breaks default class inheritance.
+			// Also, it is not reactive so it must be used as a method in the template.
+			return [this.$vnode?.data?.staticClass, this.$vnode?.data?.class]
+		},
+
+		/**
+		 * Get styles passed by parent to <NcAppSidebar> node
+		 */
+		getStyleAttr() {
+			// See getClassAttr
+			return [this.$vnode?.data?.staticStyle, this.$vnode?.data?.style]
+		},
+
+		/**
+		 * Get the parents data-v-{scopeid} attr to restore scoped styles from parent with Fragment
+		 */
+		getParentsDataVScopeId() {
+			return this.$parent?.$options._scopeId
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

Makes `<NcAppSIdebar>` with `Fragment` work like there is no `Fragment`

- Regression from: https://github.com/nextcloud-libraries/nextcloud-vue/pull/5584
- Has alternative: https://github.com/nextcloud-libraries/nextcloud-vue/pull/5627/
- `<Fragment>` breaks:
  - Passing `attributes` and `classes`, because in Vue 2 they are not a part of `$attrs` and even cannot be defined as `$props`
  - scoped styles from parent's `data-v-{scopeid}` on the root element
  - using `v-show` **but it is not fixed in this PR**
- `<Transition>` does not pass attributes with disabled inheritance (no idea why, but in vue 2 this component was not so pure)

This PR restores it in **quite a dirty way**. I don't see any better solution without a breaking change.

Example of broken apps - `Files`:
- No `cy-data-sidebar` attributes for `e2e`
- No `app-sidebar--full` class
- No `data-v-{scopeId}`  attr required for `app-sidebar--full`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/7903c96b-7ae7-4183-a80e-1e628d66ca2c) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/413abc26-362f-4bd3-bda1-e8485b718716)

### 🚧 Tasks

- [x] Pass `attrs` and `listeners` on `<aside>` directly
- [x] Manually take and bind **classes** and **styles** from VNode
- [x] Manually set `data-v-{scopeid}` from `$parent`

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
