### PR TITLE
fix(reference-picker): allow closing modal dialog on NcReferencePicker

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
@@ -6,7 +6,7 @@
 <template>
 	<NcModal v-if="show"
 		:size="modalSize"
-		:can-close="false"
+		:can-close="true"
 		class="reference-picker-modal"
 		@close="onCancel">
 		<div ref="modal_content"


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/4328

Fix possibility to close dialog via `Esc` if focus stays on "close" button

### 🖼️ Screenshots

🏚️ Before

![Peek 2024-10-10 12-51](https://github.com/user-attachments/assets/2d6e75c8-bfd2-41d4-885d-d313978ec9c6)

🏡 After

![Peek 2024-10-10 12-49](https://github.com/user-attachments/assets/8cd2b459-8ac7-4f8c-9c42-d1a7dcf7fa59)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
