### PR TITLE
feat(NcButton): Allow to specify `target` attribute for buttons with href

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -520,6 +520,14 @@ export default {
 		},
 
 		/**
+		 * Target for the `a` element if `href` is set.
+		 */
+		target: {
+			type: String,
+			default: '_self',
+		},
+
+		/**
 		 * Providing the download attribute with href downloads file when clicking.
 		 */
 		download: {
@@ -653,7 +661,7 @@ export default {
 					type: isLink ? null : this.nativeType,
 					role: isLink ? 'button' : null,
 					href: this.to ? href : (this.href || null),
-					target: isLink ? '_self' : null,
+					target: isLink ? (this.target || '_self') : null,
 					rel: isLink ? 'nofollow noreferrer noopener' : null,
 					download: (!this.to && this.href && this.download) ? this.download : null,
 					// If this button is used as a popover trigger, we need to apply trigger attrs, e.g. aria attributes


### PR DESCRIPTION
Required to allow opening links in `_blank` target via `NcButton`.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
