### PR TITLE
fix(richText): do not handle relative links without leading slash as router links

### DIFF
--- a/src/components/NcRichText/autolink.js
+++ b/src/components/NcRichText/autolink.js
@@ -115,8 +115,23 @@ export const getRoute = (router, url) => {
 
 	const isAbsoluteURL = /^https?:\/\//.test(url)
 
+	// URL is a "mailto:", "tel:" or any custom app protocol link
+	const isNonHttpLink = /^[a-z][a-z0-9+.-]*:.+/.test(url)
+	if (!isAbsoluteURL && isNonHttpLink) {
+		return null
+	}
+
 	// URL is not a link to this Nextcloud server instance => not an app route
 	if (isAbsoluteURL && !url.startsWith(getBaseUrl())) {
+		return null
+	}
+
+	if (!isAbsoluteURL && !url.startsWith('/')) {
+		// Relative URL without a leading slash are not allowed
+		// VueRouter handles such urls according to the URL RFC,
+		// for example, being on /call/abc page, link "def" is resolved as "/call/def" relative to "/call/".
+		// We don't want to support such links,
+		// so relative URL MUST start with a slash.
 		return null
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/spreed/issues/12516
- `autolink` supports relative URLs, for example, `/call/ab34cd` is resolved as a Talk route.
- It considers a link as relative if it doesn't start with `https?://`.
- However, `call/abc` or `mailto:email@nextcloud.ltd` also doesn't start with HTTP.
- The best is to only allow relative URLs with leading slashes `/`.
- Even the check for leading `/` is enough for explicitly adding a check for non-http schemes. 

VueRouter handles such URLs according to the URL RFC, for example, being on `/call/abc` page, a link `def` is resolved as `/call/def` relative to `/call/`. We don't want to support such links anyway, so relative URL MUST start with a slash.

**Alternative solution:** add a leading slash `/` to relative links.

### 🚧 Tasks

- [x] Check for non-HTTP schemes.
- [x] Support relative links only if they start with `/`.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
