### PR TITLE
fix(NcRichText): discard reference widgets on text update

### DIFF
--- a/src/components/NcRichText/NcReferenceList.vue
+++ b/src/components/NcRichText/NcReferenceList.vue
@@ -99,11 +99,13 @@ export default {
 		fetch() {
 			this.loading = true
 			if (this.referenceData) {
+				this.references = null
 				this.loading = false
 				return
 			}
 
 			if (!(new RegExp(URL_PATTERN).exec(this.text))) {
+				this.references = null
 				this.loading = false
 				return
 			}


### PR DESCRIPTION
### ☑️ Resolves

- Fix reference widgets recalculating in case of rich text change

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/69b26645-a3b8-4bcf-bd9c-bf76411d8de8)

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/424f4534-8914-43de-b914-7772dc26fadf) | ![image](https://github.com/user-attachments/assets/163858c8-95a7-4adf-bd9a-0ee525d98e11)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
