### PR TITLE
fix(NcAppNavigation): keep border only on mobile

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -342,7 +342,6 @@ export default {
 	background-color: var(--color-main-background-blur, var(--color-main-background));
 	-webkit-backdrop-filter: var(--filter-background-blur, none);
 	backdrop-filter: var(--filter-background-blur, none);
-	border-inline-end: 1px solid var(--color-border);
 
 	&--close {
 		margin-left: calc(-1 * min($navigation-width, var(--app-navigation-max-width)));
@@ -389,10 +388,18 @@ export default {
 	}
 }
 
+// Add extra border for high contrast mode
+[data-themes*="highcontrast"] {
+	.app-navigation {
+		border-inline-end: 1px solid var(--color-border);
+	}
+}
+
 // When on mobile, we make the navigation slide over the NcAppContent
 @media only screen and (max-width: $breakpoint-mobile) {
 	.app-navigation {
 		position: absolute;
+		border-inline-end: 1px solid var(--color-border);
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

- From https://github.com/nextcloud-libraries/nextcloud-vue/pull/5953
- Border right was supposed to be used only on mobile, when navigation overlaps content, but it always presents

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/75cf60b8-d003-4a3c-b12b-35ea5017f004) | ![image](https://github.com/user-attachments/assets/daaf625a-8b6c-459e-ad6b-e08b6781fe6b)
![image](https://github.com/user-attachments/assets/2040e9e2-821f-41e6-824d-ad4476d8babc) | ![image](https://github.com/user-attachments/assets/cada76e1-e22e-4513-865c-f8643df6a175)


### 🚧 Tasks

- [x] Add border only on mobile and high-contrast, remove from desktop

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
