### PR TITLE
feat(NcDialogButton): Allow to return `false` from callback to keep dialog open

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -194,6 +194,10 @@ msgstr ""
 msgid "Load more \"{options}\""
 msgstr ""
 
+#. TRANSLATORS: The button is in a loading state
+msgid "Loading …"
+msgstr ""
+
 #. TRANSLATORS: A color name for RGB(45, 115, 190)
 msgid "Mariner"
 msgstr ""

--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -609,10 +609,6 @@ export default {
 		}
 	},
 
-	mounted() {
-		this.actionsBoundariesElement = document.querySelector('#content-vue') || undefined
-	},
-
 	data() {
 		return {
 			editingValue: '',
@@ -664,6 +660,10 @@ export default {
 		open(newVal) {
 			this.opened = newVal
 		},
+	},
+
+	mounted() {
+		this.actionsBoundariesElement = document.querySelector('#content-vue') || undefined
 	},
 
 	created() {

--- a/src/components/NcDialogButton/NcDialogButton.vue
+++ b/src/components/NcDialogButton/NcDialogButton.vue
@@ -17,98 +17,107 @@ Dialog button component used by NcDialog in the actions slot to display the butt
 		<template #icon>
 			<!-- @slot Allow to set a custom icon for the button -->
 			<slot name="icon">
-				<NcIconSvgWrapper v-if="icon !== undefined" :svg="icon" />
+				<!-- The loading state is an information that must be accessible -->
+				<NcLoadingIcon v-if="isLoading" :name="t('Loading …') /* TRANSLATORS: The button is in a loading state*/" />
+				<NcIconSvgWrapper v-else-if="icon !== undefined" :svg="icon" />
 			</slot>
 		</template>
 	</NcButton>
 </template>
 
-<script>
-import { defineComponent } from 'vue'
+<script setup>
+import { ref } from 'vue'
 import NcButton from '../NcButton/index.js'
 import NcIconSvgWrapper from '../NcIconSvgWrapper/index.js'
+import NcLoadingIcon from '../NcLoadingIcon/index.js'
+import { t } from '../../l10n.js'
 
-export default defineComponent({
-	name: 'NcDialogButton',
-
-	components: {
-		NcButton,
-		NcIconSvgWrapper,
+const props = defineProps({
+	/**
+	 * The function that will be called when the button is pressed.
+	 * If the function returns `false` the click is ignored and the dialog will not be closed.
+	 * @type {() => unknown|false|Promise<unknown|false>}
+	 */
+	callback: {
+		type: Function,
+		required: false,
+		default: () => {},
 	},
 
-	props: {
-		/**
-		 * The function that will be called when the button is pressed
-		 * @type {() => void}
-		 */
-		callback: {
-			type: Function,
-			required: false,
-			default: () => {},
-		},
+	/**
+	 * The label of the button
+	 */
+	label: {
+		type: String,
+		required: true,
+	},
 
-		/**
-		 * The label of the button
-		 */
-		label: {
-			type: String,
-			required: true,
-		},
+	/**
+	 * Optional inline SVG icon for the button
+	 */
+	icon: {
+		type: String,
+		required: false,
+		default: undefined,
+	},
 
-		/**
-		 * Optional inline SVG icon for the button
-		 */
-		icon: {
-			type: String,
-			required: false,
-			default: undefined,
-		},
+	/**
+	 * The button type, see NcButton
+	 * @type {'primary'|'secondary'|'error'|'warning'|'success'}
+	 */
+	type: {
+		type: String,
+		required: false,
+		default: 'secondary',
+		validator: (type) => typeof type === 'string' && ['primary', 'secondary', 'tertiary', 'error', 'warning', 'success'].includes(type),
+	},
 
-		/**
-		 * The button type, see NcButton
-		 * @type {'primary'|'secondary'|'error'|'warning'|'success'}
-		 */
-		type: {
-			type: String,
-			required: false,
-			default: 'secondary',
-			validator: (type) => typeof type === 'string' && ['primary', 'secondary', 'tertiary', 'error', 'warning', 'success'].includes(type),
-		},
-
-		/**
-		 * See `nativeType` of `NcButton`
-		 */
-		nativeType: {
-			type: String,
-			required: false,
-			default: 'button',
-			validator(value) {
-				return ['submit', 'reset', 'button'].includes(value)
-			},
-		},
-
-		/**
-		 * If the button should be shown as disabled
-		 */
-		disabled: {
-			type: Boolean,
-			default: false,
+	/**
+	 * See `nativeType` of `NcButton`
+	 */
+	nativeType: {
+		type: String,
+		required: false,
+		default: 'button',
+		validator(value) {
+			return ['submit', 'reset', 'button'].includes(value)
 		},
 	},
 
-	emits: ['click'],
-
-	setup(props, { emit }) {
-		/**
-		 * Handle clicking the button
-		 * @param {MouseEvent} e The click event
-		 */
-		const handleClick = (e) => {
-			props.callback?.()
-			emit('click', e)
-		}
-
-		return { handleClick }
+	/**
+	 * If the button should be shown as disabled
+	 */
+	disabled: {
+		type: Boolean,
+		default: false,
 	},
 })
+
+const emit = defineEmits(['click'])
+
+const isLoading = ref(false)
+
+/**
+ * Handle clicking the button
+ * @param {MouseEvent} e The click event
+ */
+const handleClick = async (e) => {
+	// Do not re-emit while loading
+	if (isLoading.value) {
+		return
+	}
+
+	isLoading.value = true
+	try {
+		const result = await props.callback?.()
+		if (result !== false) {
+			/**
+			 * The click event (`MouseEvent`) and the value returned by the callback
+			 */
+			emit('click', e, result)
+		}
+	} finally {
+		isLoading.value = false
+	}
+}
 </script>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -65,6 +65,10 @@ module.exports = async () => {
 			return `import ${name} from '@nextcloud/vue/dist/Components/${name}.js'`
 		},
 
+		compilerConfig: {
+			transforms: { asyncAwait: false },
+		},
+
 		sections: [
 			{
 				name: 'Introduction',


### PR DESCRIPTION
### ☑️ Resolves

If the callback returns `false` then the click event will not be forwarded. This could be useful if the click triggers a validation that fails and the user should be able to fix the issue.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
