### PR TITLE
fix(NcAppSidebar): manage focus only after transition has finished

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -962,8 +962,6 @@ export default {
 		},
 
 		open() {
-			this.toggleFocusTrap()
-
 			this.checkToggleButtonContainerAvailability()
 		},
 	},
@@ -972,15 +970,6 @@ export default {
 		this.preserveElementToReturnFocus()
 
 		this.checkToggleButtonContainerAvailability()
-	},
-
-	mounted() {
-		// Focus sidebar on open only if it was opened by a user interaction
-		if (this.elementToReturnFocus) {
-			this.focus()
-		}
-
-		this.toggleFocusTrap()
 	},
 
 	beforeDestroy() {
@@ -1061,6 +1050,13 @@ export default {
 			this.$emit('opening', element)
 		},
 		onAfterEnter(element) {
+			// Focus sidebar on open only if it was opened by a user interaction
+			if (this.elementToReturnFocus) {
+				this.focus()
+			}
+
+			this.toggleFocusTrap()
+
 			/**
 			 * The sidebar is opened and the transition is complete
 			 *
@@ -1084,6 +1080,8 @@ export default {
 			 * @type {HTMLElement}
 			 */
 			this.$emit('closed', element)
+
+			this.toggleFocusTrap()
 
 			// Return focus to the element that had focus before the sidebar was opened
 			this.elementToReturnFocus?.focus({ focusVisible: true })


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/spreed/issues/12747

When NcAppSidebar appears, two things happen:
1. Transition animation with margin
2. Focus is moved to the sidebar

Moving focus scrolls container (`NcContent`) to the sidebar which is out of the container (in the process of moving from the right side). It results in weird animation when the margin changes the width + scroll of the container instead of the position of the sidebar.

P.S. `overflow: hidden` only hides the scrollbar and content, but the container is still scrollable.
`overflow: clip` is used to actually remove scrolling.

Slowed animation 1000 times to see the effect: sidebar moves left and right by 1 pixel.

![slow](https://github.com/user-attachments/assets/47fc9c0c-feb6-4941-bb0f-c6359ffb4a97)


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/user-attachments/assets/fbcb1a2e-9d5a-448f-b25c-ab9e17a21b5f) | ![after](https://github.com/user-attachments/assets/b1d0fad1-53b6-486c-8111-606f33d3e5cb)

### 🚧 Tasks

- [x] Move focus management to transition hooks
  - Both return focus and focus trap

### Alternative solution

Use `overflow: clip` on `NcContent` to remove scrolling.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
