### PR TITLE
feat(NcPasswordField): add as-text prop to remove autocomplete

### DIFF
--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -40,6 +40,10 @@ General purpose password field component.
 		<NcPasswordField :value.sync="text5"
 			:disabled="true"
 			label="Disabled" />
+
+		<NcPasswordField :value.sync="text6"
+			label="Secret token"
+			as-text />
 	</div>
 </template>
 <script>
@@ -51,6 +55,7 @@ export default {
 			text3: 'hunter',
 			text4: '',
 			text5: '',
+			text6: 'secret-token',
 		}
 	},
 }
@@ -81,12 +86,13 @@ export default {
 <template>
 	<NcInputField v-bind="propsAndAttrsToForward"
 		ref="inputField"
-		:type="isPasswordHidden ? 'password' : 'text'"
+		:type="isPasswordHidden && !asText ? 'password' : 'text'"
 		:trailing-button-label="trailingButtonLabelPassword"
 		:helper-text="computedHelperText"
 		:error="computedError"
 		:success="computedSuccess"
 		:minlength="rules.minlength"
+		:input-class="{ 'password-field__input--secure-text': isPasswordHidden && asText }"
 		v-on="$listeners"
 		@trailing-button-click="togglePasswordVisibility"
 		@input="handleInput">
@@ -195,6 +201,18 @@ export default {
 		maxlength: {
 			type: Number,
 			default: null,
+		},
+
+		/**
+		 * Render as input[type=text] that looks like password field.
+		 * Allows to avoid unwanted password-specific browser behavior,
+		 * such as save or generate password prompt.
+		 * Useful for secret token fields.
+		 * Note: autocomplete="off" is ignored by browsers.
+		 */
+		asText: {
+			type: Boolean,
+			default: false,
 		},
 	},
 
@@ -318,3 +336,11 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+:deep(.password-field__input--secure-text) {
+	// Emulate password field look
+	// This is not a part of the standard but well supported
+	-webkit-text-security: disc;
+}
+</style>


### PR DESCRIPTION
### ☑️ Resolves

- Sometimes we need to show secret but editable value, for example, a secret token
- To hide we should use password field
- But it is not a password. Neither creating a new password, nor authentication. It should not be saved, generated or autocompleted.
- The problem - browsers have save/generate prompts for password fields. This behavior cannot be disabled with `autocomplete="off"`, browsers ignore it.

Proposal: add a new `as-text` prop that forces using `type="text"` and emulates password field view.

Note: `-webkit-text-security` is not a standard feature, but well supported.

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/7ac9be5b-e373-4c7f-8dfa-d1a9f5d0c074)

### 🚧 Tasks

- [x] Add `as-text` prop to force text type and prevent autocomplete and 

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
