### PR TITLE
fix: scope css styles for TimeZonePicker

### DIFF
--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -460,6 +460,10 @@ export default {
 
 			// We overwrite the border radius of the input to account for the popover border-radius minus the padding
 			&__timezone-select.v-select {
+				&.select {
+					min-width: 246px;
+					left: -8px !important;
+				}
 				.vs__dropdown-toggle {
 					border-radius: calc(var(--border-radius-large) - 4px);
 				}
@@ -478,10 +482,6 @@ export default {
 	}
 }
 
-.v-select.select {
-	min-width: 246px;
-	left: -8px !important;
-}
 // TODO: This should be scoped or targeted by a specific selector, but the NcSelect component does not allow this yet.
 .vs__dropdown-menu--floating {
 	// Higher z-index than the popover in which the NcSelect is located.


### PR DESCRIPTION
### ☑️ Resolves

- Fix leaking styles to all NcSelects

Not sure, if `left` rule should be applied, see it's [broken on master](https://nextcloud-vue-components.netlify.app/#/Components/NcPickers?id=ncdatetimepicker), but at least scoped to timezone:

Current | Expected
-- | --
![image](https://github.com/user-attachments/assets/b4ab7bc6-e2e1-4576-8a69-23cc446d8eca) | ![image](https://github.com/user-attachments/assets/5c6779a8-d2ab-45af-8b19-3614f96b0550)



### 🖼️ Screenshots

```vue
<template>
	<span>
		<NcDateTimePicker
			v-model="time"
			type="datetime"
			:show-timezone-select="true"
			:timezone-id.sync="tz" /><br>
		{{ time }} | {{ tz }}
		<br>
		<NcSelect v-model="tz"/>
	</span>
</template>
```

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/7b720825-e9f7-4db7-b306-b4631114d7ae) | ![image](https://github.com/user-attachments/assets/58446b7c-f081-4001-92f7-df05bda39403)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
