### PR TITLE
fix(NcInputField): Make helper text aligned and maxcontrast color

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -502,8 +502,10 @@ export default {
 
 	&__helper-text-message {
 		padding-block: 4px;
+		padding-inline: var(--border-radius-large);
 		display: flex;
 		align-items: center;
+		color: var(--color-text-maxcontrast);
 
 		&__icon {
 			margin-inline-end: 8px;

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -34,6 +34,11 @@ and `minlength`.
 			<Lock :size="20" />
 		</NcTextField>
 		<NcTextField :value.sync="text2"
+			label="With helper text"
+			helper-text="This is an optional message to show e.g. validation errors."
+			@trailing-button-click="clearText">
+		</NcTextField>
+		<NcTextField :value.sync="text2"
 			label="Success state"
 			placeholder="Placeholders are possible"
 			:success="true"


### PR DESCRIPTION
### ☑️ Resolves

The helper text should be aligned with the input, at least the inline padding should match the input (without icons).
Also the helper text without any state (error / success) should be maxcontrast color.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2024-07-18 at 02-53-15 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/a4f10e91-ab29-4250-b7e0-50edc6b06647)|![Screenshot 2024-07-18 at 02-55-34 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/2791cafc-2cb2-4ec8-bd7c-62e933f805d5)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
