### PR TITLE
fix(NcListItem): Make paddings smaller again on Nextcloud 30

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -356,6 +356,7 @@
 				class="list-item"
 				:class="{
 					'list-item--compact': compact,
+					'list-item--legacy': isLegacy,
 					'list-item--one-line': oneLine,
 				}"
 				@mouseover="handleMouseover"
@@ -585,6 +586,15 @@ export default {
 		'update:menuOpen',
 	],
 
+	setup() {
+		const [major] = window._oc_config?.version.split('.', 2) ?? []
+		const isLegacy = major && Number.parseInt(major) < 30
+
+		return {
+			isLegacy,
+		}
+	},
+
 	data() {
 		return {
 			hovered: false,
@@ -780,7 +790,7 @@ export default {
 
 // NcListItem
 .list-item {
-	--list-item-padding: 8px;
+	--list-item-padding: var(--default-grid-baseline);
 	// The content are two lines of text and respect the 1.5 line height
 	--list-item-height: calc(2 * var(--default-line-height));
 	--list-item-border-radius: var(--border-radius-element, 32px);
@@ -790,9 +800,7 @@ export default {
 	position: relative;
 	flex: 0 0 auto;
 	justify-content: flex-start;
-	// we need to make sure the elements are not cut off by the border
-	padding-inline: calc((var(--list-item-height) - var(--list-item-border-radius)) / 2);
-	padding-block: var(--list-item-padding);
+	padding: var(--list-item-padding);
 	width: 100%;
 	border-radius: var(--border-radius-element, 32px);
 	cursor: pointer;
@@ -812,18 +820,29 @@ export default {
 	}
 
 	&--compact {
-		--list-item-padding: 2px;
+		--list-item-padding: calc(0.5 * var(--default-grid-baseline)) var(--default-grid-baseline);
+
+		&:not(:has(.list-item-content__subname)) {
+			--list-item-height: var(--default-clickable-area);
+		}
 	}
-	.list-item-content__details {
-		display: flex;
-		flex-direction: column;
-		justify-content: end;
-		align-items: end;
+
+	&--legacy {
+		--list-item-padding: calc(2 * var(--default-grid-baseline));
+
+		&.list-item--compact {
+			--list-item-padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
+		}
 	}
+
 	&--one-line {
 		--list-item-height: var(--default-clickable-area);
 		--list-item-border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
-		--list-item-padding: 2px;
+		--list-item-padding: var(--default-grid-baseline);
+
+		&#{&}--legacy {
+			--list-item-padding: 2px calc((var(--list-item-height) - var(--list-item-border-radius)) / 2);
+		}
 
 		.list-item-content__main {
 			display: flex;
@@ -859,8 +878,9 @@ export default {
 		display: flex;
 		flex: 1 0;
 		justify-content: space-between;
-		padding-left: 8px;
+		padding-left: calc(2 * var(--default-grid-baseline));
 		min-width: 0;
+
 		&__main {
 			flex: 1 0;
 			width: 0;
@@ -869,6 +889,13 @@ export default {
 			&--oneline {
 				display: flex;
 			}
+		}
+
+		&__details {
+			display: flex;
+			flex-direction: column;
+			justify-content: end;
+			align-items: end;
 		}
 
 		&__actions {
@@ -894,8 +921,9 @@ export default {
 			margin: 0 5px;
 		}
 	}
+
 	&__extra {
-		margin-top: 4px;
+		margin-top: var(--default-grid-baseline);
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

Add a `legacy` class so that we can keep stylings for Nextcloud 29 and older but still can style the component properly on Nextcloud 30 (smaller border radius = we can use smaller paddings)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2024-07-29 at 10-01-40 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/540ce9e9-bd3c-49ca-8890-1fe4570bea64)|![Screenshot 2024-07-29 at 09-55-11 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/1caa6720-12a7-4a6f-b952-4b7b1f585fbe)
![Screenshot 2024-07-29 at 10-01-35 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/55aacbe7-fffb-4e3d-897f-48ba40722551)|![Screenshot 2024-07-29 at 09-55-19 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/04f1ac43-eb18-4bd3-bb48-fd5821f87894)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
