### PR TITLE
feat(NcAppSidebar): force show navigation for a single tab

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -69,8 +69,10 @@ Single tab is rendered without navigation.
 ```vue
 <template>
 	<div>
+		<NcCheckboxRadioSwitch :checked.sync="forceTabs">Force tab navigation</NcCheckboxRadioSwitch>
 		<NcAppSidebar
 			name="cat-picture.jpg"
+			:force-tabs="forceTabs"
 			subname="last edited 3 weeks ago">
 			<NcAppSidebarTab name="Settings" id="settings-tab">
 				<template #icon>
@@ -87,6 +89,11 @@ import Cog from 'vue-material-design-icons/Cog.vue'
 export default {
 	components: {
 		Cog,
+	},
+	data() {
+		return {
+			forceTabs: false,
+		}
 	},
 }
 </script>
@@ -677,6 +684,7 @@ export default {
 			<NcAppSidebarTabs v-show="!loading"
 				ref="tabs"
 				:active="active"
+				:force-tabs="forceTabs"
 				@update:active="onUpdateActive">
 				<slot />
 			</NcAppSidebarTabs>
@@ -833,6 +841,13 @@ export default {
 		 * Force the actions to display in a three dot menu
 		 */
 		forceMenu: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		 * Force the tab navigation to display even if there is only one tab
+		 */
+		forceTabs: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -9,7 +9,7 @@
 	<div class="app-sidebar-tabs">
 		<!-- tabs navigation -->
 		<!-- 33 and 34 code is for page up and page down -->
-		<div v-if="hasMultipleTabs"
+		<div v-if="hasMultipleTabs || showForSingleTab"
 			role="tablist"
 			class="app-sidebar-tabs__nav"
 			@keydown.left.exact.prevent.stop="focusPreviousTab"
@@ -84,6 +84,13 @@ export default {
 			type: String,
 			default: '',
 		},
+		/**
+		 * Force the tab navigation to display even if there is only one tab
+		 */
+		forceTabs: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	emits: ['update:active'],
@@ -109,6 +116,10 @@ export default {
 		 */
 		hasMultipleTabs() {
 			return this.tabs.length > 1
+		},
+
+		showForSingleTab() {
+			return this.forceTabs && this.tabs.length === 1
 		},
 
 		currentTabIndex() {


### PR DESCRIPTION
### ☑️ Resolves

- Allows to show a tab navigation if there is only one tab available
- Should be non-interactive, act as a visual header

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/c76a8b78-952a-43ca-aad3-e9ab46f66f37) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/705baf2b-d46f-4391-9bf0-53f355be8df8)

### 🚧 Tasks

- [ ] Discuss on disabling:
  - [ ] keydown events
  - [ ] mouse events
  - [ ] aria-attributes

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
