### PR TITLE
fix(NcAppNavigationCaption): make name ellipsize

### DIFF
--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -265,9 +265,10 @@ export default {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		box-shadow: none !important;
-		flex-shrink: 0;
+		flex-shrink: 1;
 		// padding to align the name with the icon of app navigation items
 		padding: 0 calc(var(--default-grid-baseline, 4px) * 2) 0 calc(var(--default-grid-baseline, 4px) * 2);
+		padding-right: 0;
 		margin-top: 0px;
 		margin-bottom: var(--default-grid-baseline);
 	}


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/mail/issues/7171#issuecomment-2296411043

### 🖼️ Screenshots

I removed `padding-right` in order for the text to not ellipsize too early

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/aa9fcfd8-9ef9-4c70-a960-90fec06d2331) | ![image](https://github.com/user-attachments/assets/ffaf58e6-0b29-4737-b991-2760e2980737)
