### PR TITLE
[next] chore(NcUserStatusIcon): remove warn if status is not set

### DIFF
--- a/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
+++ b/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
@@ -42,7 +42,6 @@ This component displays a user status icon.
 </template>
 
 <script>
-import { warn } from 'vue'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { getCapabilities } from '@nextcloud/capabilities'
@@ -147,12 +146,6 @@ export default {
 				}
 			},
 		},
-	},
-
-	mounted() {
-		if (!this.user && !this.status) {
-			warn('[NcUserStatusIcon] The `user` or `status` prop should be set.')
-		}
 	},
 }
 </script>


### PR DESCRIPTION
- Manual backport of https://github.com/nextcloud-libraries/nextcloud-vue/pull/5715