### PR TITLE
fix(NcAvatar): orbital best-fit adaptive status icon 

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -500,7 +500,7 @@ export default {
 
 		avatarStyle() {
 			return {
-				'--size': this.size + 'px',
+				'--avatar-size': this.size + 'px',
 				lineHeight: this.showInitials ? (this.size + 'px') : 0,
 				fontSize: Math.round(this.size * 0.45) + 'px',
 			}
@@ -811,8 +811,8 @@ export default {
 .avatardiv {
 	position: relative;
 	display: inline-block;
-	width: var(--size);
-	height: var(--size);
+	width: var(--avatar-size);
+	height: var(--avatar-size);
 
 	&--unknown {
 		position: relative;
@@ -854,24 +854,24 @@ export default {
 		:deep() {
 			.button-vue,
 			.button-vue__icon {
-				height: var(--size);
-				min-height: var(--size);
-				width: var(--size) !important;
-				min-width: var(--size);
+				height: var(--avatar-size);
+				min-height: var(--avatar-size);
+				width: var(--avatar-size) !important;
+				min-width: var(--avatar-size);
 			}
 		}
 		& > :deep(.button-vue),
 		& > :deep(.action-item .button-vue) {
-			--button-radius: calc(var(--size) / 2);
+			--button-radius: calc(var(--avatar-size) / 2);
 		}
 	}
 
 	.avatardiv__initials-wrapper {
 		display: block;
-		height: var(--size);
-		width: var(--size);
+		height: var(--avatar-size);
+		width: var(--avatar-size);
 		background-color: var(--color-main-background);
-		border-radius: calc(var(--size) / 2);
+		border-radius: calc(var(--avatar-size) / 2);
 
 		.avatardiv__initials {
 			position: absolute;
@@ -893,8 +893,8 @@ export default {
 	}
 
 	.material-design-icon {
-		width: var(--size);
-		height: var(--size);
+		width: var(--avatar-size);
+		height: var(--avatar-size);
 	}
 
 	.avatardiv__user-status {
@@ -939,7 +939,7 @@ export default {
 
 .avatar-class-icon {
 	display: block;
-	border-radius: calc(var(--size) / 2);
+	border-radius: calc(var(--avatar-size) / 2);
 	background-color: var(--color-background-darker);
 	height: 100%;
 }

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -934,23 +934,33 @@ export default {
 	}
 
 	.avatardiv__user-status {
+		// Size of the status icon to make it:
+		// - 💫 Orbital: the status icon's center is positioned on the avatar circle
+		// - ⏹️ Best-fit: the status icon is as large as possible without exceeding the avatar box
+		// See PR for math explanation: PR #6004
+		--avatar-status-size-orbital: calc(var(--avatar-size) * (1 - 1 / sqrt(2)));
+		// Limit the status icon size to the status of a small clickable avatar
+		// Ideally avatars with a smaller should not be used with the status icon at all
+		--avatar-status-size-min: calc(var(--default-clickable-area) * (1 - 1 / sqrt(2)));
+		--avatar-status-size: max(var(--avatar-status-size-orbital), var(--avatar-status-size-min));
+		// Because the status icon size is limited, smaller avatar requires a position offset to keep the status icon orbital
+		--avatar-status-icon-position: min(0px, (var(--avatar-status-size-orbital) - var(--avatar-status-size)) / 2);
 		box-sizing: border-box;
 		position: absolute;
-		inset-inline-end: -4px;
-		bottom: -4px;
-		min-height: 14px;
-		min-width: 14px;
-		max-height: 18px;
-		max-width: 18px;
-		height: 40%;
-		width: 40%;
+		inset-inline-end: var(--avatar-status-icon-position);
+		inset-block-end: var(--avatar-status-icon-position);
+		height: var(--avatar-status-size);
+		width: var(--avatar-status-size);
 		line-height: 1;
-		font-size: clamp(var(--font-size-small, 13px), 85%, var(--default-font-size));
+		font-size: calc(var(--avatar-status-size) / 1.2);
 		background-color: var(--color-main-background);
 		background-repeat: no-repeat;
-		background-size: 16px;
+		background-size: var(--avatar-status-size);
 		background-position: center;
 		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 
 		.acli:hover & {
 			border-color: var(--color-background-hover);

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -41,44 +41,24 @@ export default {
 ### Avatar with preloaded status
 ```
 <template>
-<div class="grid">
-	<NcAvatar user="janedoe"
-		display-name="Jane Doe"
-		:size="44"
-		:preloaded-user-status="status.online">
-	</NcAvatar>
-	<NcAvatar user="janedoe"
-		display-name="Jane Doe"
-		:size="44"
-		:preloaded-user-status="status.away">
-	</NcAvatar>
-	<NcAvatar user="janedoe"
-		display-name="Jane Doe"
-		:size="44"
-		:preloaded-user-status="status.dnd">
-	</NcAvatar>
-	<NcAvatar user="janedoe"
-		display-name="Jane Doe"
-		:size="44"
-		:preloaded-user-status="status.custom">
-	</NcAvatar>
-	<NcAvatar user="janedoe"
-		display-name="Jane Doe"
-		:preloaded-user-status="status.online">
-	</NcAvatar>
-	<NcAvatar user="janedoe"
-		display-name="Jane Doe"
-		:preloaded-user-status="status.away">
-	</NcAvatar>
-	<NcAvatar user="janedoe"
-		display-name="Jane Doe"
-		:preloaded-user-status="status.dnd">
-	</NcAvatar>
-	<NcAvatar user="janedoe"
-		display-name="Jane Doe"
-		:preloaded-user-status="status.custom">
-	</NcAvatar>
-</div>
+	<div>
+		<NcAvatar user="janedoe"
+			display-name="Jane Doe"
+			:preloaded-user-status="status.online">
+		</NcAvatar>
+		<NcAvatar user="janedoe"
+			display-name="Jane Doe"
+			:preloaded-user-status="status.away">
+		</NcAvatar>
+		<NcAvatar user="janedoe"
+			display-name="Jane Doe"
+			:preloaded-user-status="status.dnd">
+		</NcAvatar>
+		<NcAvatar user="janedoe"
+			display-name="Jane Doe"
+			:preloaded-user-status="status.custom">
+		</NcAvatar>
+	</div>
 </template>
 
 <script>
@@ -111,16 +91,6 @@ export default {
 	},
 }
 </script>
-<style>
-	.grid {
-		width: fit-content;
-		display: grid;
-		justify-content: center;
-		align-items: center;
-		gap: 8px;
-		grid-template-columns: repeat(4, 1fr);
-	}
-</style>
 ```
 
 ### Avatar for non-users
@@ -148,6 +118,72 @@ export default {
 	margin: 15px 25px;
 }
 </style>
+```
+
+### Avatar size
+
+```vue
+<template>
+	<div>
+		<div v-for="size in [15, 24, 34, 44, 180]">
+			<span>
+				{{ size }}px
+			</span>
+			<NcAvatar user="alice-smith"
+				display-name="Alice Smith"
+				:size="size"
+				:preloaded-user-status="status.online" />
+			<NcAvatar user="bob-doe"
+				display-name="Bob Doe"
+				:size="size"
+				:preloaded-user-status="status.meeting" />
+		</div>
+		<div>
+			<div>
+				Custom: {{ customSize }}px
+			</div>
+			<NcAvatar user="alice-smith"
+				display-name="Alice Smith"
+				:size="customSize"
+				:preloaded-user-status="status.online" />
+			<NcAvatar user="bob-doe"
+				display-name="Bob Doe"
+				:size="customSize"
+				:preloaded-user-status="status.meeting" />
+		</div>
+		<div>
+			<input type="range" v-model="customSize" :min="15" :max="180" step="1" />
+		</div>
+	</div>
+</template>
+
+<script>
+import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+
+export default {
+	components: {
+		AccountMultiple,
+	},
+
+	data() {
+		return {
+			customSize: 20,
+			status: {
+				online: {
+					icon: '',
+					status: 'online',
+					message: 'Available',
+				},
+				meeting: {
+					icon: '📆',
+					status: 'online',
+					message: 'In a meeting',
+				},
+			},
+		}
+	},
+}
+</script>
 ```
 
 </docs>

--- a/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
+++ b/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
@@ -125,13 +125,14 @@ const activeSvg = computed(() => status.value && matchSvg[status.value])
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	min-width: 16px;
-	min-height: 16px;
-	max-width: 20px;
-	max-height: 20px;
 
 	&--invisible {
 		filter: var(--background-invert-if-dark);
+	}
+
+	:deep(svg) {
+		width: 100%;
+		height: 100%;
 	}
 }
 </style>


### PR DESCRIPTION
## Resolves

- Avatar has variable size
- The status icon also has a variable size (25% width)
- But the status icon still has a fixed position
- On different size avatar status has different position
  - On a large avatar - too far from the avatar
  - On a small avatar - outside of avatar box
  - On some sizes - inside, but not in a perfect position
- Use cases
  - Talk Desktop title bar (small avatar)
  - Auto-complete (small avatar)
  - Profile page (large avatar)
- Ref: https://github.com/nextcloud-libraries/nextcloud-vue/pull/5959
- Ref: https://github.com/nextcloud/spreed/pull/12956#pullrequestreview-2238732106

### Status icon size

This PR makes the status icon:
- - 💫 **Orbital**: the status icon's center is positioned on the avatar circle
- - ⏹️ **Best-fit**: the status icon is as large as possible without exceeding the avatar box

<img width="1376" height="804" alt="image" src="https://github.com/user-attachments/assets/b2b13e20-b747-4042-a4f5-224a69f75ce1" />

### Edge case: small avatar

The solution above doesn't work well on a very small avatar. It makes the 
- Status icon size is limited to fit `--clickable-area-small` avatar
- The position is moved to keep it orbital

<img width="1005" height="874" alt="image" src="https://github.com/user-attachments/assets/3c11971a-6d58-4deb-960c-dc630edf28a5" />

## 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="417" height="332" alt="image" src="https://github.com/user-attachments/assets/04192f2d-7437-4732-be15-c2e01f65e918" /> | <img width="415" height="329" alt="image" src="https://github.com/user-attachments/assets/6d7aab02-4ece-4ed3-884f-f82362e75898" />
![before](https://github.com/user-attachments/assets/e1cced71-9db4-424e-9d5d-94a12a78859a) | ![after](https://github.com/user-attachments/assets/a19b6bc8-2381-4c99-91f0-2e26909235db)
## 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
