### PR TITLE
fix(NcCheckboxRadioSwitch): adjust to new border radius

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -195,11 +195,11 @@ export default {
 	display: flex;
 	align-items: center;
 	flex-direction: row;
-	gap: 4px;
+	gap: var(--default-grid-baseline);
 	user-select: none;
 	min-height: var(--default-clickable-area);
-	border-radius: var(--default-clickable-area);
-	padding: 4px calc((var(--default-clickable-area) - var(--icon-height)) / 2);
+	border-radius: var(--checkbox-radio-switch--border-radius);
+	padding: var(--default-grid-baseline) calc((var(--default-clickable-area) - var(--icon-height)) / 2);
 	// Set to 100% to make text overflow work on button style
 	width: 100%;
 	// but restrict to content so plain checkboxes / radio switches do not expand

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -682,9 +682,9 @@ export default {
 		color: var(--color-primary-element-light);
 	}
 
-	$border-radius: calc(var(--default-clickable-area) / 2);
+	--checkbox-radio-switch--border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
 	// keep inner border width in mind
-	$border-radius-outer: calc($border-radius + 2px);
+	--checkbox-radio-switch--border-radius-outer: calc(var(--checkbox-radio-switch--border-radius) + 2px);
 
 	&--button-variant.checkbox-radio-switch {
 		background-color: var(--color-main-background);
@@ -721,7 +721,7 @@ export default {
 
 	&--button-variant:not(&--button-variant-v-grouped):not(&--button-variant-h-grouped),
 	&--button-variant &__content {
-		border-radius: $border-radius;
+		border-radius: var(--checkbox-radio-switch--border-radius);
 	}
 
 	/* Special rules for vertical button groups */
@@ -732,12 +732,12 @@ export default {
 	}
 	&--button-variant-v-grouped {
 		&:first-of-type {
-			border-top-left-radius: $border-radius-outer;
-			border-top-right-radius: $border-radius-outer;
+			border-top-left-radius: var(--checkbox-radio-switch--border-radius-outer);
+			border-top-right-radius: var(--checkbox-radio-switch--border-radius-outer);
 		}
 		&:last-of-type {
-			border-bottom-left-radius: $border-radius-outer;
-			border-bottom-right-radius: $border-radius-outer;
+			border-bottom-left-radius: var(--checkbox-radio-switch--border-radius-outer);
+			border-bottom-right-radius: var(--checkbox-radio-switch--border-radius-outer);
 		}
 
 		// remove borders between elements
@@ -755,12 +755,12 @@ export default {
 	/* Special rules for horizontal button groups */
 	&--button-variant-h-grouped {
 		&:first-of-type {
-			border-top-left-radius: $border-radius-outer;
-			border-bottom-left-radius: $border-radius-outer;
+			border-top-left-radius: var(--checkbox-radio-switch--border-radius-outer);
+			border-bottom-left-radius: var(--checkbox-radio-switch--border-radius-outer);
 		}
 		&:last-of-type {
-			border-top-right-radius: $border-radius-outer;
-			border-bottom-right-radius: $border-radius-outer;
+			border-top-right-radius: var(--checkbox-radio-switch--border-radius-outer);
+			border-bottom-right-radius: var(--checkbox-radio-switch--border-radius-outer);
 		}
 
 		// remove borders between elements


### PR DESCRIPTION
* Closes https://github.com/nextcloud-libraries/nextcloud-vue/pull/5923

### ☑️ Resolves

- adjust `NcCheckboxRadioSwitch` to new border radius

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/a5e9dae4-9124-48e9-835e-1afdba7eae6d) | ![image](https://github.com/user-attachments/assets/04301135-a4c6-4e54-a0c1-e62979a50786)
![image](https://github.com/user-attachments/assets/8c497e42-6086-4435-9b34-e4bdfdd61a97) | ![image](https://github.com/user-attachments/assets/7900ed84-ac2d-4332-a64c-f5ee10bd546b)
![image](https://github.com/user-attachments/assets/a18dd871-9245-41ee-a16c-d0e759d38651) | ![image](https://github.com/user-attachments/assets/0e34758d-2443-4715-9625-d229905cd4d5)
![image](https://github.com/user-attachments/assets/4b06c403-458b-4f76-9e0f-750a5b35ed15) | ![image](https://github.com/user-attachments/assets/ff5be3fe-e90b-4147-9d85-c08118c2d074)
### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
