### PR TITLE
fix(NcListItem): change condition to display the counter number 

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -482,10 +482,10 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 								<slot name="details">{{ details }}</slot>
 							</div>
 							<!-- Counter and indicator -->
-							<div v-if="counterNumber !== undefined || hasIndicator"
+							<div v-if="counterNumber !== 0 || hasIndicator"
 								v-show="showAdditionalElements"
 								class="list-item-details__extra">
-								<NcCounterBubble v-if="counterNumber !== undefined"
+								<NcCounterBubble v-if="counterNumber !== 0"
 									:count="counterNumber"
 									:active="isActive || active"
 									class="list-item-details__counter"


### PR DESCRIPTION
The previous condition was always showing the counter number because the `counter-number` prop has `0` as default value.

This can be seen in a few examples in https://next--nextcloud-vue-components.netlify.app/#/Components/NcListItems?id=nclistitem

![image](https://github.com/user-attachments/assets/89adfe35-fe88-4f5e-8a34-ebdcff06e2c2)

``` vue
<NcListItem compact
	name="Name of the element">
	<template #icon>
		<IconNoteText :size="20" />
	</template>
</NcListItem>
```