### PR TITLE
fix(NcRichText): show links title for desktop client

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -377,6 +377,10 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+		showLinkTooltip: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	emits: ['interact:todo'],
 
@@ -500,6 +504,10 @@ export default {
 											to: route,
 										},
 									}, children)
+								}
+
+								if (this.showLinkTooltip) {
+									attrs.attrs.title = attrs.attrs.href
 								}
 							}
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/talk-desktop/issues/320

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
