### PR TITLE
fix(NcReferenceWidget): pass elements to intersection observer

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -72,9 +72,9 @@ export default {
 		const widgetRoot = ref()
 		const { width } = useElementSize(widgetRoot)
 
-		useIntersectionObserver(widgetRoot, () => {
+		useIntersectionObserver(widgetRoot, ([entry]) => {
 			nextTick(() => {
-				isVisible.value = widgetRoot.value?.isIntersecting ?? false
+				isVisible.value = entry.isIntersecting
 			})
 		})
 


### PR DESCRIPTION
### ☑️ Resolves

* Regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/5561

Intersection observer has observed elements as output

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
