### PR TITLE
fix(NcMentionBubble): hide selectable mention id from widescreens

### DIFF
--- a/src/components/NcRichContenteditable/NcMentionBubble.vue
+++ b/src/components/NcRichContenteditable/NcMentionBubble.vue
@@ -158,7 +158,10 @@ $bubble-avatar-size: $bubble-height - 2 * $bubble-padding;
 	&__select {
 		position: absolute;
 		z-index: -1;
-		left: -1000px;
+		left: -100vw;
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix visible userid from mention bubble on widescreens (21:9, zoomed out)

### 🖼️ Screenshots

🏚️ Before

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/46e4a7df-8a5a-439d-8c42-3588fd9c16c9)

🏡 After

![image](https://github.com/nextcloud-libraries/nextcloud-vue/assets/93392545/a7a08dd9-ad4c-478c-878d-9b3f8f7e8dcd)

### 🏁 Checklist

- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade