### PR TITLE
feat(NcAppSidebar): add `toggleAttrs` prop to pass attributes on the toggle button

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -460,6 +460,7 @@ export default {
 			:aria-label="t('Open sidebar')"
 			class="app-sidebar__toggle"
 			:class="toggleClasses"
+			v-bind="toggleAttrs"
 			type="tertiary"
 			@click="$emit('update:open', true)">
 			<template #icon>
@@ -790,12 +791,20 @@ export default {
 		},
 
 		/**
-		 * Custom classes to assign to the sidebar toggle button
+		 * Custom classes to assign to the sidebar toggle button.
 		 * If needed this can be used to assign styles to the button using `:deep()` selector.
 		 */
 		toggleClasses: {
 			type: [String, Array, Object],
 			default: '',
+		},
+
+		/**
+		 * Custom attrs to assign to the sidebar toggle button.
+		 */
+		toggleAttrs: {
+			type: Object,
+			default: undefined,
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

- In Talk when we are in the call, we need the top bar to be **dark-themed**.
  In the past, we had a custom toggle button in the top bar with `data-dark-theme` on the top bar to archive that. Now with the built-in toggle button, it is not possible...
- Add `toggleAttrs` similar to `toggleClasses` prop to pass attributes on the toggle button
  - Allows to set `data-them-dark` manually from Talk
- Alternative: 
  1. Add `hideToggle` prop to hide the default toggle button
  2. Add `NcAppToggleButton` to allow users to place it anywhere
  3. Connect this `NcAppToggleButton` with `NcAppSidebar` inside `@nextcloud/vue`
  4. Do not forget about slide animations for the custom toggle button

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/7a8cf811-5295-4045-ac16-22125ee8adb2) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/1b9b9b83-263a-4077-90a0-f4090080cdcb)

### 🚧 Tasks

- [x] Add `toggleAttrs`

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
