### PR TITLE
fix(NcRichContentEditable): remove overlapping placeholder with tribute trigger

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -1040,6 +1040,7 @@ export default {
 			this.focus()
 			const index = this.tribute.collection.findIndex(collection => collection.trigger === trigger)
 			this.tribute.showMenuForCollection(this.$refs.contenteditable, index)
+			this.updateValue(this.$refs.contenteditable.innerHTML)
 			document.addEventListener('click', this.hideTribute, true)
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

🙈

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/84044328/590b8c0c-064c-4bd9-8fb7-4b76e6299646) | ![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/84044328/d62e4076-43cc-4b75-978c-6687466bca59)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
