### PR TITLE
NcListItem: make the max width of the NcListItem in oneline mode apply only to the content name

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -959,15 +959,15 @@ export default {
 			justify-content: start;
 			gap: 12px;
 			min-width: 0;
-			max-width: 300px;
 		}
 		.list-item-content__details {
 			flex-direction: row;
-			align-items: unset;
+			align-items: center;
 			justify-content: end;
 		}
 		.list-item-content__name {
 			align-self: center;
+			max-width: 300px;
 		}
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/mail/issues/10086

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot from 2024-09-02 16-30-31](https://github.com/user-attachments/assets/9f817ab8-b47e-48b6-946c-483648710b8f) | ![Screenshot from 2024-09-02 16-31-48](https://github.com/user-attachments/assets/ab78114b-499d-4330-b997-5d60ebeb4805)

