### PR TITLE
fix(style): adjust elements styles to unit-less line-height

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -441,7 +441,7 @@ export default {
 		margin-inline: var(--input-padding-start) var(--input-padding-end);
 		max-width: fit-content;
 		font-size: var(--input-label-font-size);
-		inset-block-start: calc((var(--default-clickable-area) - var(--default-line-height)) / 2); // center the label vertically
+		inset-block-start: calc((var(--default-clickable-area) - 1lh) / 2); // center the label vertically
 		inset-inline: var(--border-width-input-focused, 2px);
 		// Fix color so that users do not think the input already has content
 		color: var(--color-text-maxcontrast);

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -792,7 +792,7 @@ export default {
 .list-item {
 	--list-item-padding: var(--default-grid-baseline);
 	// The content are two lines of text and respect the 1.5 line height
-	--list-item-height: calc(2 * var(--default-line-height));
+	--list-item-height: 2lh;
 	--list-item-border-radius: var(--border-radius-element, 32px);
 	// General styles
 	box-sizing: border-box;


### PR DESCRIPTION
### ☑️ Resolves

- Based on https://github.com/nextcloud-libraries/nextcloud-vue/pull/5887
- unitless line-height cannot be used as a unit value in calculations
- Replaced with `lh`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/a933ee54-e81d-47d7-9a3c-240a5af0599b) | ![image](https://github.com/user-attachments/assets/d389ffc6-8a3c-414a-9140-b12818e0e011)
![image](https://github.com/user-attachments/assets/8da9fb1c-c501-4e7f-8b32-c2766bca9ac7) | ![image](https://github.com/user-attachments/assets/383239f7-9ca0-4e61-a98e-432791b0a111)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
