### PR TITLE
fix(NcCounterBubble): increase size

### DIFF
--- a/src/components/NcCounterBubble/NcCounterBubble.vue
+++ b/src/components/NcCounterBubble/NcCounterBubble.vue
@@ -292,14 +292,14 @@ export default {
 
 <style lang="scss" scoped>
 .counter-bubble__counter {
-	--counter-bubble-line-height: 1em;
+	--counter-bubble-height: 22px; // ~ 1cap + 2 * 1.5 * grid
 	font-size: var(--font-size-small, 13px);
 	overflow: hidden;
 	width: fit-content;
-	min-width: calc(var(--counter-bubble-line-height) + 2 * var(--default-grid-baseline)); // Make it not narrower than a circle
+	min-width: var(--counter-bubble-height); // Make it not narrower than a circle
 	text-align: center;
-	line-height: var(--counter-bubble-line-height);
-	padding: var(--default-grid-baseline);
+	line-height: var(--counter-bubble-height); // Expand line-height to full height to center text vertically
+	padding: 0 calc(1.5 * var(--default-grid-baseline));
 	border-radius: var(--border-radius-pill);
 	background-color: var(--color-primary-element-light);
 	font-weight: bold;
@@ -329,15 +329,6 @@ export default {
 	&--outlined.active {
 		color: var(--color-main-background);
 		box-shadow: inset 0 0 0 2px;
-	}
-}
-
-// Make it pixel perfect aligned
-@supports (line-height: 1cap) {
-	.counter-bubble__counter {
-		// 1em is higher than one digit and makes it not perfectly vertically aligned
-		// 1cap = hight of a digit (T character)
-		--counter-bubble-line-height: 1cap;
 	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- ⚠️ On top of https://github.com/nextcloud-libraries/nextcloud-vue/pull/5863/files
  - See only the last commit
- Padding around looks to small
  - Increase padding to `1.5 * grid` (**applies only to large numbers**)
- Height is a bit small
  - Increases to 22px (~ 1cap + padding)
- Centering with `1cap` was not very well supported from https://github.com/nextcloud-libraries/nextcloud-vue/pull/5948 
  - Use `line-height` to expand height and center text instead of `1cap`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/d2c5e504-2f6a-42a1-a02c-22e618d3934d) | ![image](https://github.com/user-attachments/assets/287a4f0e-315f-4a7b-b388-bc7e6ea6845a)
![image](https://github.com/user-attachments/assets/8db0d1aa-c3c5-48f6-86a5-4db13606468a) | ![image](https://github.com/user-attachments/assets/6d0929a0-1d84-41a2-8166-b0d0db36905c)
![image](https://github.com/user-attachments/assets/36a2b1c0-8ef0-4289-a2fc-7ace259fcaf9) | ![image](https://github.com/user-attachments/assets/8b4eb5d2-1e40-44d4-9c7d-36e8996b4d2c)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
