### PR TITLE
fix(NcActions): Role `menu` needs a label assigned so label by trigger

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1262,6 +1262,7 @@ export default {
 					},
 					popoverContainerA11yAttrs: {},
 					popoverUlA11yAttrs: {
+						'aria-labelledby': this.triggerRandomId,
 						id: this.randomId,
 						role: 'menu',
 					},
@@ -1311,7 +1312,11 @@ export default {
 					withFocusTrap: true,
 					triggerA11yAttr: {},
 					popoverContainerA11yAttrs: {},
-					popoverUlA11yAttrs: {},
+					popoverUlA11yAttrs: {
+						// there is nothing against labelling a list, it is mostly recommended
+						// so as we do not know the dialog type lets include the label
+						'aria-labelledby': this.triggerRandomId,
+					},
 				},
 			}
 			return configs[this.actionsMenuSemanticType]


### PR DESCRIPTION
### ☑️ Resolves

See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role

The `menu` needs a label set, so lets add it similar to dialog role. In general we could consider always add it to the `ul` as this is pretty valid and has good browser support.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
