### PR TITLE
fix: force color-main-text for icons in NcAppSidebarTabs

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -273,7 +273,7 @@ export default {
 				border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0 !important;
 				margin: 0 !important;
 				border-bottom: var(--default-grid-baseline) solid transparent !important;
-				.checkbox-content__icon--checked > * {
+				.checkbox-content__icon > * {
 					color: var(--color-main-text) !important;
 				}
 			}


### PR DESCRIPTION
### ☑️ Resolves

- Continuation of #6055
- Both rules have same specificity (0.4.0):
  - `.checkbox-radio-switch--button-variant:not(.checkbox-radio-switch--checked) .checkbox-radio-switch__icon > *` in NcChevkboxRadioSwitch 
  - `.checkbox-content--button-variant .checkbox-content__icon:not(.checkbox-content__icon--checked) > *` in NcCheckboxContent
- so it might come up again sooner or later (noticed when linked new lib to spreed app, but not noifications app)
- since we have styles overriden for NcAppSidebarTabs specifically, they should force cover both checked and default icon

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="239" alt="image" src="https://github.com/user-attachments/assets/ce90112a-c723-4b39-9817-7b4c1de4c03f"> | <img width="243" alt="image" src="https://github.com/user-attachments/assets/64d90b6e-1105-427a-8af2-3f55360c1049">


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
