### PR TITLE
fix(NcCounterButton): adjust min-width to make it a right circle

### DIFF
--- a/src/components/NcCounterBubble/NcCounterBubble.vue
+++ b/src/components/NcCounterBubble/NcCounterBubble.vue
@@ -76,10 +76,11 @@ export default {
 	overflow: hidden;
 	width: fit-content;
 	max-width: var(--default-clickable-area);
+	min-width: calc(1lh + 2 * var(--default-grid-baseline)); // Make it not narrower than a circle
 	text-align: center;
 	text-overflow: ellipsis;
 	line-height: 1em;
-	padding: 4px 6px;
+	padding: var(--default-grid-baseline);
 	border-radius: var(--border-radius-pill);
 	background-color: var(--color-primary-element-light);
 	font-weight: bold;


### PR DESCRIPTION
### ☑️ Resolves

- Fixes: with small numbers like `1` NcCounterBubble is narrower than a circle
- Makes `min-width` equal to `height`

Note: it is a but not centered vertically, because actually digits in fonts are smaller than line height. It will be fixed in a separate PR.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/c41fb5ec-d5c0-4c8b-9509-6724d7b4d31d) | ![image](https://github.com/user-attachments/assets/b2b54717-a1ac-46fd-8a64-7297c76c659d)
![image](https://github.com/user-attachments/assets/869b75bc-6170-4f4f-8c73-c3e67c9bdf68) | ![image](https://github.com/user-attachments/assets/29eb5f0f-8756-466e-9a76-3249be61b66f)
![image](https://github.com/user-attachments/assets/42049f7f-2b2a-4f71-bbe9-2c6282de9121) | ![image](https://github.com/user-attachments/assets/c767f05c-4dcb-4e05-9321-b65caeafb30f) 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
