### PR TITLE
fix(NcRichContenteditable): adjust to new design

### DIFF
--- a/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
+++ b/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
@@ -106,8 +106,10 @@ export default {
 <style lang="scss" scoped>
 .autocomplete-result {
 	display: flex;
-	height: var(--default-clickable-area);
-	padding: var(--default-grid-baseline) 0;
+	align-items: center;
+	gap: var(--default-grid-baseline);
+	line-height: 1.2;
+	--auto-complete-result-avatar-size: var(--default-clickable-area);
 
 	&__icon {
 		position: relative;
@@ -127,21 +129,22 @@ export default {
 	}
 
 	&__status {
+		--auto-complete-result-status-icon-size: clamp(14px, var(--auto-complete-result-avatar-size) * 0.4, 18px);
+		// Avatar Radius * (1 - 1 / sqrt(2)) - Status Icon Radius / 2
+		--auto-complete-result-status-icon-position: calc(var(--auto-complete-result-avatar-size) / 2 * (1 - 1 / sqrt(2)) - var(--auto-complete-result-status-icon-size) / 2);
 		box-sizing: border-box;
 		position: absolute;
-		right: -4px;
-		bottom: -4px;
-		min-width: 18px;
-		min-height: 18px;
-		width: 18px;
-		height: 18px;
+		right: var(--auto-complete-result-status-icon-position);
+		bottom: var(--auto-complete-result-status-icon-position);
+		height: var(--auto-complete-result-status-icon-size);
+		width: var(--auto-complete-result-status-icon-size);
 		border: 2px solid var(--color-main-background);
 		border-radius: 50%;
 		background-color: var(--color-main-background);
-		font-size: var(--default-font-size);
-		line-height: 15px;
+		font-size: calc(var(--auto-complete-result-status-icon-size) / 1.2);
+		line-height: 1.2;
 		background-repeat: no-repeat;
-		background-size: 16px;
+		background-size: var(--auto-complete-result-status-icon-size);
 		background-position: center;
 
 		&--icon {
@@ -156,7 +159,6 @@ export default {
 		flex-direction: column;
 		justify-content: center;
 		min-width: 0;
-		padding-left: calc(var(--default-grid-baseline) * 2);
 	}
 
 	&__title,

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -1155,27 +1155,34 @@ export default {
 .tribute-container {
 	z-index: 9000;
 	overflow: auto;
-	// Hide container root element while initialising
+	// Hide container root element while initializing
 	position: absolute;
 	left: -10000px;
 	// Space it out a bit from the text
 	margin: var(--default-grid-baseline) 0;
 	padding: var(--default-grid-baseline);
 	color: var(--color-text-maxcontrast);
-	border-radius: var(--border-radius);
+	border-radius: var(--border-radius-element, var(--border-radius));
 	background: var(--color-main-background);
 	box-shadow: 0 1px 5px var(--color-box-shadow);
 
+	&,
+	& * {
+		box-sizing: border-box;
+	}
+
+	ul {
+		display: flex;
+		flex-direction: column;
+		gap: var(--default-grid-baseline);
+	}
+
 	.tribute-container__item {
 		color: var(--color-text-maxcontrast);
-		border-radius: var(--border-radius);
-		padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
-		margin-bottom: var(--default-grid-baseline);
+		border-radius: var(--border-radius-small, var(--border-radius));
+		padding: var(--default-grid-baseline);
 		cursor: pointer;
-
-		&:last-child {
-			margin-bottom: 0;
-		}
+		min-height: var(--clickable-area-small, auto);
 
 		&:global(.highlight) {
 			color: var(--color-main-text);
@@ -1199,11 +1206,10 @@ export default {
 	max-width: 300px;
 	// Show maximum 4 entries and a half to show scroll
 	// Autocomplete height
-	// + 2 paddings around autocomplete
-	// + 2 paddings arouind tribute item
+	// + 2 paddings inside autocomplete
 	// + 1 padding gap
 	// And 1.5 paddings - container's padding without the last gap
-	max-height: calc((var(--default-clickable-area) + 5 * var(--default-grid-baseline)) * 4.5 - 1.5 * var(--default-grid-baseline));
+	max-height: calc((var(--default-clickable-area) + 3 * var(--default-grid-baseline)) * 4.5 - 1.5 * var(--default-grid-baseline));
 }
 
 .tribute-container-emoji,
@@ -1212,8 +1218,7 @@ export default {
 	max-width: 200px;
 	// Show maximum 5 entries and a half to show scroll
 	// Item height
-	// + 2 paddings around autocomplete
-	// + 2 paddings arouind tribute item
+	// + 2 paddings around tribute item
 	// + 1 padding gap
 	// And 1.5 paddings - container's padding without the last gap
 	max-height: calc((24px + 3 * var(--default-grid-baseline)) * 5.5 - 1.5 * var(--default-grid-baseline));
@@ -1223,10 +1228,6 @@ export default {
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-
-		&__emoji {
-			padding-right: calc(var(--default-grid-baseline) * 2);
-		}
 	}
 }
 
@@ -1246,7 +1247,7 @@ export default {
 			width: 20px;
 			height: 20px;
 			object-fit: contain;
-			padding-right: calc(var(--default-grid-baseline) * 2);
+			padding-right: var(--default-grid-baseline);
 			filter: var(--background-invert-if-dark);
 		}
 	}


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/5975

### 🚧 Tasks

- [x] Use new and correct border-radious variables with old values as a fallback
- [x] Adjust paddings to remove double paddings
  - Paddings adjustments also applies for 28+29 intentionally (previously there were double paddings)
- [x] Add `box-sizing: border-box` so it doesn't break if mounted to body
- [x] Change style of autocomplete using 1.2 line-height to fix cutting issue
  - Also applies for 28 + 29, but not a visible change

Note, it has some copy-paste from `NcAvatar` and `NcListItem`. We can look at reuse in a follow-up

### 🖼️ Screenshots

🏚️ Before 30 | 🏡 After 30
---|---
![image](https://github.com/user-attachments/assets/046f62d2-4440-425c-9579-1d54f7e08e81) | ![image](https://github.com/user-attachments/assets/262b2b19-9f44-4678-997b-1a0701cd098b)
![image](https://github.com/user-attachments/assets/c064db8a-4f93-44e9-80a0-e3531c97cd60) | ![image](https://github.com/user-attachments/assets/8f4818ee-9141-4dfa-af69-dc1dd5b2ebde)
![image](https://github.com/user-attachments/assets/11067bde-0509-4f84-87bd-bbccd61026e4) | ![image](https://github.com/user-attachments/assets/60b7e8e7-0709-4ecd-9c01-4c544648302d)

🏚️ Before 28 | 🏡 After 28
---|---
![image](https://github.com/user-attachments/assets/f6dcfc91-b228-4fe4-a9d4-cc257fd56aa5) | ![image](https://github.com/user-attachments/assets/a65bcdec-b898-43f2-99f1-5bba6737e8ed)
![image](https://github.com/user-attachments/assets/4e2f883c-7d4c-42d9-ab18-68ee56e91cb4) | ![image](https://github.com/user-attachments/assets/ef2f2309-4b6b-4840-b05a-a5e325a53646)
![image](https://github.com/user-attachments/assets/f9e320c6-a5d2-4ad1-a593-e187e7e49be4) | ![image](https://github.com/user-attachments/assets/7b31f4e5-34b8-4f47-9c20-6ee56098dfad)



### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
