### PR TITLE
fix(useHotKey): respect press of MacOS Cmd key as Ctrl key

### DIFF
--- a/docs/composables/useHotKey.md
+++ b/docs/composables/useHotKey.md
@@ -21,7 +21,7 @@ where:
   - `push`: whether the event should be triggered on both keydown and keyup
   - `prevent`: prevents the default action of the event
   - `stop`: prevents propagation of the event in the capturing and bubbling phases
-  - `ctrl`: whether the Ctrl key should be pressed
+  - `ctrl`: whether the Ctrl key should be pressed (Cmd key on MacOS)
   - `alt`: whether the Alt key should be pressed
   - `shift`: whether the Shift key should be pressed
 - `stopCallback`: a callback to stop listening to the event

--- a/src/composables/useHotKey/index.js
+++ b/src/composables/useHotKey/index.js
@@ -5,6 +5,7 @@
 import { onKeyStroke } from '@vueuse/core'
 
 const disableKeyboardShortcuts = window.OCP?.Accessibility?.disableKeyboardShortcuts?.()
+const isMac = /mac|ipad|iphone|darwin/i.test(navigator.userAgent)
 
 /**
  * Check if event target (active element) is editable (allows input from keyboard) or NcModal is open
@@ -26,7 +27,8 @@ function shouldIgnoreEvent(event) {
 }
 
 const eventHandler = (callback, options) => (event) => {
-	if (!!options.ctrl !== event.ctrlKey) {
+	const ctrlKeyPressed = isMac ? event.metaKey : event.ctrlKey
+	if (ctrlKeyPressed !== Boolean(options.ctrl)) {
 		// Ctrl is required and not pressed, or the opposite
 		return
 	} else if (!!options.alt !== event.altKey) {


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/spreed/issues/13155
- Regression from #5899

### 🖼️ Screenshots

No visual changes

### 🚧 Tasks

- [x] Test on MacOS: Should allow to copy text with Cmd+C, if hotkey for 'C' is assigned

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
