### PR TITLE
fix(NcRichText): modify MENTION_START regex to work on older MobileSafari versions

### DIFF
--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -11,8 +11,8 @@ import stripTags from 'striptags'
 import Vue from 'vue'
 
 // Referenced from public function getMentions(): https://github.com/nextcloud/server/blob/master/lib/private/Comments/Comment.php
-// Beginning or whitespace. Non-capturing group within word boundary
-const MENTION_START = /\B(?<![^a-z0-9_\-@.'\s])/.source
+// Beginning or whitespace. Uses positive lookahead (to work on MobileSafari <16.4)
+const MENTION_START = /(?=[a-z0-9_\-@.'])\B/.source
 // Capturing groups like: @user-id, @"guest/abc16def", @"federated_user/user-id", @"user-id with space"
 const MENTION_SIMPLE = /(@[a-z0-9_\-@.']+)/.source
 const MENTION_GUEST = /@&quot;guest\/[a-f0-9]+&quot;/.source


### PR DESCRIPTION
Fixes RichText causes errors on WebKit | Invalid regex #5589

This regex performs the same function as the one used before, but does not make use of negative lookbehinds and therefore should work on older MobileSafari versions.

To test, I looked first at the original mentioned regex from nextcloud server to get an idea of what the intended valid and invalid captures were. I tested both the original and modified regexes for both the server one and the one used in this component to verify that the matching groups were the same. The overall match 1 (blue highlight) is slightly different however the capture group 1 (green highlight) has the same content across both so this should be compatible.

### ☑️ Resolves

- Fix #5589 
- Fix https://github.com/nextcloud/forms/issues/2163

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="765" alt="original" src="https://github.com/user-attachments/assets/e2b4ef10-415d-41f9-9760-d6dfd3bbadfa"> | <img width="766" alt="modified original" src="https://github.com/user-attachments/assets/1b48f988-3fbc-43b9-bb0b-fb7d1ee66a3e">
<img width="765" alt="original concatenated userid" src="https://github.com/user-attachments/assets/6527327d-7d1b-45a1-b78e-a8c2f856fcac"> | <img width="768" alt="modified concatenated userid" src="https://github.com/user-attachments/assets/47e07789-5fd3-4bef-82f2-00d9936a21e7">


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
