### PR TITLE
fix(NcActions): NcActionCheckbox and NcActionRadio icon alignment

### DIFF
--- a/src/components/NcActionCheckbox/NcActionCheckbox.vue
+++ b/src/components/NcActionCheckbox/NcActionCheckbox.vue
@@ -206,8 +206,7 @@ export default {
 
 		&::before {
 			margin-block: 0 !important;
-			// 16px is the width of the checkbox including the border
-			margin-inline: calc((var(--default-clickable-area) - 16px) / 2) !important;
+			margin-inline: calc((var(--default-clickable-area) - 14px) / 2) !important;
 		}
 	}
 

--- a/src/components/NcActionRadio/NcActionRadio.vue
+++ b/src/components/NcActionRadio/NcActionRadio.vue
@@ -199,10 +199,9 @@ export default {
 		padding: 0 !important;
 		padding-right: $icon-margin !important;
 
-		// radio-width is 12px, border is 2
-		// (44 - 14 - 2) / 2 = 14
+		// (34 -14) / 2 = 10 same as ncactioncheckbox
 		&::before {
-			margin: 0 14px 0 !important;
+			margin: calc((var(--default-clickable-area) - 14px) / 2) !important;
 		}
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix #5957

### 🖼️ Screenshots

🏚️ Before | 🏡 After
![Screenshot from 2024-08-14 10-42-45](https://github.com/user-attachments/assets/e2983e71-ad8f-4644-814c-3c155577bf64)
|
![Screenshot from 2024-08-14 11-36-43](https://github.com/user-attachments/assets/faf041ff-9686-4b3f-84a5-f97e2653b6de)



### 🚧 Tasks

- [x] Change the margin of both ncactioncheckbox and ncactionradio so they align. I decreased the margin because they dont fit with the other elements, like 'remove attendee' in the screenshot. I think that comes from making icons smaller.
### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
