### PR TITLE
chore(NcUserStatusIcon): remove warn if status is not set

### DIFF
--- a/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
+++ b/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
@@ -42,7 +42,6 @@ This component displays a user status icon.
 </template>
 
 <script>
-import Vue from 'vue'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { getCapabilities } from '@nextcloud/capabilities'
@@ -147,12 +146,6 @@ export default {
 				}
 			},
 		},
-	},
-
-	mounted() {
-		if (!this.user && !this.status) {
-			Vue.util.warn('[NcUserStatusIcon] The `user` or `status` prop should be set.')
-		}
 	},
 }
 </script>


### PR DESCRIPTION
### ☑️ Resolves

- Removes a warning error from server
- This could also be fixed on server side by using `v-if` on component node.
  But actually, this component already has `v-if="activeStatus"` on root and works completely normal without status being set.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
