### PR TITLE
fix: japanese system tags translation

### DIFF
--- a/l10n/ja.pot
+++ b/l10n/ja.pot
@@ -12,10 +12,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgid "{tag} (invisible)"
-msgstr "{タグ} (不可視)"
+msgstr "{tag} (不可視)"
 
 msgid "{tag} (restricted)"
-msgstr "{タグ} (制限付)"
+msgstr "{tag} (制限付)"
 
 msgid "a few seconds ago"
 msgstr ""


### PR DESCRIPTION
### ☑️ Resolves

- Fix #…

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1111" alt="image" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/40746210/fcaf5d79-9a52-465f-a23e-b29071d75a83"> | <img width="1111" alt="image" src="https://github.com/nextcloud-libraries/nextcloud-vue/assets/40746210/1ad828cb-b536-4873-963e-518ee3c9a454">

### 🚧 Tasks

- [x] ...

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
