### PR TITLE
fix(NcColorPicker): Make the color circle size depend on clickable area

### DIFF
--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -59,7 +59,7 @@ export default {
 
 .color0 {
 	width: 100px;
-	height: 40px;
+	height: 34px;
 	border-radius: 6px;
 }
 </style>
@@ -98,7 +98,7 @@ export default {
 
 .color1 {
 	width: 100px;
-	height: 40px;
+	height: 34px;
 	margin-left: 20px;
 	border-radius: 6px;
 }
@@ -133,7 +133,7 @@ export default {
 
 .color0 {
 	width: 100px;
-	height: 40px;
+	height: 34px;
 	margin-left: 20px;
 	border-radius: 6px;
 }
@@ -433,9 +433,9 @@ export default {
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			width: 34px;
-			height: 34px;
-			min-height: 34px;
+			width: calc(var(--default-clickable-area) - 10px);
+			height: calc(var(--default-clickable-area) - 10px);
+			min-height: calc(var(--default-clickable-area) - 10px);
 			margin: auto;
 			padding: 0;
 			color: white;
@@ -449,9 +449,9 @@ export default {
 				opacity: .6;
 			}
 			&--active {
-				width: 38px;
-				height: 38px;
-				min-height: 38px;
+				width: calc(var(--default-clickable-area) - 6px);
+				height: calc(var(--default-clickable-area) - 6px);
+				min-height: calc(var(--default-clickable-area) - 6px);
 				transition: all 100ms ease-in-out;
 				opacity: 1 !important;
 			}
@@ -481,8 +481,8 @@ export default {
 		}
 
 		&-active-color {
-			width: 34px;
-			height: 34px;
+			width: calc(var(--default-clickable-area) - 10 px);
+			height: calc(var(--default-clickable-area) - 10 px);
 			border-radius: 17px;
 		}
 


### PR DESCRIPTION
### ☑️ Resolves

- For https://github.com/nextcloud/calendar/issues/6145

The size of the circles is hard coded but the grid size depends on the clickable area. So I made the size dependent as well. I've tested this with a clickable area of 34. It works with the old 44 as well:

![image](https://github.com/user-attachments/assets/f3f66408-c9dc-49b4-b41d-664b69628d8a)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2024-07-17 13-53-00](https://github.com/user-attachments/assets/d9bab60e-cfc6-47e9-947b-cb321d0f2ae5) | ![Bildschirmfoto vom 2024-07-17 13-52-37](https://github.com/user-attachments/assets/bcf61670-3c12-4b15-acff-d66f256d0360)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
