### PR TITLE
fix(NcUserBubble): make it perfectly aligned circle

### DIFF
--- a/src/components/NcCounterBubble/NcCounterBubble.vue
+++ b/src/components/NcCounterBubble/NcCounterBubble.vue
@@ -72,14 +72,15 @@ export default {
 
 <style lang="scss" scoped>
 .counter-bubble__counter {
+	--counter-bubble-line-height: 1em;
 	font-size: calc(var(--default-font-size) * .8);
 	overflow: hidden;
 	width: fit-content;
 	max-width: var(--default-clickable-area);
-	min-width: calc(1lh + 2 * var(--default-grid-baseline)); // Make it not narrower than a circle
+	min-width: calc(var(--counter-bubble-line-height) + 2 * var(--default-grid-baseline)); // Make it not narrower than a circle
 	text-align: center;
 	text-overflow: ellipsis;
-	line-height: 1em;
+	line-height: var(--counter-bubble-line-height);
 	padding: var(--default-grid-baseline);
 	border-radius: var(--border-radius-pill);
 	background-color: var(--color-primary-element-light);
@@ -112,4 +113,12 @@ export default {
 	}
 }
 
+// Make it pixel perfect aligned
+@supports (line-height: 1cap) {
+	.counter-bubble__counter {
+		// 1em is higher than one digit and makes it not perfectly vertically aligned
+		// 1cap = hight of a digit (T character)
+		--counter-bubble-line-height: 1cap;
+	}
+}
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- With 1 digit in `NcUserBubble` the digit is not exactly in the middle
- The problem is that `1em` line height is bigger than actual digit height
- Usually it is not a problem, but with a circle it looks better than it's perfectly in the middle
- Using `cap` fixes the problem
- `cap` is not well supported, so using `1em` as a fallback

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/dd2c27ea-33d9-4fc1-939b-c2eedd1071d4) | ![image](https://github.com/user-attachments/assets/15c6a196-b9d0-4150-b8ac-03e4b8ff4013)
![image](https://github.com/user-attachments/assets/285f8154-50a7-40b7-9873-4b991ab3a1ed) | ![image](https://github.com/user-attachments/assets/19727af3-09a1-41d0-96e9-ebfb0453f644)
Top padding is bigger than the bottom | Padding is almost equal


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
