### PR TITLE
chore(docs): specify more Nextcloud versions in styleguidist

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -73,12 +73,15 @@ module.exports = async () => {
 				usageMode: 'hide',
 			},
 			{
-				name: 'Latest version: v8.x (Nextcloud 28)',
-				href: 'https://nextcloud-vue-components.netlify.app',
+				name: 'Versions',
 				sections: [
 					{
-						name: 'next v9.x (Nextcloud 28 + Vue 3)',
+						name: 'next v9.x (Nextcloud 28+ on Vue 3)',
 						href: 'https://next--nextcloud-vue-components.netlify.app',
+					},
+					{
+						name: 'current v8.x (Nextcloud 28+)',
+						href: 'https://nextcloud-vue-components.netlify.app',
 					},
 					{
 						name: 'v7.x (Nextcloud 25 - 27)',


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/c90903ba-b02e-401e-85fc-1d262099c1df) | ![image](https://github.com/user-attachments/assets/8b4671c1-1548-44b5-a3e5-be37b49f838c)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
