### PR TITLE
fix(NcCheckboxRadioSwitch): switch may always have checked-like background

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -217,6 +217,7 @@ export default {
 	&__icon > * {
 		width: var(--icon-size);
 		height: var(--icon-size);
+		color: var(--color-primary-element);
 	}
 
 	&--button-variant {
@@ -231,12 +232,6 @@ export default {
 
 	&--has-text {
 		padding-right: $icon-margin;
-	}
-
-	&:not(&--button-variant) {
-		.checkbox-content__icon > * {
-			color: var(--color-primary-element);
-		}
 	}
 
 	&, * {


### PR DESCRIPTION
### ☑️ Resolves

- Fix issues caused by wrong stylesheet import order for NcCheckboxRadioSwitch

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/db84878d-e87c-4370-8197-841ad190e3c3) | ![image](https://github.com/user-attachments/assets/d506574e-50f0-4d16-ac39-aaaeb3e5d6fe)
![image](https://github.com/user-attachments/assets/fda91378-698c-423e-9d02-e2d06779e93e) | ![image](https://github.com/user-attachments/assets/1d90eb52-0088-448c-a572-eff41f0b1d91)
![image](https://github.com/user-attachments/assets/c4d905d7-b56d-4caa-b346-d5ade24b0260) | ![image](https://github.com/user-attachments/assets/90ef870d-3c3f-46c8-9f70-6a2e169f711b)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
Signed-off-by: Antreesy <antreesy.web@gmail.com>