### PR TITLE
Feat: emit height difference of NcReferenceList after loading.

### DIFF
--- a/src/components/NcRichText/NcReferenceList.vue
+++ b/src/components/NcRichText/NcReferenceList.vue
@@ -106,14 +106,15 @@ export default {
 				return
 			}
 
+			// get the height of the component before the references are loaded
+			const height = this.$el.offsetHeight
 			this.resolve().then((response) => {
 				this.references = response.data.ocs.data.references
-				this.loading = false
-				this.$emit('loaded')
 			}).catch((error) => {
 				console.error('Failed to extract references', error)
+			}).finally(() => {
 				this.loading = false
-				this.$emit('loaded')
+				this.$emit('loaded', height)
 			})
 		},
 		resolve() {

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -378,7 +378,7 @@ export default {
 			default: true,
 		},
 	},
-	emits: ['interact:todo'],
+	emits: ['interact:todo', 'reference-list-loaded'],
 
 	data() {
 		return {
@@ -387,6 +387,13 @@ export default {
 	},
 
 	methods: {
+		handleReferenceListLoaded(oldHeight) {
+			this.$nextTick(() => {
+				// emit height difference to parent component
+				const heightDiff = this.$refs.referenceList.$el.offsetHeight - oldHeight
+				this.$emit('reference-list-loaded', heightDiff)
+			})
+		},
 		renderPlaintext(h) {
 			const context = this
 			const placeholders = this.text.split(/(\{[a-z\-_.0-9]+\})/ig).map(function(entry, index, list) {
@@ -415,11 +422,13 @@ export default {
 				this.referenceLimit > 0
 					? h('div', { class: 'rich-text--reference-widget' }, [
 						h(NcReferenceList, {
+							ref: 'referenceList',
 							props: {
 								text: this.text,
 								referenceData: this.references,
 								interactive: this.referenceInteractive,
 							},
+							on: { loaded: this.handleReferenceListLoaded },
 						}),
 					])
 					: null,
@@ -540,11 +549,13 @@ export default {
 				this.referenceLimit > 0
 					? h('div', { class: 'rich-text--reference-widget' }, [
 						h(NcReferenceList, {
+							ref: 'referenceList',
 							props: {
 								text: this.text,
 								referenceData: this.references,
 								interactive: this.referenceInteractive,
 							},
+							on: { loaded: this.handleReferenceListLoaded },
 						}),
 					])
 					: null,


### PR DESCRIPTION
### ☑️ Resolves

Needed for https://github.com/nextcloud/spreed/issues/10627. Link previews are adding extra height which causes jumping in the chat scroll. 

### 🖼️ Screenshots

No visual changes

### 🚧 Tasks

- [ ] event `loaded` now has height difference as a payload [CHANGED BEHAVIOR]

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
