### PR TITLE
fix(NcListItem): allow to control the display of a three dot menu

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -513,6 +513,7 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 					@focusout="handleBlur">
 					<NcActions ref="actions"
 						:primary="isActive || active"
+						:force-menu="forceMenu"
 						:aria-label="computedActionsAriaLabel"
 						@update:open="handleActionsUpdateOpen">
 						<template v-if="$slots['actions-icon']" #icon>
@@ -670,6 +671,15 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		/**
+		 * Force the actions to display in a three dot menu
+		 */
+		forceMenu: {
+			type: Boolean,
+			default: false,
+		},
+
 		/**
 		 * Show the list component layout
 		 */


### PR DESCRIPTION
### ☑️ Resolves

- Related to https://github.com/nextcloud/spreed/issues/12921

The other general solution is to use `actionsProps` prop. It can be a better solution if we often want to customize `NcActions` in `NcListItem` in depth

### 🖼️ Screenshots

There is one action

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/eba7701e-7170-44d1-989c-05b462848e9c) | ![image](https://github.com/user-attachments/assets/3203778d-495c-4043-b79b-7e85dc96fb49)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
