### PR TITLE
NcAppSettingsSection: make titles normal h3 size

### DIFF
--- a/src/components/NcAppSettingsSection/NcAppSettingsSection.vue
+++ b/src/components/NcAppSettingsSection/NcAppSettingsSection.vue
@@ -66,7 +66,7 @@ export default {
 .app-settings-section {
 	margin-bottom: 80px;
 	&__name {
-		font-size: 20px;
+		font-size: 1.6em;
 		margin: 0;
 		padding: 20px 0;
 		font-weight: bold;


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/mail/pull/9879

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-07-17 17-52-36](https://github.com/user-attachments/assets/c2862c6d-5689-4820-9d48-d69eb70184c8) | ![image](https://github.com/user-attachments/assets/ad32b022-859d-4ff3-b416-aab1824465ba)

Not sure why their size was limited in the first place
