### PR TITLE
refactor(NcModal): get rid of unneeded calc()

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -889,7 +889,7 @@ export default {
 			align-items: center;
 			justify-content: center;
 			box-sizing: border-box;
-			margin: calc(calc(var(--header-height) - var(--default-clickable-area)) / 2);
+			margin: calc((var(--header-height) - var(--default-clickable-area)) / 2);
 			padding: 0;
 		}
 
@@ -916,14 +916,14 @@ export default {
 				box-sizing: border-box;
 				width: var(--default-clickable-area);
 				height: var(--default-clickable-area);
-				margin: calc(calc(var(--header-height) - var(--default-clickable-area)) / 2);
+				margin: calc((var(--header-height) - var(--default-clickable-area)) / 2);
 				cursor: pointer;
 				opacity: $opacity_normal;
 			}
 		}
 
 		&:deep() .action-item {
-			margin: calc(calc(var(--header-height) - var(--default-clickable-area)) / 2);
+			margin: calc((var(--header-height) - var(--default-clickable-area)) / 2);
 
 			&--single {
 				box-sizing: border-box;


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/pull/5978#discussion_r1722061777

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
