### PR TITLE
fix: alignement of listitem name for one line layout

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -837,6 +837,9 @@ export default {
 			align-items: unset;
 			justify-content: end;
 		}
+		.list-item-content__name {
+			align-self: center;
+		}
 	}
 
 	&__anchor {


### PR DESCRIPTION
### ☑️ Resolves

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![ab](https://github.com/user-attachments/assets/3f2f5c84-146f-40b7-9be3-61d7a94c2956) | ![bc](https://github.com/user-attachments/assets/fe43a823-e9db-4987-b427-f35bd73e1c98)

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
