### PR TITLE
style(NcHeaderMenu): pass text-on-background color for header menu

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -337,7 +337,7 @@ $externalMargin: 8px;
 
 		// header is filled with primary or image background
 		filter: none !important;
-		color: var(--color-primary-text) !important;
+		color: var(--color-background-plain-text, var(--color-primary-text)) !important;
 	}
 
 	&--opened &__trigger,


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/notifications/issues/1962

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/895ed766-a8ec-4159-b591-22abb50fe516) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/ad3c3eaf-f9db-40de-a958-1432a3faefe8)

### 🚧 Tasks

- [ ] Drop internal styles at server:
  - [ ] UnifiedSearch
  - [ ] ContactsMenu
  - [ ] AppMenu (NcActions `aria-label="More apps"`)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
