### PR TITLE
feat(NcActions): submenus

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -387,6 +387,10 @@ export default {
 			from: 'NcActions:isSemanticMenu',
 			default: false,
 		},
+		openSubmenu: {
+			from: 'NcActions:openSubmenu',
+			default: () => () => {},
+		},
 	},
 
 	props: {
@@ -409,11 +413,12 @@ export default {
 		},
 
 		/**
-		 * If this is a menu, a chevron icon will
-		 * be added at the end of the line
+		 * Weather the button opens a submenu
+		 * - Boolean value makes button looks like a submenu opener
+		 * - String value can be used to open a specific submenu slot in NcActions
 		 */
 		isMenu: {
-			type: Boolean,
+			type: [Boolean, String],
 			default: false,
 		},
 
@@ -518,6 +523,11 @@ export default {
 		 */
 		handleClick(event) {
 			this.onClick(event)
+
+			if (typeof this.isMenu === 'string') {
+				this.openSubmenu(this.isMenu)
+			}
+
 			// If modelValue or type is set (so modelValue might be null for tri-state) we need to update it
 			if (this.modelValue !== null || this.type !== 'button') {
 				if (this.type === 'radio') {

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -788,6 +788,39 @@ p {
 </style>
 ```
 
+## Submenus
+
+To create multi-level menus:
+- Add `<NcActionButton is-menu="NAME" />` where NAME is the name of the submenu
+- Pass submenu to a `submenu:NAME` slot
+
+```vue
+<template>
+	<NcActions>
+		<template #default>
+			<NcActionButton>Option 1</NcActionButton>
+			<NcActionButton is-menu="two">Option 2</NcActionButton>
+			<NcActionButton is-menu="three">Option 3</NcActionButton>
+			<NcActionButton>Option 4</NcActionButton>
+		</template>
+		<template #submenu:two>
+			<NcActionButton>Option 2.1</NcActionButton>
+			<NcActionButton is-menu="two-two">Option 2.2</NcActionButton>
+			<NcActionButton>Option 2.3</NcActionButton>
+		</template>
+		<template #submenu:two-two>
+			<NcActionButton>Option 2.2.1</NcActionButton>
+			<NcActionButton>Option 2.2.2</NcActionButton>
+		</template>
+		<template #submenu:three>
+			<NcActionButton>Option 3.1</NcActionButton>
+			<NcActionButton>Option 3.2</NcActionButton>
+			<NcActionButton>Option 3.3</NcActionButton>
+		</template>
+	</NcActions>
+</template>
+```
+
 ## NcActions children limitations
 
 `<NcActions>` is supposed to be used with direct `<NcAction*>` children.
@@ -959,6 +992,8 @@ import { useElementBounding, useWindowSize } from '@vueuse/core'
 import Vue, { ref, computed, toRef } from 'vue'
 
 import IconDotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
+import IconArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import NcActionButton from '../NcActionButton/NcActionButton.vue'
 
 const focusableSelector = '.focusable'
 
@@ -990,6 +1025,7 @@ export default {
 			 * @type {import('vue').ComputedRef<boolean>}
 			 */
 			'NcActions:isSemanticMenu': computed(() => this.actionsMenuSemanticType === 'menu'),
+			'NcActions:openSubmenu': this.pushSubmenu,
 		}
 	},
 
@@ -1208,6 +1244,8 @@ export default {
 		return {
 			opened: this.open,
 			focusIndex: 0,
+			submenuStack: [],
+			submenuIndexStack: [],
 			/**
 			 * @type {'menu'|'expanded'|'dialog'|'tooltip'|'unknown'}
 			 */
@@ -1407,6 +1445,22 @@ export default {
 			}
 		},
 
+		pushSubmenu(submenu) {
+			this.submenuStack.push(submenu)
+			this.submenuIndexStack.push(this.focusIndex)
+			this.$nextTick(() => {
+				this.focusFirstAction()
+			})
+		},
+
+		popSubmenu() {
+			this.submenuStack.pop()
+			this.focusIndex = this.submenuIndexStack.pop()
+			this.$nextTick(() => {
+				this.focusAction()
+			})
+		},
+
 		// MENU STATE MANAGEMENT
 		openMenu(e) {
 			if (this.opened) {
@@ -1429,6 +1483,12 @@ export default {
 		},
 		async closeMenu(returnFocus = true) {
 			if (!this.opened) {
+				return
+			}
+
+			// Only close submenu
+			if (this.submenuStack.length) {
+				this.popSubmenu()
 				return
 			}
 
@@ -1615,6 +1675,14 @@ export default {
 			this.handleEscapePressed(event)
 		},
 
+		onKeyup(event) {
+			// Escape is handled globally on body by keydown
+			// Prevent floating-vue to handle it again on keyup
+			if (event.key === 'Escape') {
+				event.stopPropagation()
+			}
+		},
+
 		onTriggerKeydown(event) {
 			if (event.key === 'Escape') {
 				// Tooltip has no focusable elements and the focus remains on the trigger button.
@@ -1736,12 +1804,14 @@ export default {
 	 * @return {object|undefined} The created VNode
 	 */
 	render(h) {
+		const menuSlot = this.submenuStack.length ? `submenu:${this.submenuStack.at(-1)}` : 'default'
+
 		/**
 		 * Filter the Actions, so that we only get allowed components.
 		 * This also ensure that we don't get 'text' elements, which would
 		 * become problematic later on.
 		 */
-		const actions = (this.$slots.default || []).filter(action => this.getActionName(action))
+		const actions = (this.$slots[menuSlot] || []).filter(action => this.getActionName(action))
 
 		// Check that we have at least one action
 		if (actions.length === 0) {
@@ -1768,6 +1838,20 @@ export default {
 		 * @type {import('vue').VNode[]}
 		 */
 		const menuActions = actions.filter(action => !inlineActions.includes(action))
+
+		if (this.submenuStack.length) {
+			const backButton = h(NcActionButton, {
+				on: {
+					click: () => {
+						this.popSubmenu()
+					},
+				},
+			}, [
+				t('Back'),
+				h(IconArrowLeft, { slot: 'icon' }),
+			])
+			menuActions.unshift(backButton)
+		}
 
 		/**
 		 * Determine what kind of menu we have.
@@ -1968,6 +2052,7 @@ export default {
 							...this.config.popoverContainerA11yAttrs,
 						},
 						on: {
+							keyup: this.onKeyup,
 							keydown: this.onKeydown,
 							mousemove: this.onMouseFocusAction,
 						},
@@ -2054,7 +2139,7 @@ export default {
 				],
 			},
 			[
-				renderActionsPopover(actions),
+				renderActionsPopover(menuActions),
 			],
 		)
 	},


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud-libraries/nextcloud-vue/issues/6066

Add submenu feature:
- `NcActionButton`'s `is-menu` is now not only for an icon, but actually to handle a specific menu
- `#submenu:NAME` slot is uses to pass a specific submenu

Takes into account:
- Multi-level menu stack
- Adding "Back" button to return from a submenu
- <kbd>Escape</kbd> closes submenu instead on an entire menu
- After opening a menu the first element is on focus
- After closing submenu the focus returns to the menu button

To discus:
- `submenu` vs `menu` name for slot

### 🖼️ Screenshots

#### Docs

![image](https://github.com/user-attachments/assets/e1498296-e84a-4eea-962b-0d353ea44fe3)

#### In action

![NcActions-Submenu](https://github.com/user-attachments/assets/ee2411d6-a2f9-4e20-a22a-84d8cf531339)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
