### PR TITLE
fix(NcAppSidebar): apply toggle offset transition only on sidebar transition

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -1126,8 +1126,15 @@ export default {
 	--app-sidebar-padding: #{$app-navigation-padding};
 	// A padding between the toggle button and the page border
 	--app-sidebar-offset: 0;
-	transition-duration: var(--animation-quick);
-	transition-property: --app-sidebar-offset;
+	// Explicitly disable transition by default to enable it only when sidebar animation is active
+	// !important to override styles from an older version, because it's global non-scoped styles
+	transition: --app-sidebar-offset 0ms !important;
+}
+
+// When AppSidebar is animation is active - also apply transition for the toggle button offset
+.content:has(.app-sidebar.slide-right-enter-active),
+.content:has(.app-sidebar.slide-right-leave-active) {
+	transition: --app-sidebar-offset var(--animation-quick);
 }
 
 .content:has(.app-sidebar__toggle) {


### PR DESCRIPTION
### ☑️ Resolves

- There is a transition for the sidebar toggle button
- It makes sense when the sidebar is opening/closing
- It looks like a glitch initially when it appears

### 🖼️ Screenshots

Slowed down to be more visible on gifs

🏚️ Before | 🏡 After
---|---
![sidebar-toggle-appear-before](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/1b013976-cc8e-4a56-9063-18d8a3ca85c8) | ![sidebar-toggle-appear-after](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/0b153f71-1d45-48b0-8b2b-305aec3deabc)
![sidebar-toggle-slide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/4ef5e4f5-44ec-4faf-991f-eb7d0d26a82f) | ![sidebar-toggle-slide](https://github.com/nextcloud-libraries/nextcloud-vue/assets/25978914/77f59e4a-e364-460a-bcaf-d277c1ccb513)
### 🚧 Tasks

- [x] Disable `--app-sidebar-offset` transition by default
- [x] Enable `--app-sidebar-offset` transition when `NcAppSidebar` transition is active
- [x] Make sure it has no changes for sliding

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
