### PR TITLE
fix(NcListItem): do not render counter on falsy values

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -398,10 +398,10 @@
 								<slot name="details">{{ details }}</slot>
 							</div>
 							<!-- Counter and indicator -->
-							<div v-if="counterNumber != 0 || hasIndicator"
+							<div v-if="counterNumber || hasIndicator"
 								v-show="showAdditionalElements"
 								class="list-item-details__extra">
-								<NcCounterBubble v-if="counterNumber != 0"
+								<NcCounterBubble v-if="counterNumber"
 									:active="isActive || active"
 									class="list-item-details__counter"
 									:type="counterType">


### PR DESCRIPTION
### ☑️ Resolves

- Fix empty container, if counter has been passed as falsy value, but not 0 (null)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/8d4f4b90-ba06-4def-bbb0-84f4a34571f9) | ![image](https://github.com/user-attachments/assets/eb904939-3600-4f90-9a31-fac2be436bb5)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
