### PR TITLE
feat: forward compatibility with v9 on `v-model` props/events

### DIFF
--- a/src/components/NcActionCheckbox/NcActionCheckbox.vue
+++ b/src/components/NcActionCheckbox/NcActionCheckbox.vue
@@ -10,8 +10,8 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 <template>
 	<NcActions>
 		<NcActionCheckbox @change="alert('(un)checked !')">First choice</NcActionCheckbox>
-		<NcActionCheckbox value="second" v-model="checkboxValue" @change="alert('(un)checked !')">Second choice (v-model)</NcActionCheckbox>
-		<NcActionCheckbox :checked="true" @change="alert('(un)checked !')">Third choice (checked)</NcActionCheckbox>
+		<NcActionCheckbox v-model="checkboxValue" value="second" @change="alert('(un)checked !')">Second choice (v-model)</NcActionCheckbox>
+		<NcActionCheckbox :model-value="checkboxValue" @change="alert('(un)checked !')">Third choice (checked)</NcActionCheckbox>
 		<NcActionCheckbox :disabled="true" @change="alert('(un)checked !')">Fourth choice (disabled)</NcActionCheckbox>
 	</NcActions>
 </template>
@@ -40,7 +40,7 @@ export default {
 			<input :id="id"
 				ref="checkbox"
 				:disabled="disabled"
-				:checked="checked"
+				:checked="model"
 				:value="value"
 				:class="{ focusable: isFocusable }"
 				type="checkbox"
@@ -56,6 +56,7 @@ export default {
 </template>
 
 <script>
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 
@@ -72,8 +73,8 @@ export default {
 	},
 
 	model: {
-		prop: 'checked',
-		event: 'update:checked',
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 
 	props: {
@@ -87,9 +88,18 @@ export default {
 		},
 
 		/**
-		 * checked state of the the checkbox element
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		checked: {
+			type: Boolean,
+			default: undefined,
+		},
+
+		/**
+		 * checked state of the the checkbox element
+		 */
+		modelValue: {
 			type: Boolean,
 			default: false,
 		},
@@ -115,8 +125,26 @@ export default {
 		'change',
 		'check',
 		'uncheck',
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:checked',
+		/**
+		 * Emitted when the checkbox state is changed
+		 * @type {boolean}
+		 */
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
 	],
+
+	setup() {
+		const model = useModelMigration('checked', 'update:checked')
+		return {
+			model,
+		}
+	},
 
 	computed: {
 		/**
@@ -135,7 +163,7 @@ export default {
 		 */
 		ariaChecked() {
 			if (this.isInSemanticMenu) {
-				return this.checked ? 'true' : 'false'
+				return this.model ? 'true' : 'false'
 			}
 			return undefined
 		},
@@ -147,12 +175,7 @@ export default {
 			this.$refs.label.click()
 		},
 		onChange(event) {
-			/**
-			 * Emitted when the checkbox state is changed
-			 *
-			 * @type {boolean}
-			 */
-			this.$emit('update:checked', this.$refs.checkbox.checked)
+			this.model = this.$refs.checkbox.checked
 
 			/**
 			 * Emitted when the checkbox state is changed

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -14,12 +14,12 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 ```vue
 	<template>
 		<NcActions>
-			<NcActionInput :value.sync="text" :label-outside="true" label="Label outside the input">
+			<NcActionInput v-model="text" :label-outside="true" label="Label outside the input">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
 			</NcActionInput>
-			<NcActionInput :value.sync="text" :show-trailing-button="false" label="Input without trailing button">
+			<NcActionInput v-model="text" :show-trailing-button="false" label="Input without trailing button">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
@@ -30,25 +30,25 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				</template>
 				This is the placeholder
 			</NcActionInput>
-			<NcActionInput type="password" :value.sync="text" label="Password with visible label">
+			<NcActionInput type="password" v-model="text" label="Password with visible label">
 				<template #icon>
 					<Key :size="20" />
 				</template>
 				Password placeholder
 			</NcActionInput>
-			<NcActionInput type="password" :value.sync="text" :show-trailing-button="false">
+			<NcActionInput type="password" v-model="text" :show-trailing-button="false">
 				<template #icon>
 					<Key :size="20" />
 				</template>
 				Password placeholder
 			</NcActionInput>
-			<NcActionInput type="color" :value.sync="color" label="Favorite color">
+			<NcActionInput type="color" v-model="color" label="Favorite color">
 				<template #icon>
 					<Eyedropper :size="20" />
 				</template>
 				Color placeholder
 			</NcActionInput>
-			<NcActionInput label="Visible label" :value.sync="text">
+			<NcActionInput label="Visible label" v-model="text">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
@@ -59,19 +59,20 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 					<Close :size="20" />
 				</template>
 			</NcActionInput>
-			<NcActionInput type="date" isNativePicker :value="new Date()">
+			<NcActionInput type="date" isNativePicker v-model="date">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
 				Please pick a date
 			</NcActionInput>
-			<NcActionInput type="date">
+			<NcActionInput v-model="date" type="date">
 				<template #icon>
 					<Pencil :size="20" />
 				</template>
 				Please pick a date
 			</NcActionInput>
 			<NcActionInput
+				v-model="multiSelected"
 				type="multiselect"
 				input-label="Fruit selection"
 				:options="['Apple', 'Banana', 'Cherry']">
@@ -113,6 +114,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 				color: '#0082C9',
 				text: 'This is the input text',
 				multiSelected: [],
+				date: new Date(),
 			}
 		},
 	}
@@ -154,7 +156,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 
 						<NcDateTimePicker v-if="datePickerType"
 							ref="datetimepicker"
-							:value="value"
+							:value="model"
 							style="z-index: 99999999999;"
 							:placeholder="text"
 							:disabled="disabled"
@@ -167,16 +169,16 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 
 						<NcDateTimePickerNative v-else-if="isNativePicker"
 							:id="idNativeDateTimePicker"
-							:value="value"
+							:value="model"
 							:type="nativeDatePickerType"
 							:input-class="{ focusable: isFocusable }"
 							class="action-input__datetimepicker"
 							v-bind="$attrs"
-							@input="$emit('input', $event)"
+							@update:model-value="model = $event"
 							@change="$emit('change', $event)" />
 
 						<NcSelect v-else-if="isMultiselectType"
-							:value="value"
+							:value="model"
 							:placeholder="text"
 							:disabled="disabled"
 							:append-to-body="$attrs.appendToBody || $attrs['append-to-body'] || false"
@@ -187,7 +189,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 
 						<NcPasswordField v-else-if="type==='password'"
 							:id="inputId"
-							:value="value"
+							:value="model"
 							:label="label"
 							:label-outside="!label || labelOutside"
 							:placeholder="text"
@@ -208,13 +210,13 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 							</label>
 							<div class="action-input__input-container">
 								<NcColorPicker id="inputId"
-									:value="value"
+									:value="model"
 									class="colorpicker__trigger"
 									v-bind="$attrs"
 									v-on="$listeners"
-									@input="onInput"
+									@update:model-value="onInput"
 									@submit="$refs.form.requestSubmit()">
-									<button :style="{'background-color': value}"
+									<button :style="{'background-color': model}"
 										class="colorpicker__preview"
 										:class="{ focusable: isFocusable }" />
 								</NcColorPicker>
@@ -223,7 +225,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 
 						<NcTextField v-else
 							:id="inputId"
-							:value="value"
+							:value="model"
 							:label="label"
 							:label-outside="!label || labelOutside"
 							:placeholder="text"
@@ -254,6 +256,7 @@ import NcTextField from '../NcTextField/index.js'
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 import { t } from '../../l10n.js'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 export default {
 	name: 'NcActionInput',
@@ -269,8 +272,8 @@ export default {
 	mixins: [ActionGlobalMixin],
 
 	model: {
-		prop: 'value',
-		event: 'update:value',
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 
 	props: {
@@ -340,9 +343,17 @@ export default {
 			default: true,
 		},
 		/**
-		 * value attribute of the input field
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		value: {
+			type: [String, Date, Number, Array],
+			default: undefined,
+		},
+		/**
+		 * value attribute of the input field
+		 */
+		modelValue: {
 			type: [String, Date, Number, Array],
 			default: '',
 		},
@@ -389,8 +400,28 @@ export default {
 		'input',
 		'submit',
 		'change',
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:value',
+		/**
+		 * Emitted when the inputs value changes
+		 * ! DatetimePicker only send the value
+		 *
+		 * @type {string|Date}
+		 */
+		'update:modelValue',
+		/** Same as `update:modelValue` but with a different event name */
+		'update:model-value',
 	],
+
+	setup() {
+		const model = useModelMigration('value', 'update:value')
+		return {
+			model,
+		}
+	},
 
 	computed: {
 		isIconUrl() {
@@ -455,13 +486,8 @@ export default {
 			 * @type {Event|Date}
 			 */
 			this.$emit('input', event)
-			/**
-			 * Emitted when the inputs value changes
-			 * ! DatetimePicker only send the value
-			 *
-			 * @type {string|Date}
-			 */
-			this.$emit('update:value', event.target ? event.target.value : event)
+
+			this.model = event.target ? event.target.value : event
 		},
 		onSubmit(event) {
 			event.preventDefault()

--- a/src/components/NcActionRadio/NcActionRadio.vue
+++ b/src/components/NcActionRadio/NcActionRadio.vue
@@ -13,7 +13,7 @@ So that only one of each name set can be selected at the same time.
 	<NcActions>
 		<NcActionRadio @change="alert('(un)checked !')" name="uniqueId">First choice</NcActionRadio>
 		<NcActionRadio value="second" v-model="radioValue" name="uniqueId" @change="alert('(un)checked !')">Second choice (v-model)</NcActionRadio>
-		<NcActionRadio :checked="true" name="uniqueId" @change="alert('(un)checked !')">Third choice (checked)</NcActionRadio>
+		<NcActionRadio :model-value="true" name="uniqueId" @change="alert('(un)checked !')">Third choice (checked)</NcActionRadio>
 		<NcActionRadio :disabled="true" name="uniqueId" @change="alert('(un)checked !')">Fourth choice (disabled)</NcActionRadio>
 	</NcActions>
 </template>
@@ -59,6 +59,7 @@ So that only one of each name set can be selected at the same time.
 </template>
 
 <script>
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 
@@ -75,8 +76,8 @@ export default {
 	},
 
 	model: {
-		prop: 'checked',
-		event: 'update:checked',
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 
 	props: {
@@ -90,9 +91,18 @@ export default {
 		},
 
 		/**
-		 * checked state of the the radio element
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		checked: {
+			type: Boolean,
+			default: undefined,
+		},
+
+		/**
+		 * checked state of the the radio element
+		 */
+		modelValue: {
 			type: Boolean,
 			default: false,
 		},
@@ -125,9 +135,27 @@ export default {
 	},
 
 	emits: [
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:checked',
+		/**
+		 * The radio state is changed
+		 * @type {boolean}
+		 */
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
 		'change',
 	],
+
+	setup() {
+		const model = useModelMigration('checked', 'update:checked')
+		return {
+			model,
+		}
+	},
 
 	computed: {
 		/**
@@ -146,7 +174,7 @@ export default {
 		 */
 		 ariaChecked() {
 			if (this.isInSemanticMenu) {
-				return this.checked ? 'true' : 'false'
+				return this.model ? 'true' : 'false'
 			}
 			return undefined
 		},
@@ -158,12 +186,7 @@ export default {
 			this.$refs.label.click()
 		},
 		onChange(event) {
-			/**
-			 * Emitted when the radio state is changed
-			 *
-			 * @type {boolean}
-			 */
-			this.$emit('update:checked', this.$refs.radio.checked)
+			this.model = this.$refs.radio.checked
 
 			/**
 			 * Emitted when the radio state is changed

--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -10,17 +10,17 @@ All undocumented attributes will be bound to the textarea. e.g. `maxlength`
 ```
 <template>
 	<NcActions>
-		<NcActionTextEditable value="This is a textarea">
+		<NcActionTextEditable v-model="text1">
 			<template #icon>
 				<Pencil :size="20" />
 			</template>
 		</NcActionTextEditable>
-		<NcActionTextEditable :disabled="true" value="This is a disabled textarea">
+		<NcActionTextEditable v-model="text2" disabled>
 			<template #icon>
 				<Pencil :size="20" />
 			</template>
 		</NcActionTextEditable>
-		<NcActionTextEditable name="Please edit the text" v-model="value">
+		<NcActionTextEditable name="text3" v-model="text3">
 			<template #icon>
 				<Pencil :size="20" />
 			</template>
@@ -34,11 +34,14 @@ export default {
 	components: {
 		Pencil,
 	},
-	data () {
+
+	data() {
 		return {
-			value: 'This is a textarea with name',
+			text1: 'This is a textarea',
+			text2: 'This is a disabled textarea',
+			text3: 'This is a textarea with name',
 		}
-	},
+	}
 }
 </script>
 ```
@@ -71,7 +74,7 @@ export default {
 
 				<textarea :id="computedId"
 					:disabled="disabled"
-					:value="value"
+					:value="model"
 					v-bind="$attrs"
 					:class="['action-text-editable__textarea', { focusable: isFocusable }]"
 					@input="onInput" />
@@ -87,6 +90,7 @@ export default {
 </template>
 
 <script>
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 import ActionTextMixin from '../../mixins/actionText.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 
@@ -102,8 +106,8 @@ export default {
 	mixins: [ActionTextMixin],
 
 	model: {
-		prop: 'value',
-		event: 'update:value',
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 
 	props: {
@@ -123,9 +127,17 @@ export default {
 			default: false,
 		},
 		/**
-		 * value attribute of the input field
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		value: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * value attribute of the input field
+		 */
+		modelValue: {
 			type: String,
 			default: '',
 		},
@@ -133,9 +145,28 @@ export default {
 
 	emits: [
 		'input',
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:value',
+		/**
+		 * Emitted when the inputs value changes
+		 *
+		 * @type {string|Date}
+		 */
+		'update:modelValue',
+		/** Same as `update:modelValue` but with a different event name */
+		'update:model-value',
 		'submit',
 	],
+
+	setup() {
+		const model = useModelMigration('value', 'update:value')
+		return {
+			model,
+		}
+	},
 
 	computed: {
 		/**
@@ -160,12 +191,8 @@ export default {
 			 * @type {Event|Date}
 			 */
 			this.$emit('input', event)
-			/**
-			 * Emitted when the inputs value changes
-			 *
-			 * @type {string|Date}
-			 */
-			this.$emit('update:value', event.target.value)
+
+			this.model = event.target.value
 		},
 		onSubmit(event) {
 			event.preventDefault()

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -16,10 +16,10 @@ Note: All attributes on the element are passed to the inner input element - exce
 ```vue
 <template>
 	<div>
-		<NcCheckboxRadioSwitch :checked.sync="sharingEnabled">Enable sharing</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch :checked.sync="sharingEnabled" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled">Enable sharing</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch v-model="sharingEnabled">Enable sharing (v-model)</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch :checked="sharingEnabled" :loading="loading" @update:checked="onToggle">Enable sharing (with request loading)</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch :model-value="sharingEnabled" :loading="loading" @update:modelValue="onToggle">Enable sharing (with request loading)</NcCheckboxRadioSwitch>
 		<br>
 		sharingEnabled: {{ sharingEnabled }}
 	</div>
@@ -50,8 +50,8 @@ export default {
 ```vue
 <template>
 	<div>
-		<NcCheckboxRadioSwitch :checked.sync="sharingPermission" value="r" name="sharing_permission_radio" type="radio">Default permission read</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch :checked.sync="sharingPermission" value="rw" name="sharing_permission_radio" type="radio">Default permission read+write</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingPermission" value="r" name="sharing_permission_radio" type="radio">Default permission read</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingPermission" value="rw" name="sharing_permission_radio" type="radio">Default permission read+write</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch v-model="sharingPermission" value="rwx" name="sharing_permission_radio" type="radio">Default permission read+write+execute</NcCheckboxRadioSwitch>
 		<br>
 		sharingPermission: {{ sharingPermission }}
@@ -76,7 +76,7 @@ export default {
 		<div style="display: flex">
 			<NcCheckboxRadioSwitch
 				:button-variant="true"
-				:checked.sync="sharingPermission"
+				v-model="sharingPermission"
 				value="r"
 				name="sharing_permission_radio"
 				type="radio"
@@ -85,7 +85,7 @@ export default {
 			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch
 				:button-variant="true"
-				:checked.sync="sharingPermission"
+				v-model="sharingPermission"
 				value="rw"
 				name="sharing_permission_radio"
 				type="radio"
@@ -97,7 +97,7 @@ export default {
 		<div style="width: fit-content">
 			<NcCheckboxRadioSwitch
 				:button-variant="true"
-				:checked.sync="sharingPermission"
+				v-model="sharingPermission"
 				value="r"
 				name="sharing_permission_radio"
 				type="radio"
@@ -106,7 +106,7 @@ export default {
 			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch
 				:button-variant="true"
-				:checked.sync="sharingPermission"
+				v-model="sharingPermission"
 				value="rw"
 				name="sharing_permission_radio"
 				type="radio"
@@ -136,7 +136,7 @@ export default {
 		<div style="display: flex">
 			<NcCheckboxRadioSwitch
 				:button-variant="true"
-				:checked.sync="enableSettings"
+				v-model="enableSettings"
 				value="y"
 				name="sharing_permission_radio"
 				type="radio"
@@ -146,7 +146,7 @@ export default {
 			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch
 				:button-variant="true"
-				:checked.sync="enableSettings"
+				v-model="enableSettings"
 				value="n"
 				name="sharing_permission_radio"
 				type="radio"
@@ -159,7 +159,7 @@ export default {
 		<div style="width: fit-content">
 			<NcCheckboxRadioSwitch
 				:button-variant="true"
-				:checked.sync="enableSettings"
+				v-model="enableSettings"
 				value="y"
 				name="sharing_permission_radio"
 				type="radio"
@@ -169,7 +169,7 @@ export default {
 			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch
 				:button-variant="true"
-				:checked.sync="enableSettings"
+				v-model="enableSettings"
 				value="n"
 				name="sharing_permission_radio"
 				type="radio"
@@ -202,9 +202,9 @@ export default {
 ```vue
 <template>
 	<div>
-		<NcCheckboxRadioSwitch :disabled="true" :checked.sync="sharingPermission" value="r" name="sharing_permission">Permission read</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch :checked.sync="sharingPermission" value="w" name="sharing_permission">Permission write</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch :checked.sync="sharingPermission" value="d" name="sharing_permission">Permission delete</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch :disabled="true" v-model="sharingPermission" value="r" name="sharing_permission">Permission read</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingPermission" value="w" name="sharing_permission">Permission write</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingPermission" value="d" name="sharing_permission">Permission delete</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch v-model="sharingPermission" value="x" name="sharing_permission">Permission execute</NcCheckboxRadioSwitch>
 		<br>
 		sharingPermission: {{ sharingPermission }}
@@ -225,9 +225,9 @@ export default {
 ```vue
 <template>
 	<div>
-		<NcCheckboxRadioSwitch :checked.sync="sharingEnabled" type="switch">Enable sharing</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">Enable sharing</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">Enable sharing (v-model)</NcCheckboxRadioSwitch>
-		<NcCheckboxRadioSwitch :checked.sync="sharingEnabled" type="switch" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
 		<br>
 		sharingEnabled: {{ sharingEnabled }}
 	</div>
@@ -304,6 +304,7 @@ export default {
 import { n, t } from '../../l10n.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 import NcCheckboxContent, { TYPE_BUTTON, TYPE_CHECKBOX, TYPE_RADIO, TYPE_SWITCH } from './NcCheckboxContent.vue'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 export default {
 	name: 'NcCheckboxRadioSwitch',
@@ -316,8 +317,8 @@ export default {
 	inheritAttrs: false,
 
 	model: {
-		prop: 'checked',
-		event: 'update:checked',
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 
 	props: {
@@ -396,9 +397,18 @@ export default {
 		},
 
 		/**
-		 * Checked state. To be used with `:value.sync`
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		checked: {
+			type: [Boolean, Array, String],
+			default: undefined,
+		},
+
+		/**
+		 * Checkbox value
+		 */
+		modelValue: {
 			type: [Boolean, Array, String],
 			default: false,
 		},
@@ -456,7 +466,23 @@ export default {
 		},
 	},
 
-	emits: ['update:checked'],
+	emits: [
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
+		'update:checked',
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
+	],
+
+	setup() {
+		const model = useModelMigration('checked', 'update:checked')
+		return {
+			model,
+		}
+	},
 
 	computed: {
 		dataAttrs() {
@@ -540,18 +566,18 @@ export default {
 		/**
 		 * Check if that entry is checked
 		 * If value is defined, we use that as the checked value
-		 * If not, we expect true/false in this.checked
+		 * If not, we expect true/false in checked state
 		 *
 		 * @return {boolean}
 		 */
 		isChecked() {
 			if (this.value !== null) {
-				if (Array.isArray(this.checked)) {
-					return [...this.checked].indexOf(this.value) > -1
+				if (Array.isArray(this.model)) {
+					return [...this.model].indexOf(this.value) > -1
 				}
-				return this.checked === this.value
+				return this.model === this.value
 			}
-			return this.checked === true
+			return this.model === true
 		},
 
 		hasIndeterminate() {
@@ -564,7 +590,7 @@ export default {
 
 	mounted() {
 		if (this.name && this.type === TYPE_CHECKBOX) {
-			if (!Array.isArray(this.checked)) {
+			if (!Array.isArray(this.model)) {
 				throw new Error('When using groups of checkboxes, the updated value will be an array.')
 			}
 		}
@@ -575,7 +601,7 @@ export default {
 		}
 
 		// https://material.io/components/checkboxes#usage
-		if (typeof this.checked !== 'boolean' && this.type === TYPE_SWITCH) {
+		if (typeof this.model !== 'boolean' && this.type === TYPE_SWITCH) {
 			throw new Error('Switches can only be used with boolean as checked prop.')
 		}
 	},
@@ -591,19 +617,19 @@ export default {
 
 			// If this is a radio, there can only be one value
 			if (this.type === TYPE_RADIO) {
-				this.$emit('update:checked', this.value)
+				this.model = this.value
 				return
 			}
 
 			// If this is a radio, there can only be one value
 			if (this.type === TYPE_SWITCH) {
-				this.$emit('update:checked', !this.isChecked)
+				this.model = !this.isChecked
 				return
 			}
 
 			// If the initial value was a boolean, let's keep it that way
-			if (typeof this.checked === 'boolean') {
-				this.$emit('update:checked', !this.checked)
+			if (typeof this.model === 'boolean') {
+				this.model = !this.model
 				return
 			}
 
@@ -613,9 +639,9 @@ export default {
 				.map(input => input.value)
 
 			if (values.includes(this.value)) {
-				this.$emit('update:checked', values.filter((v) => v !== this.value))
+				this.model = values.filter((v) => v !== this.value)
 			} else {
-				this.$emit('update:checked', [...values, this.value])
+				this.model = [...values, this.value]
 			}
 		},
 

--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -71,7 +71,7 @@ export default {
 <template>
 	<div class="container1">
 		<NcButton @click="open = !open"> Click Me </NcButton>
-		<NcColorPicker :value="color" @input="updateColor" :shown.sync="open" @submit="open = false" v-slot="{ attrs }">
+		<NcColorPicker :model-value="color" @update:model-value="updateColor" :shown.sync="open" @submit="open = false" v-slot="{ attrs }">
 			<div v-bind="attrs" :style="{'background-color': color}" class="color1" />
 		</NcColorPicker>
 	</div>
@@ -217,6 +217,7 @@ import Check from 'vue-material-design-icons/Check.vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 
 import { Chrome } from 'vue-color'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 const HEX_REGEX = /^#([a-f0-9]{3}|[a-f0-9]{6})$/i
 
@@ -232,13 +233,27 @@ export default {
 		NcPopover,
 	},
 
+	model: {
+		prop: 'modelValue',
+		event: 'update:modelValue',
+	},
+
 	props: {
 		/**
-		 * A HEX color that represents the initial value of the picker
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		value: {
 			type: String,
-			required: true,
+			default: undefined,
+		},
+
+		/**
+		 * A HEX color that represents the initial value of the picker
+		 */
+		modelValue: {
+			type: String,
+			default: undefined,
 		},
 
 		/**
@@ -287,13 +302,30 @@ export default {
 		'submit',
 		'close',
 		'update:open',
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:value',
+		/**
+		 * Emits a hexadecimal string e.g. '#ffffff'
+		 */
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
 		'input',
 	],
 
+	setup() {
+		const model = useModelMigration('value', 'update:value', true)
+		return {
+			model,
+		}
+	},
+
 	data() {
 		return {
-			currentColor: this.value,
+			currentColor: this.model,
 			advanced: false,
 			ariaBack: t('Back'),
 			ariaMore: t('More options'),
@@ -321,7 +353,7 @@ export default {
 	},
 
 	watch: {
-		value(color) {
+		model(color) {
 			this.currentColor = color
 		},
 	},
@@ -370,10 +402,7 @@ export default {
 			}
 			this.currentColor = color
 
-			/**
-			 * Emits a hexadecimal string e.g. '#ffffff'
-			 */
-			this.$emit('update:value', color)
+			this.model = color
 
 			/**
 			 * Emits a hexadecimal string e.g. '#ffffff'

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -117,12 +117,12 @@ export default {
 		:popup-class="{ 'show-week-number': showWeekNumber }"
 		:show-week-number="showWeekNumber"
 		:type="type"
-		:value="value"
+		:value="model"
 		v-bind="$attrs"
 		v-on="$listeners"
 		@select-year="handleSelectYear"
 		@select-month="handleSelectMonth"
-		@update:value="$emit('update:value', value)">
+		@input="model = $event">
 		<template #icon-calendar>
 			<NcPopover v-if="showTimezoneSelect"
 				popup-role="dialog"
@@ -160,6 +160,7 @@ export default {
 <script>
 import { t } from '../../l10n.js'
 import GenRandomId from '../../utils/GenRandomId.js'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 import NcTimezonePicker from '../NcTimezonePicker/index.js'
 import NcPopover from '../NcPopover/index.js'
@@ -200,6 +201,11 @@ export default {
 
 	inheritAttrs: false,
 
+	model: {
+		prop: 'modelValue',
+		event: 'update:modelValue',
+	},
+
 	props: {
 		clearable: {
 			type: Boolean,
@@ -232,12 +238,21 @@ export default {
 		},
 
 		/**
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
+		// eslint-disable-next-line
+		value: {
+			default: undefined,
+		},
+
+		/**
 		 * The value to initialize, but also two-way bind the selected date. The date is – like the `Date` object in
 		 * JavaScript – tied to UTC. The selected time zone does not have an influence of the selected time and date
 		 * value. You have to translate the time yourself when you want to factor in time zones.
 		 */
 		// eslint-disable-next-line
-		value: {
+		modelValue: {
 			default: () => new Date(),
 		},
 
@@ -276,12 +291,21 @@ export default {
 	},
 
 	emits: [
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:value',
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
 		'update:timezone-id',
 	],
 
 	setup() {
+		const model = useModelMigration('value', 'update:value')
 		return {
+			model,
 			timezoneDialogHeaderId: `timezone-dialog-header-${GenRandomId()}`,
 		}
 	},

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -40,7 +40,7 @@ For a list of all available props and attributes, please check the [HTMLInputEle
 						'input-field__input--success': success,
 						'input-field__input--error': error,
 					}]"
-				:value="value.toString()"
+				:value="model?.toString()"
 				v-on="$listeners"
 				@input="handleInput">
 			<!-- Label -->
@@ -97,6 +97,7 @@ import GenRandomId from '../../utils/GenRandomId.js'
 
 import AlertCircle from 'vue-material-design-icons/AlertCircleOutline.vue'
 import Check from 'vue-material-design-icons/Check.vue'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 export default {
 	name: 'NcInputField',
@@ -110,18 +111,27 @@ export default {
 	inheritAttrs: false,
 
 	model: {
-		prop: 'value',
-		event: 'update:value',
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 
 	props: {
 		/**
-		 * The value of the input field
-		 * If type is 'number' and a number is passed as value than the type of `update:value` will also be 'number'
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		value: {
 			type: [String, Number],
-			required: true,
+			default: undefined,
+		},
+
+		/**
+		 * The value of the input field
+		 * If type is 'number' and a number is passed as value than the type of `update:modelValue` will also be 'number'
+		 */
+		modelValue: {
+			type: [String, Number],
+			default: undefined,
 		},
 
 		/**
@@ -248,9 +258,23 @@ export default {
 	},
 
 	emits: [
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:value',
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
 		'trailing-button-click',
 	],
+
+	setup() {
+		const model = useModelMigration('value', 'update:value', true)
+		return {
+			model,
+		}
+	},
 
 	computed: {
 		computedId() {
@@ -317,7 +341,8 @@ export default {
 		},
 
 		handleInput(event) {
-			this.$emit('update:value', this.type === 'number' && typeof this.value === 'number' ? parseFloat(event.target.value, 10) : event.target.value)
+			const newValue = this.type === 'number' && typeof this.model === 'number' ? parseFloat(event.target.value, 10) : event.target.value
+			this.model = newValue
 		},
 
 		handleTrailingButtonClick(event) {

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -12,7 +12,7 @@ General purpose password field component.
 ```
 <template>
 	<div class="wrapper">
-		<NcPasswordField :value.sync="text1"
+		<NcPasswordField v-model="text1"
 			label="Old password" />
 		<div class="external-label">
 			<label for="textField">New password</label>
@@ -24,24 +24,24 @@ General purpose password field component.
 		<div class="external-label">
 			<label for="textField2">New password</label>
 			<NcPasswordField id="textField2"
-				:value.sync="text3"
+				v-model="text3"
 				:error="true"
 				:label-outside="true"
 				placeholder="Min. 12 characters"
 				helper-text="Password is insecure" />
 		</div>
 
-		<NcPasswordField :value.sync="text4"
+		<NcPasswordField v-model="text4"
 			label="Good new password"
 			:success="true"
 			placeholder="Min. 12 characters"
 			helper-text="Password is secure" />
 
-		<NcPasswordField :value.sync="text5"
+		<NcPasswordField v-model="text5"
 			:disabled="true"
 			label="Disabled" />
 
-		<NcPasswordField :value.sync="text6"
+		<NcPasswordField v-model="text6"
 			label="Secret token"
 			as-text />
 	</div>
@@ -116,6 +116,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { generateOcsUrl } from '@nextcloud/router'
 import { t } from '../../l10n.js'
 import logger from '../../utils/logger.js'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 /**
  * @typedef PasswordPolicy
@@ -147,8 +148,8 @@ export default {
 	inheritAttrs: false,
 
 	model: {
-		prop: 'value',
-		event: 'update:value',
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 
 	props: {
@@ -224,8 +225,28 @@ export default {
 	emits: [
 		'valid',
 		'invalid',
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:value',
+		/**
+		 * Triggers when the value inside the password field is
+		 * updated.
+		 *
+		 * @property {string} The new value
+		 */
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
 	],
+
+	setup() {
+		const model = useModelMigration('value', 'update:value')
+		return {
+			model,
+		}
+	},
 
 	data() {
 		return {
@@ -273,7 +294,7 @@ export default {
 	},
 
 	watch: {
-		value(newValue) {
+		model(newValue) {
 			if (this.checkPasswordStrength) {
 				if (passwordPolicy === null) {
 					return
@@ -303,13 +324,7 @@ export default {
 		},
 
 		handleInput(event) {
-			/**
-			 * Triggers when the value inside the password field is
-			 * updated.
-			 *
-			 * @property {string} The new value
-			 */
-			this.$emit('update:value', event.target.value)
+			this.model = event.target.value
 		},
 		togglePasswordVisibility() {
 			this.isPasswordHidden = !this.isPasswordHidden

--- a/src/components/NcSettingsInputText/NcSettingsInputText.vue
+++ b/src/components/NcSettingsInputText/NcSettingsInputText.vue
@@ -9,7 +9,7 @@
 <template>
 	<div>
 		<NcSettingsInputText v-model="value" label="Label" hint="Hint" />
-		<NcSettingsInputText label="Label" value="Value" hint="Hint" disabled />
+		<NcSettingsInputText label="Label" model-value="Value" hint="Hint" disabled />
 	</div>
 </template>
 
@@ -34,7 +34,7 @@ export default {
 			<label :for="id" class="action-input__label">{{ label }}</label>
 			<input :id="id"
 				type="text"
-				:value="value"
+				:value="model"
 				:disabled="disabled"
 				@input="onInput"
 				@change="onChange">
@@ -52,6 +52,7 @@ export default {
 <script>
 import { t } from '../../l10n.js'
 import GenRandomId from '../../utils/GenRandomId.js'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 export default {
 	name: 'NcSettingsInputText',
@@ -79,9 +80,18 @@ export default {
 		},
 
 		/**
-		 * value of the select group input
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		value: {
+			type: String,
+			default: undefined,
+		},
+
+		/**
+		 * value of the select group input
+		 */
+		 modelValue: {
 			type: String,
 			default: '',
 		},
@@ -105,11 +115,30 @@ export default {
 	},
 
 	emits: [
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:value',
+		/**
+		 * Emitted when the inputs value changes
+		 *
+		 * @type {string}
+		 */
+		'update:modelValue',
+		/* Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
 		'input',
 		'submit',
 		'change',
 	],
+
+	setup() {
+		const model = useModelMigration('value', 'update:value')
+		return {
+			model,
+		}
+	},
 
 	data() {
 		return {
@@ -128,12 +157,7 @@ export default {
 	methods: {
 		onInput(event) {
 			this.$emit('input', event)
-			/**
-			 * Emitted when the inputs value changes
-			 *
-			 * @type {string}
-			 */
-			this.$emit('update:value', event.target.value)
+			this.model = event.target.value
 		},
 		onSubmit(event) {
 			if (!this.disabled) {

--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -13,7 +13,7 @@ It extends and styles an HTMLTextAreaElement.
 <template>
 	<div class="wrapper">
 		<NcTextArea label="Text area"
-			:value.sync="text1"
+			v-model="text1"
 			placeholder="Placeholders are possible"
 			helper-text="This is a regular helper text." >
 		</NcTextArea>
@@ -22,27 +22,27 @@ It extends and styles an HTMLTextAreaElement.
 			:success="true">
 		</NcTextArea>
 		<NcTextArea label="Error state"
-			:value.sync="text3"
+			v-model="text3"
 			placeholder="Enter something valid"
 			helper-text="Helper texts will be styled accordingly."
 			:error="true">
 		</NcTextArea>
 		<NcTextArea label="Disabled"
-			:value.sync="text4"
+			v-model="text4"
 			:disabled="true" />
 		<NcTextArea label="Disabled + Success"
-			:value.sync="text5"
+			v-model="text5"
 			:success="true"
 			:disabled="true" />
 		<div class="external-label">
 			<label for="textField">External label</label>
 			<NcTextArea id="textField"
-				:value.sync="text6"
+				v-model="text6"
 				:label-outside="true"
 				placeholder="Text area with external label" />
 		</div>
 		<NcTextArea label="Custom size and no resize"
-			:value.sync="text7"
+			v-model="text7"
 			resize="none"
 			rows="5" />
 		</NcTextArea>
@@ -105,7 +105,7 @@ It extends and styles an HTMLTextAreaElement.
 						'textarea__input--error': error,
 					}]"
 				:style="{ resize: resize }"
-				:value="value"
+				:value="model"
 				v-on="$listeners"
 				@input="handleInput" />
 			<!-- Label -->
@@ -134,6 +134,7 @@ import GenRandomId from '../../utils/GenRandomId.js'
 
 import AlertCircle from 'vue-material-design-icons/AlertCircleOutline.vue'
 import Check from 'vue-material-design-icons/Check.vue'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 export default {
 	name: 'NcTextArea',
@@ -146,17 +147,26 @@ export default {
 	inheritAttrs: false,
 
 	model: {
-		prop: 'value',
-		event: 'update:value',
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 
 	props: {
 		/**
-		 * The value of the input field
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		value: {
 			type: String,
-			required: true,
+			default: undefined,
+		},
+
+		/**
+		 * The value of the input field
+		 */
+		modelValue: {
+			type: String,
+			default: undefined,
 		},
 
 		/**
@@ -247,8 +257,22 @@ export default {
 	},
 
 	emits: [
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:value',
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
 	],
+
+	setup() {
+		const model = useModelMigration('value', 'update:value', true)
+		return {
+			model,
+		}
+	},
 
 	computed: {
 		computedId() {
@@ -307,7 +331,7 @@ export default {
 		},
 
 		handleInput(event) {
-			this.$emit('update:value', event.target.value)
+			this.model = event.target.value
 		},
 	},
 }

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -18,7 +18,7 @@ and `minlength`.
 ```
 <template>
 	<div class="wrapper">
-		<NcTextField :value.sync="text1"
+		<NcTextField v-model="text1"
 			label="Leading icon and clear trailing button"
 			trailing-button-icon="close"
 			:show-trailing-button="text1 !== ''"
@@ -33,18 +33,18 @@ and `minlength`.
 			@trailing-button-click="clearText">
 			<Lock :size="20" />
 		</NcTextField>
-		<NcTextField :value.sync="text2"
+		<NcTextField v-model="text2"
 			label="With helper text"
 			helper-text="This is an optional message to show e.g. validation errors."
 			@trailing-button-click="clearText">
 		</NcTextField>
-		<NcTextField :value.sync="text2"
+		<NcTextField v-model="text2"
 			label="Success state"
 			placeholder="Placeholders are possible"
 			:success="true"
 			@trailing-button-click="clearText">
 		</NcTextField>
-		<NcTextField :value.sync="text3"
+		<NcTextField v-model="text3"
 			label="Error state"
 			placeholder="Enter something valid"
 			:error="true"
@@ -59,7 +59,7 @@ and `minlength`.
 			:disabled="true" />
 		<div class="external-label">
 			<label for="textField">External label</label>
-			<NcTextField :value.sync="text5"
+			<NcTextField v-model="text5"
 				id="textField"
 				:label-outside="true"
 				placeholder="Input with external label"
@@ -146,6 +146,7 @@ import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import Undo from 'vue-material-design-icons/UndoVariant.vue'
 
 import { t } from '../../l10n.js'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 const NcInputFieldProps = new Set(Object.keys(NcInputField.props))
 
@@ -163,8 +164,8 @@ export default {
 	inheritAttrs: false,
 
 	model: {
-		prop: 'value',
-		event: 'update:value',
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 
 	props: {
@@ -207,8 +208,22 @@ export default {
 	},
 
 	emits: [
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
 		'update:value',
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
 	],
+
+	setup() {
+		const model = useModelMigration('value', 'update:value')
+		return {
+			model,
+		}
+	},
 
 	computed: {
 		propsAndAttrsToForward() {
@@ -251,7 +266,7 @@ export default {
 		},
 
 		handleInput(event) {
-			this.$emit('update:value', event.target.value)
+			this.model = event.target.value
 		},
 	},
 }

--- a/src/components/NcTimezonePicker/NcTimezonePicker.vue
+++ b/src/components/NcTimezonePicker/NcTimezonePicker.vue
@@ -46,11 +46,16 @@ import getTimezoneManager from './timezoneDataProviderService.js'
 import GenRandomId from '../../utils/GenRandomId.js'
 import NcSelect from '../NcSelect/index.js'
 import { t } from '../../l10n.js'
+import { useModelMigration } from '../../composables/useModelMigration.ts'
 
 export default {
 	name: 'NcTimezonePicker',
 	components: {
 		NcSelect,
+	},
+	model: {
+		prop: 'modelValue',
+		event: 'update:modelValue',
 	},
 	props: {
 		/**
@@ -61,9 +66,17 @@ export default {
 			default: () => [],
 		},
 		/**
-		 * The selected timezone. Use v-model for two-way binding. The default timezone is floating, which means a time independent of timezone. See https://icalendar.org/CalDAV-Access-RFC-4791/7-3-date-and-floating-time.html for details.
+		 * Removed in v9 - use `modelValue` (`v-model`) instead
+		 * @deprecated
 		 */
 		value: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * The selected timezone. Use v-model for two-way binding. The default timezone is floating, which means a time independent of timezone. See https://icalendar.org/CalDAV-Access-RFC-4791/7-3-date-and-floating-time.html for details.
+		 */
+		modelValue: {
 			type: String,
 			default: 'floating',
 		},
@@ -75,21 +88,39 @@ export default {
 			default: () => `tz-${GenRandomId(5)}`,
 		},
 	},
-	emits: ['input'],
+	emits: [
+		/**
+		 * Removed in v9 - use `update:modelValue` (`v-model`) instead
+		 * @deprecated
+		 */
+		'input',
+		/**
+		 * Two-way binding of the value prop. Use v-model="selectedTimezone" for two-way binding
+		 */
+		'update:modelValue',
+		/** Same as update:modelValue for Vue 2 compatibility */
+		'update:model-value',
+	],
+	setup() {
+		const model = useModelMigration('value', 'input')
+		return {
+			model,
+		}
+	},
 	computed: {
 		placeholder() {
 			return t('Type to search time zone')
 		},
 		selectedTimezone() {
 			for (const additionalTimezone of this.additionalTimezones) {
-				if (additionalTimezone.timezoneId === this.value) {
+				if (additionalTimezone.timezoneId === this.model) {
 					return additionalTimezone
 				}
 			}
 
 			return {
-				label: getReadableTimezoneName(this.value),
-				timezoneId: this.value,
+				label: getReadableTimezoneName(this.model),
+				timezoneId: this.model,
 			}
 		},
 		options() {
@@ -123,10 +154,7 @@ export default {
 				return
 			}
 
-			/**
-			 * Two-way binding of the value prop. Use v-model="selectedTimezone" for two-way binding
-			 */
-			this.$emit('input', newValue.timezoneId)
+			this.model = newValue.timezoneId
 		},
 
 		/**

--- a/src/composables/useModelMigration.ts
+++ b/src/composables/useModelMigration.ts
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import Vue, { getCurrentInstance, computed } from 'vue'
+
+/**
+ * Create model proxy to new v9 model (modelValue + update:modelValue) with a fallback to old model
+ * @param {string} oldModelName - Name of model prop in nextcloud-vue v8
+ * @param {string} oldModelEvent - Event name of model event in nextcloud-vue v8
+ * @param {boolean} required - If the prop is required
+ * @return {import('vue').WritableComputedRef} - model proxy
+ */
+export function useModelMigration(oldModelName, oldModelEvent, required = false) {
+	const vm = getCurrentInstance()!.proxy
+
+	if (required && vm.$props[oldModelName] === undefined && vm.$props.modelValue === undefined) {
+		Vue.util.warn(`Missing required prop: "modelValue" or old "${oldModelName}"`)
+	}
+
+	const model = computed({
+		get() {
+			if (vm.$props[oldModelName] !== undefined) {
+				return vm.$props[oldModelName]
+			}
+			return vm.$props.modelValue
+		},
+
+		set(value) {
+			// Old nextcloud-vue v8 event
+			vm.$emit(oldModelEvent, value)
+			// New nextcloud-vue v9 event
+			vm.$emit('update:modelValue', value)
+			// Vue 2 fallback for kebab-case event names in templates (recommended by Vue 3 style guide)
+			vm.$emit('update:model-value', value)
+		},
+	})
+
+	return model
+}


### PR DESCRIPTION
### ☑️ Resolves

This PR adds **forward compatibility** with `next` (`v9`) on `v-model` props/events
- `modelValue` prop fallbacks to an old prop
- `update:modelValue` is emitted together with an old event
- `update:model-value` is emitted as well to use the new Vue 3 recommended event style in template compatible with Vue 2

Implementation details:
- Added `useModelMigration` to create migration proxy that:
  - Returns a new model prop if an old one is not defined
  - Triggers a new event together with an old one on set
  - Checks if either old or new prop is provided for required model
- Use `model` proxy instead of old prop to get value
- Assign to `model` instead of `$emit` an old event
- Define new `prop` and `event` as well as define/update `model` option
- Update docs:
  - Mark the old interfaces as deprecated in docs
  - Use `v-model` in docs examples

### Screenshots

#### Docs

![image](https://github.com/user-attachments/assets/582fe1b2-734e-450e-a5f3-3a46fd35e41e)

#### `required: true`

![image](https://github.com/user-attachments/assets/81253d1e-6b71-4e59-8dff-1e2c1407e84a)

### 📃 Components

- Check components with `:checked` + `@update:checked`:
  - [x] NcActionCheckbox
  - [x] NcActionRadio
  - [x] NcCheckboxRadioSwitch
- Text input fields with `:value` + `@update:value`:
  - [x] NcActionTextEditable
  - [x] NcInputField
  - [x] NcPasswordField
  - [x] NcRichContenteditable
  - [x] NcTextArea
  - [x] NcTextField
- Selects (`:value` + `@input`):
  - [x] NcSelect
  - [x] NcSelectTags
  - [x] NcSettingsSelectGroup
- Pickers (`:value` + `@input`):
  - [x] NcColorPicker 
  - [x] NcDateTimePicker
  - [x] NcDateTimePickerNative
  - [x] NcTimezonePicker
- Special with `:value` + `@update:value`:
  - [x] NcActionInput
- Misc.:
  - [x] NcSettingsInputText (`:value` + `@update:value`)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
