### PR TITLE
fix(NcUserBubble): fix tag assignment if no url but to provided

### DIFF
--- a/src/components/NcUserBubble/NcUserBubble.vue
+++ b/src/components/NcUserBubble/NcUserBubble.vue
@@ -249,9 +249,13 @@ export default {
 		},
 
 		isLinkComponent() {
-			return this.hasUrl
-				? (this.to ? RouterLink : 'a')
-				: 'div'
+			if (this.hasUrl) {
+				return 'a'
+			} else if (this.to) {
+				return RouterLink
+			} else {
+				return 'div'
+			}
 		},
 
 		popoverEmpty() {
@@ -338,9 +342,5 @@ export default {
 		padding: 0;
 		padding-left: 4px;
 	}
-}
-
-a.user-bubble__content {
-	cursor: pointer;
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- Fix bug introduced in #5708
- splitted with if/else block to redefine 'div' tag and condition later 

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
