### PR TITLE
fix(NcAppContent): splitpane splitter styles with dark theme

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -418,23 +418,15 @@ export default {
 			}
 		}
 	}
-	.app-content-wrapper--vertical-split {
-		.splitpanes__splitter {
-			width: 9px;
-			margin-left: -5px;
-			background-color: transparent;
-			border-left: none;
 
-			&:before,
-			&:after {
-				display: none;
-			}
-		}
-	}
-	.app-content-wrapper--horizontal-split {
+	&.splitpanes--vertical {
 		.splitpanes__splitter {
-			height: 9px;
-			margin-top: -5px;
+			background-color: var(--color-main-background);
+			border-left: 1px solid var(--color-border);
+
+			&::before, &::after {
+				background-color: var(--color-border);
+			}
 		}
 	}
 }


### PR DESCRIPTION
The CSS selectors used for the splitter were no functional, so we were using the default ones from splitpane here.

Use our variables for colors to unbreak styling in dark mode.


### 🖼️ Screenshots

🏚️ Light mode before | 🏡 Light mode after
---|---
![grafik](https://github.com/user-attachments/assets/729a252d-a50a-4123-9950-c79365341b42) | ![grafik](https://github.com/user-attachments/assets/e4d99777-675a-43d2-9217-ac9b4408a555)

🏚️ Dark mode before | 🏡 Dark mode after
---|---
![grafik](https://github.com/user-attachments/assets/92d252e7-5fb9-4a37-a2f0-18d48a870627) | ![grafik](https://github.com/user-attachments/assets/51b5dac3-a86c-46b2-8db4-e9995757f362)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
