### PR TITLE
[NcRichText] Add style to mount point for custom picker and custom widget elements

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
@@ -26,6 +26,7 @@
 		<div v-else-if="mode === MODES.customElement"
 			class="custom-element-wrapper">
 			<NcCustomPickerElement :provider="selectedProvider"
+				class="custom-element"
 				@submit="submitLink"
 				@cancel="cancelCustomElement" />
 		</div>
@@ -180,6 +181,11 @@ export default {
 		display: flex;
 		overflow-y: auto;
 		width: 100%;
+		.custom-element {
+			display: flex;
+			overflow-y: auto;
+			width: 100%;
+		}
 	}
 }
 </style>

--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -200,6 +200,7 @@ export default {
 
 			// create a separate element so we can rerender on the ref again
 			const widget = document.createElement('div')
+			widget.style = 'width: 100%;'
 			this.$refs.customWidget.appendChild(widget)
 			this.$nextTick(() => {
 				// Waiting for the ref to become available


### PR DESCRIPTION
Mounting in Vue 3 does not replace the mount point but sets its innerHTML. So the mount point needs to be styled to take all the space in its container.

This does not affect custom elements mounted with Vue 2 because the mount point is replaced so it disappears.
It will only fix custom elements mounted with Vue 3.

This can be forward-ported to next.