### PR TITLE
fix(NcActions): assign NcContent as NcActions > NcPopover default boundaries

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1131,7 +1131,7 @@ export default {
 		 */
 		boundariesElement: {
 			type: Element,
-			default: () => document.querySelector('#app-content-vue') ?? document.querySelector('body'),
+			default: () => document.querySelector('#content-vue') ?? document.querySelector('body'),
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

- Fix regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/5806#discussion_r1685505657
- default boundaries is NcAppContent `<main />`, so NcAppNavigation and NcAppSidebar stays out of it
- Didn't notice any drawbacks yet, so @susnux please check if that suffice previous PR results 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/39eb7a0a-5709-4773-94b2-d7af4beb71ac) | ![image](https://github.com/user-attachments/assets/097c210c-d3c2-429a-902e-b3eeaf675047)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
