### PR TITLE
fix(NcRichText): debounce the update of widget visibility

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -34,6 +34,7 @@
 	</div>
 </template>
 <script>
+import debounce from 'debounce'
 import { useElementSize, useIntersectionObserver } from '@vueuse/core'
 import { nextTick, ref } from 'vue'
 import { RouterLink } from 'vue-router'
@@ -71,10 +72,13 @@ export default {
 		// This is the widget root node
 		const widgetRoot = ref()
 		const { width } = useElementSize(widgetRoot)
+		const debounceUpdateVisible = debounce((value) => {
+			isVisible.value = value
+		}, 100)
 
 		useIntersectionObserver(widgetRoot, ([entry]) => {
 			nextTick(() => {
-				isVisible.value = entry.isIntersecting
+				debounceUpdateVisible(entry.isIntersecting)
 			})
 		})
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/spreed/issues/13237
- IntersectionObserver triggered if any pixel of observed element appears in viewport for a moment
- with debouncing the update, it won't be triggered during programmatic smooth scroll (less than 100ms in viewport with this commit)
- is 100 ms enough?


### 🖼️ Screenshots

🏚️ Before

https://github.com/user-attachments/assets/230c76fc-fa7c-4878-9f1a-5dd17ed507c9

🏡 After

https://github.com/user-attachments/assets/b6ac738a-b57c-426b-9c5a-37ae0aa46cfe


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
