### PR TITLE
[next] fix(NcListItem): correctly use NcCounterBubble after slot removal

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -114,9 +114,7 @@ Just nest the counter in a template within `<NcAppNavigationItem>` and add `#cou
 					<Folder :size="20" />
 				</template>
 				<template #counter>
-					<NcCounterBubble>
-						99+
-					</NcCounterBubble>
+					<NcCounterBubble :count="90" />
 				</template>
 			</NcAppNavigationItem>
 		</ul>
@@ -145,9 +143,7 @@ prevent the user from collapsing the items.
 					<Folder :size="20" />
 				</template>
 				<template #counter>
-					<NcCounterBubble>
-						99+
-					</NcCounterBubble>
+					<NcCounterBubble :count="90" />
 				</template>
 				<template #actions>
 					<NcActionButton @click="alert('Edit')">

--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -482,15 +482,14 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 								<slot name="details">{{ details }}</slot>
 							</div>
 							<!-- Counter and indicator -->
-							<div v-if="counterNumber || hasIndicator"
+							<div v-if="counterNumber !== undefined || hasIndicator"
 								v-show="showAdditionalElements"
 								class="list-item-details__extra">
-								<NcCounterBubble v-if="counterNumber"
+								<NcCounterBubble v-if="counterNumber !== undefined"
+									:count="counterNumber"
 									:active="isActive || active"
 									class="list-item-details__counter"
-									:type="counterType">
-									{{ counterNumber }}
-								</NcCounterBubble>
+									:type="counterType" />
 
 								<span v-if="hasIndicator" class="list-item-details__indicator">
 									<!-- @slot This slot is used for some indicator in form of icon -->


### PR DESCRIPTION
### ☑️ Resolves

- Regressions from https://github.com/nextcloud-libraries/nextcloud-vue/pull/5997

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
