### PR TITLE
fix(NcAppNavigationCaption ): properly align with NcAppNavigationItem

### DIFF
--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -240,7 +240,7 @@ export default {
 		box-shadow: none !important;
 		flex-shrink: 0;
 		// padding to align the name with the icon of app navigation items
-		padding: 0 calc(var(--default-grid-baseline, 4px) * 2) 0 calc(var(--default-grid-baseline, 4px) * 3);
+		padding: 0 calc(var(--default-grid-baseline, 4px) * 2) 0 calc(var(--default-grid-baseline, 4px) * 2);
 		margin-top: 0px;
 		margin-bottom: 12px;
 	}


### PR DESCRIPTION
Make NcAppNavigationCaption properly align with NcAppNavigationItem

### ☑️ Resolves

- Fix https://github.com/nextcloud/calendar/pull/6129#issuecomment-2225327507

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
 ![Screenshot from 2024-07-15 10-16-03](https://github.com/user-attachments/assets/3a9b1f10-b620-4b2b-90a4-a524468ee017) | ![Screenshot from 2024-07-15 10-14-38](https://github.com/user-attachments/assets/b76d9f23-761d-40e1-93c7-2b47160b4b7c)

