### PR TITLE
fix(NcHeaderMenu): Remove padding from popover menu

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -341,6 +341,11 @@ $externalMargin: 8px;
 		// header is filled with primary or image background
 		filter: none !important;
 		color: var(--color-background-plain-text, var(--color-primary-text)) !important;
+
+		&:focus-visible {
+			outline: none !important;
+			box-shadow: none !important;
+		}
 	}
 
 	&--opened &__trigger,
@@ -350,11 +355,6 @@ $externalMargin: 8px;
 		opacity: 1;
 	}
 
-	#{&}__trigger:focus-visible {
-		outline: none !important;
-		box-shadow: none !important;
-	}
-
 	&__wrapper {
 		position: fixed;
 		z-index: 2000;
@@ -362,7 +362,6 @@ $externalMargin: 8px;
 		inset-inline-end: 0;
 		box-sizing: border-box;
 		margin: 0 $externalMargin;
-		padding: 8px;
 		border-radius: 0 0 var(--border-radius) var(--border-radius);
 		border-radius: var(--border-radius-large);
 		background-color: var(--color-main-background);


### PR DESCRIPTION
* From @jancborchardt comment (3rd one): https://github.com/nextcloud/server/pull/47568#pullrequestreview-2268099943

### ☑️ Resolves
There should be no padding within the popover menu. The popover container is not style-able (at least not without hacking the (not exposed-)CSS classes), so users can not remove the padding themself.

The padding is a problem if the content is scroll-able, because the scrollbar should be on the very end of the container and not floating around.

### 🖼️ Screen recording

#### 🏚️ Before

[Bildschirmaufnahme_20240830_002829.webm](https://github.com/user-attachments/assets/65f03a35-5c8e-46df-b818-f84c86888d4b)

#### 🏡 After

[Bildschirmaufnahme_20240830_002718.webm](https://github.com/user-attachments/assets/356a6b8f-8391-4244-a87d-a0b8017eb6f5)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
