### PR TITLE
fix(NcHeaderMenu): Ensure trigger button is has same width as wrapper

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -334,7 +334,7 @@ $externalMargin: 8px;
 	height: var(--header-height);
 
 	#{&}__trigger {
-		width: 100% !important;
+		--button-size: var(--header-height) !important;
 		height: var(--header-height);
 		opacity: .85;
 
@@ -397,6 +397,10 @@ $externalMargin: 8px;
 @media only screen and (max-width: $breakpoint-small-mobile) {
 	.header-menu {
 		width: var(--default-clickable-area);
+
+		#{&}__trigger {
+			--button-size: var(--default-clickable-area) !important;
+		}
 	}
 }
 </style>


### PR DESCRIPTION
* First step for https://github.com/nextcloud/server/issues/46997

### ☑️ Resolves

Make sure the header button is correctly resized on small screen.
Before only the outer container was resized but the inner button was larger than the container -> scroll bars were shown.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
