### PR TITLE
fix(NcCheckBoxRadioSwitch): do not toggle on a click on a link inside

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -575,8 +575,8 @@ export default {
 		t,
 		n,
 
-		onToggle() {
-			if (this.disabled) {
+		onToggle(event) {
+			if (this.disabled || event.target.tagName.toLowerCase() === 'a') {
 				return
 			}
 


### PR DESCRIPTION
… a link

### ☑️ Resolves

In rich text > tasks list, check boxes can have links

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![link1](https://github.com/user-attachments/assets/dcdcae9f-44b5-4ee2-8317-d93587bbe99d)| ![link-2](https://github.com/user-attachments/assets/4840c1f1-99f3-4e08-856c-dec46b90036f)



### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
