### PR TITLE
fix(NcAppNavigation): RTL support

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -344,7 +344,7 @@ export default {
 	backdrop-filter: var(--filter-background-blur, none);
 
 	&--close {
-		margin-left: calc(-1 * min($navigation-width, var(--app-navigation-max-width)));
+		margin-inline-start: calc(-1 * min($navigation-width, var(--app-navigation-max-width)));
 	}
 
 	&__search {

--- a/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
+++ b/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
@@ -71,8 +71,8 @@ export default {
 .app-navigation-toggle-wrapper {
 	position: absolute;
 	top: var(--app-navigation-padding);
-	right: calc(0px - var(--app-navigation-padding));
-	margin-right: calc(-1 * var(--default-clickable-area));
+	inset-inline-end: calc(0px - var(--app-navigation-padding));
+	margin-inline-end: calc(-1 * var(--default-clickable-area));
 }
 
 button.app-navigation-toggle {


### PR DESCRIPTION
### ☑️ Resolves

- part of https://github.com/nextcloud/mail/issues/10227

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="366" alt="image" src="https://github.com/user-attachments/assets/bf6ec118-b20e-427f-85e8-30918377241c">|<img width="403" alt="image" src="https://github.com/user-attachments/assets/dc1ade50-bb0b-482a-ab6b-e8525b36c83a">
<img width="345" alt="image" src="https://github.com/user-attachments/assets/bf249585-8684-402b-9999-38d787971564"> | <img width="326" alt="image" src="https://github.com/user-attachments/assets/a38b06ff-7606-490f-ad30-a3d8653da862">
### 🚧 reproduction 

1. Change nextcloud to an Rtl language (arabic here) 
2. the toggle disappears 
3. the navigation doesn't disappear once the toggle pressed  


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
