### PR TITLE
chore(docs): remove SPDX header from component docs

### DIFF
--- a/src/mixins/actionGlobal.js
+++ b/src/mixins/actionGlobal.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+// An empty comment below is needed to prevent styleguidist from using SPDX header as a mixin=component description in docs
+/** */
 export default {
 	beforeUpdate() {
 		this.text = this.getText()

--- a/src/mixins/clickOutsideOptions/index.js
+++ b/src/mixins/clickOutsideOptions/index.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+// An empty comment below is needed to prevent styleguidist from using SPDX header as a mixin=component description in docs
+/** */
 export default {
 	props: {
 		/**


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/5808

When there is nothing else in a mixin, styleguidist uses SPDX header as mixin's JSDoc and adds it to the component docs.

```js
/**
 * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
 * SPDX-License-Identifier: AGPL-3.0-or-later
 */

export default {
  // Mixin
```

Affected components:
- `NcHeaderMenu`
- `NcAppNavigationSettings`
- `NcActionCheckbox`
- `NcActionInput`
- `NcActionLink`
- `NcActionRouter`
- `NcActionRadio`
- `NcActionText`
- `NcActionTextEditable`

This can be disabled via [validExtends](https://vue-styleguidist.github.io/Configuration.html#validextends) config, but that would also remove `props` docs defined in mixins.

A solution - add a fake empty JSDoc in a mixin.

### Alternative solution

Get rid of mixins

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/ffbf0c3a-0b7d-4e32-b4da-bd3c009508b8) | ![image](https://github.com/user-attachments/assets/9c27e4fd-9256-46e2-ab47-a01874feb3a1)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
