### PR TITLE
feat(NcAppSidebar): add noToggle prop to hide the built-in toggle button

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -439,7 +439,7 @@ export default {
 <template>
 	<Fragment>
 		<!-- With vue3 we can move this inside the transition, but vue2 does not allow v-show in transition -->
-		<NcButton v-if="!open"
+		<NcButton v-if="!open && !noToggle"
 			:aria-label="t('Open sidebar')"
 			class="app-sidebar__toggle"
 			:class="toggleClasses"
@@ -763,10 +763,10 @@ export default {
 		/**
 		 * Allow to conditionally show the sidebar
 		 * You can also use `v-if` on the sidebar, but using the open prop allow to keep
-		 * the sidebar inside the DOM for performance if it is opened and closed multple times.
+		 * the sidebar inside the DOM for performance if it is opened and closed multiple times.
 		 *
 		 * When using the `open` property to close the sidebar a built-in toggle button will be shown to reopen it,
-		 * similar to the app navigation.
+		 * similar to the app navigation. You can remove this button with the `no-toggle` prop.
 		 */
 		open: {
 			type: Boolean,
@@ -788,6 +788,14 @@ export default {
 		toggleAttrs: {
 			type: Object,
 			default: undefined,
+		},
+
+		/**
+		 * Do not add the built-in toggle button with `open` prop.
+		 */
+		noToggle: {
+			type: Boolean,
+			default: false,
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

- Allows to use `open` state (which is the only way to hide sidebar with `v-show`) without the built-in toggle button

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/a68d94d0-e581-4bb3-ab75-6bf1e9b4b4b7) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/cecab406-9d1a-43af-b422-d7fadcca6f49)

### 🚧 Tasks

- [x] Add `noToggle` prop

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
