### PR TITLE
[next] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9245,9 +9245,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12624,10 +12624,11 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/http-proxy": "^1.17.8",


### PR DESCRIPTION
# Audit report

This audit fix resolves 34 of the total 37 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [anymatch](#user-content-anymatch)
* [bonjour](#user-content-bonjour)
* [braces](#user-content-braces)
* [chokidar](#user-content-chokidar)
* [css-loader](#user-content-css-loader)
* [dns-packet](#user-content-dns-packet)
* [elliptic](#user-content-elliptic)
* [http-proxy-middleware](#user-content-http-proxy-middleware)
* [icss-utils](#user-content-icss-utils)
* [ip](#user-content-ip)
* [markdown-to-jsx](#user-content-markdown-to-jsx)
* [micromatch](#user-content-micromatch)
* [multicast-dns](#user-content-multicast-dns)
* [node-forge](#user-content-node-forge)
* [node-gettext](#user-content-node-gettext)
* [postcss](#user-content-postcss)
* [postcss-modules-extract-imports](#user-content-postcss-modules-extract-imports)
* [postcss-modules-local-by-default](#user-content-postcss-modules-local-by-default)
* [postcss-modules-scope](#user-content-postcss-modules-scope)
* [postcss-modules-values](#user-content-postcss-modules-values)
* [react-styleguidist](#user-content-react-styleguidist)
* [readdirp](#user-content-readdirp)
* [selfsigned](#user-content-selfsigned)
* [vue-inbrowser-compiler](#user-content-vue-inbrowser-compiler)
* [vue-inbrowser-compiler-demi](#user-content-vue-inbrowser-compiler-demi)
* [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* [vue-inbrowser-prismjs-highlighter](#user-content-vue-inbrowser-prismjs-highlighter)
* [vue-styleguidist](#user-content-vue-styleguidist)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vue-tsc](#user-content-vue-tsc)
* [webpack](#user-content-webpack)
* [webpack-dev-middleware](#user-content-webpack-dev-middleware)
* [webpack-dev-server](#user-content-webpack-dev-server)
## Fixed vulnerabilities

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`

### anymatch <a href="#user-content-anymatch" id="anymatch">#</a>
* Caused by vulnerable dependency:
  * [micromatch](#user-content-micromatch)
* Affected versions: 1.2.0 - 2.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/anymatch`

### bonjour <a href="#user-content-bonjour" id="bonjour">#</a>
* Caused by vulnerable dependency:
  * [multicast-dns](#user-content-multicast-dns)
* Affected versions: >=3.3.1
* Package usage:
  * `node_modules/bonjour`

### braces <a href="#user-content-braces" id="braces">#</a>
* Uncontrolled resource consumption in braces
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-grv7-fg5c-xmjg](https://github.com/advisories/GHSA-grv7-fg5c-xmjg)
* Affected versions: <3.0.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/braces`

### chokidar <a href="#user-content-chokidar" id="chokidar">#</a>
* Caused by vulnerable dependency:
  * [anymatch](#user-content-anymatch)
  * [braces](#user-content-braces)
  * [readdirp](#user-content-readdirp)
* Affected versions: 1.3.0 - 2.1.8
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/chokidar`

### css-loader <a href="#user-content-css-loader" id="css-loader">#</a>
* Caused by vulnerable dependency:
  * [icss-utils](#user-content-icss-utils)
  * [postcss](#user-content-postcss)
  * [postcss-modules-extract-imports](#user-content-postcss-modules-extract-imports)
  * [postcss-modules-local-by-default](#user-content-postcss-modules-local-by-default)
  * [postcss-modules-scope](#user-content-postcss-modules-scope)
  * [postcss-modules-values](#user-content-postcss-modules-values)
* Affected versions: 0.15.0 - 4.3.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/css-loader`

### dns-packet <a href="#user-content-dns-packet" id="dns-packet">#</a>
* Caused by vulnerable dependency:
  * [ip](#user-content-ip)
* Affected versions: <=5.2.4
* Package usage:
  * `node_modules/bonjour/node_modules/dns-packet`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Valid ECDSA signatures erroneously rejected in Elliptic
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-fc9h-whq2-v747](https://github.com/advisories/GHSA-fc9h-whq2-v747)
* Affected versions: <=6.5.7
* Package usage:
  * `node_modules/elliptic`

### http-proxy-middleware <a href="#user-content-http-proxy-middleware" id="http-proxy-middleware">#</a>
* Denial of service in http-proxy-middleware
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-c7qv-q95q-8v27](https://github.com/advisories/GHSA-c7qv-q95q-8v27)
* Affected versions: <=2.0.7-beta.1
* Package usage:
  * `node_modules/http-proxy-middleware`
  * `node_modules/vue-styleguidist/node_modules/http-proxy-middleware`

### icss-utils <a href="#user-content-icss-utils" id="icss-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=4.1.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/icss-utils`

### ip <a href="#user-content-ip" id="ip">#</a>
* ip SSRF improper categorization in isPublic
* Severity: **high** (CVSS 8.1)
* Reference: [https://github.com/advisories/GHSA-2p57-rm9w-gvfp](https://github.com/advisories/GHSA-2p57-rm9w-gvfp)
* Affected versions: *
* Package usage:
  * `node_modules/ip`

### markdown-to-jsx <a href="#user-content-markdown-to-jsx" id="markdown-to-jsx">#</a>
* Cross site scripting in markdown-to-jsx
* Severity: **moderate** (CVSS 6.1)
* Reference: [https://github.com/advisories/GHSA-4wx3-54gh-9fr9](https://github.com/advisories/GHSA-4wx3-54gh-9fr9)
* Affected versions: <7.4.0
* Package usage:
  * `node_modules/markdown-to-jsx`

### micromatch <a href="#user-content-micromatch" id="micromatch">#</a>
* Regular Expression Denial of Service (ReDoS) in micromatch
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-952p-6rrq-rcjv](https://github.com/advisories/GHSA-952p-6rrq-rcjv)
* Affected versions: <=4.0.7
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/micromatch`

### multicast-dns <a href="#user-content-multicast-dns" id="multicast-dns">#</a>
* Caused by vulnerable dependency:
  * [dns-packet](#user-content-dns-packet)
* Affected versions: 6.0.0 - 7.2.2
* Package usage:
  * `node_modules/bonjour/node_modules/multicast-dns`

### node-forge <a href="#user-content-node-forge" id="node-forge">#</a>
* Prototype Pollution in node-forge debug API.
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-5rrq-pxf6-6jx5](https://github.com/advisories/GHSA-5rrq-pxf6-6jx5)
* Affected versions: <=1.2.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/node-forge`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **moderate** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss`

### postcss-modules-extract-imports <a href="#user-content-postcss-modules-extract-imports" id="postcss-modules-extract-imports">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=2.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-extract-imports`

### postcss-modules-local-by-default <a href="#user-content-postcss-modules-local-by-default" id="postcss-modules-local-by-default">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=3.0.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-local-by-default`

### postcss-modules-scope <a href="#user-content-postcss-modules-scope" id="postcss-modules-scope">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=2.2.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-scope`

### postcss-modules-values <a href="#user-content-postcss-modules-values" id="postcss-modules-values">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=3.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-values`

### react-styleguidist <a href="#user-content-react-styleguidist" id="react-styleguidist">#</a>
* Caused by vulnerable dependency:
  * [markdown-to-jsx](#user-content-markdown-to-jsx)
  * [webpack-dev-server](#user-content-webpack-dev-server)
* Affected versions: >=5.0.0-beta.9
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/react-styleguidist`

### readdirp <a href="#user-content-readdirp" id="readdirp">#</a>
* Caused by vulnerable dependency:
  * [micromatch](#user-content-micromatch)
* Affected versions: 2.2.0 - 2.2.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/readdirp`

### selfsigned <a href="#user-content-selfsigned" id="selfsigned">#</a>
* Caused by vulnerable dependency:
  * [node-forge](#user-content-node-forge)
* Affected versions: 1.1.1 - 1.10.14
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/selfsigned`

### vue-inbrowser-compiler <a href="#user-content-vue-inbrowser-compiler" id="vue-inbrowser-compiler">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler`

### vue-inbrowser-compiler-demi <a href="#user-content-vue-inbrowser-compiler-demi" id="vue-inbrowser-compiler-demi">#</a>
* Caused by vulnerable dependency:
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler-demi`

### vue-inbrowser-compiler-utils <a href="#user-content-vue-inbrowser-compiler-utils" id="vue-inbrowser-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-demi](#user-content-vue-inbrowser-compiler-demi)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler-utils`

### vue-inbrowser-prismjs-highlighter <a href="#user-content-vue-inbrowser-prismjs-highlighter" id="vue-inbrowser-prismjs-highlighter">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* Affected versions: *
* Package usage:
  * `node_modules/vue-inbrowser-prismjs-highlighter`

### vue-styleguidist <a href="#user-content-vue-styleguidist" id="vue-styleguidist">#</a>
* Caused by vulnerable dependency:
  * [css-loader](#user-content-css-loader)
  * [react-styleguidist](#user-content-react-styleguidist)
  * [vue-inbrowser-compiler](#user-content-vue-inbrowser-compiler)
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
  * [vue-inbrowser-prismjs-highlighter](#user-content-vue-inbrowser-prismjs-highlighter)
  * [vue-template-compiler](#user-content-vue-template-compiler)
  * [webpack-dev-server](#user-content-webpack-dev-server)
* Affected versions: *
* Package usage:
  * `node_modules/vue-styleguidist`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`

### webpack <a href="#user-content-webpack" id="webpack">#</a>
* Webpack's AutoPublicPathRuntimeModule has a DOM Clobbering Gadget that leads to XSS
* Severity: **moderate** (CVSS 6.4)
* Reference: [https://github.com/advisories/GHSA-4vvj-4cpr-p986](https://github.com/advisories/GHSA-4vvj-4cpr-p986)
* Affected versions: 5.0.0-alpha.0 - 5.93.0
* Package usage:
  * `node_modules/webpack`

### webpack-dev-middleware <a href="#user-content-webpack-dev-middleware" id="webpack-dev-middleware">#</a>
* Path traversal in webpack-dev-middleware
* Severity: **high** (CVSS 7.4)
* Reference: [https://github.com/advisories/GHSA-wr3j-pwj9-hqq6](https://github.com/advisories/GHSA-wr3j-pwj9-hqq6)
* Affected versions: <=5.3.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/webpack-dev-middleware`

### webpack-dev-server <a href="#user-content-webpack-dev-server" id="webpack-dev-server">#</a>
* Caused by vulnerable dependency:
  * [bonjour](#user-content-bonjour)
  * [chokidar](#user-content-chokidar)
  * [http-proxy-middleware](#user-content-http-proxy-middleware)
  * [ip](#user-content-ip)
  * [selfsigned](#user-content-selfsigned)
  * [webpack-dev-middleware](#user-content-webpack-dev-middleware)
* Affected versions: <=4.7.4
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/webpack-dev-server`