### PR TITLE
feat(NcRichText): highlight code syntax if language provided

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ const ignorePatterns = [
 	'hast-*',
 	'is-*',
 	'longest-streak', // ESM dependency of remark-gfm
+	'lowlight', // ESM dependency of rehype-highlight
 	'markdown-table', // ESM dependency of remark-gfm
 	'mdast-util-*',
 	'micromark',

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
         "rehype-external-links": "^3.0.0",
+        "rehype-highlight": "^7.0.1",
         "rehype-react": "^7.1.2",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.0",
@@ -14852,6 +14853,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
@@ -14868,6 +14885,15 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hmac-drbg": {
@@ -19178,6 +19204,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.1.0.tgz",
+      "integrity": "sha512-CEbNVoSikAxwDMDPjXlqlFYiZLkDJHwyGu/MfOsJnF3d7f3tds5J3z8s/l9TMXhzfsJCCJEAsD78842mwmg0PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.9.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -23795,6 +23836,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.1.tgz",
+      "integrity": "sha512-dB/vVGFsbm7xPglqnYbg0ABg6rAuIWKycTvuXaOO27SgLoOFNoTlniTBtAxp3n5ZyMioW1a3KwiNqgjkb6Skjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-react": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-7.2.0.tgz",
@@ -28009,6 +28067,20 @@
       "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "linkify-string": "^4.0.0",
     "md5": "^2.3.0",
     "rehype-external-links": "^3.0.0",
+    "rehype-highlight": "^7.0.1",
     "rehype-react": "^7.1.2",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.0",

--- a/src/components/NcRichText/highlight.scss
+++ b/src/components/NcRichText/highlight.scss
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+* Colors and class selectors are extracted from source code of:
+* - library: highlight.js (v11.10.0)
+* - light theme: highlight.js/styles/github.css
+* - dark theme: highlight.js/styles/github-dark.css
+* and reworked to use with Nextcloud dark and light theme
+*/
+
+@mixin highlight-light-colors {
+	--hljs-color: var(--color-main-text, #24292e);
+	--hljs-background-color: var(--color-background-dark, #ffffff);
+	--hljs-syntax-keyword-color: #d73a49;
+	--hljs-syntax-entity-color: #6f42c1;
+	--hljs-syntax-constant-color: #005cc5;
+	--hljs-syntax-string-color: #032f62;
+	--hljs-syntax-variable-color: #e36209;
+	--hljs-syntax-comment-color: #6a737d;
+	--hljs-syntax-entity-tag-color: #22863a;
+	--hljs-syntax-storage-modifier-import-color: #24292e;
+	--hljs-syntax-markup-heading-color: #005cc5;
+	--hljs-syntax-markup-list-color: #735c0f;
+	--hljs-syntax-markup-italic-color: #24292e;
+	--hljs-syntax-markup-bold-color: #24292e;
+	--hljs-syntax-markup-inserted-color: #22863a;
+	--hljs-syntax-markup-inserted-background-color: #f0fff4;
+	--hljs-syntax-markup-deleted-color: #b31d28;
+	--hljs-syntax-markup-deleted-background-color: #ffeef0;
+}
+
+@mixin highlight-dark-colors {
+	--hljs-color: var(--color-main-text, #c9d1d9);
+	--hljs-background-color: var(--color-background-dark, #0d1117);
+	--hljs-syntax-keyword-color: #ff7b72;
+	--hljs-syntax-entity-color: #d2a8ff;
+	--hljs-syntax-constant-color: #79c0ff;
+	--hljs-syntax-string-color: #a5d6ff;
+	--hljs-syntax-variable-color: #ffa657;
+	--hljs-syntax-comment-color: #8b949e;
+	--hljs-syntax-entity-tag-color: #7ee787;
+	--hljs-syntax-storage-modifier-import-color: #c9d1d9;
+	--hljs-syntax-markup-heading-color: #1f6feb;
+	--hljs-syntax-markup-list-color: #f2cc60;
+	--hljs-syntax-markup-italic-color: #c9d1d9;
+	--hljs-syntax-markup-bold-color: #c9d1d9;
+	--hljs-syntax-markup-inserted-color: #aff5b4;
+	--hljs-syntax-markup-inserted-background-color: #033a16;
+	--hljs-syntax-markup-deleted-color: #ffdcd7;
+	--hljs-syntax-markup-deleted-background-color: #67060c;
+}
+
+@mixin highlight-rules {
+	pre:has(.hljs) {
+		color: var(--hljs-color);
+		background: var(--hljs-background-color);
+	}
+
+	.hljs-doctag,
+	.hljs-keyword,
+	.hljs-meta .hljs-keyword,
+	.hljs-template-tag,
+	.hljs-template-variable,
+	.hljs-type,
+	.hljs-variable.language_ {
+		/* prettylights-syntax-keyword */
+		color: var(--hljs-syntax-keyword-color);
+	}
+
+	.hljs-title,
+	.hljs-title.class_,
+	.hljs-title.class_.inherited__,
+	.hljs-title.function_ {
+		/* prettylights-syntax-entity */
+		color: var(--hljs-syntax-entity-color)
+	}
+
+	.hljs-attr,
+	.hljs-attribute,
+	.hljs-literal,
+	.hljs-meta,
+	.hljs-number,
+	.hljs-operator,
+	.hljs-variable,
+	.hljs-selector-attr,
+	.hljs-selector-class,
+	.hljs-selector-id {
+		/* prettylights-syntax-constant */
+		color: var(--hljs-syntax-constant-color);
+	}
+
+	.hljs-regexp,
+	.hljs-string,
+	.hljs-meta .hljs-string {
+		/* prettylights-syntax-string */
+		color: var(--hljs-syntax-string-color);
+	}
+
+	.hljs-built_in,
+	.hljs-symbol {
+		/* prettylights-syntax-variable */
+		color: var(--hljs-syntax-variable-color);
+	}
+
+	.hljs-comment,
+	.hljs-code,
+	.hljs-formula {
+		/* prettylights-syntax-comment */
+		color: var(--hljs-syntax-comment-color);
+	}
+
+	.hljs-name,
+	.hljs-quote,
+	.hljs-selector-tag,
+	.hljs-selector-pseudo {
+		/* prettylights-syntax-entity-tag */
+		color: var(--hljs-syntax-entity-tag-color);
+	}
+
+	.hljs-subst {
+		/* prettylights-syntax-storage-modifier-import */
+		color: var(--hljs-syntax-storage-modifier-import-color);
+	}
+
+	.hljs-section {
+		/* prettylights-syntax-markup-heading */
+		color: var(--hljs-syntax-markup-heading-color);
+		font-weight: bold
+	}
+
+	.hljs-bullet {
+		/* prettylights-syntax-markup-list */
+		color: var(--hljs-syntax-markup-list-color);
+	}
+
+	.hljs-emphasis {
+		/* prettylights-syntax-markup-italic */
+		color: var(--hljs-syntax-markup-italic-color);
+		font-style: italic
+	}
+
+	.hljs-strong {
+		/* prettylights-syntax-markup-bold */
+		color: var(--hljs-syntax-markup-bold-color);
+		font-weight: bold
+	}
+
+	.hljs-addition {
+		/* prettylights-syntax-markup-inserted */
+		color: var(--hljs-syntax-markup-inserted-color);
+		background-color: var(--hljs-syntax-markup-inserted-background-color);
+	}
+
+	.hljs-deletion {
+		/* prettylights-syntax-markup-deleted */
+		color: var(--hljs-syntax-markup-deleted-color);
+		background-color: var(--hljs-syntax-markup-deleted-background-color);
+	}
+
+	.hljs-char.escape_,
+	.hljs-link,
+	.hljs-params,
+	.hljs-property,
+	.hljs-punctuation,
+	.hljs-tag {
+		/* purposely ignored */
+	}
+}

--- a/src/components/NcRichText/richtext.scss
+++ b/src/components/NcRichText/richtext.scss
@@ -2,10 +2,12 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
- 
- /**
+
+/**
  * Styles are extracted to extract scss to dist folder, too.
  */
+
+@import './highlight.scss';
 
 li.task-list-item > ul,
 li.task-list-item > ol,
@@ -214,5 +216,30 @@ li.task-list-item > pre {
 		padding-left: 13px;
 		border-left: 2px solid var(--color-border-dark);
 		color: var(--color-text-lighter);
+	}
+}
+
+/**
+* Highlight code syntax in code blocks
+*/
+.rich-text--wrapper-markdown {
+	@include highlight-rules;
+}
+
+@media (prefers-color-scheme: light) {
+	.rich-text--wrapper-markdown {
+		@include highlight-light-colors;
+	}
+	[data-theme-dark] .rich-text--wrapper-markdown {
+		@include highlight-dark-colors;
+	}
+}
+
+@media (prefers-color-scheme: dark) {
+	.rich-text--wrapper-markdown {
+		@include highlight-dark-colors;
+	}
+	[data-theme-light] .rich-text--wrapper-markdown {
+		@include highlight-light-colors;
 	}
 }

--- a/tests/unit/components/NcRichText/NcRichText.spec.js
+++ b/tests/unit/components/NcRichText/NcRichText.spec.js
@@ -5,6 +5,7 @@
 
 import { mount } from '@vue/test-utils'
 import NcRichText from '../../../../src/components/NcRichText/NcRichText.vue'
+import { nextTick } from 'vue'
 
 describe('NcRichText', () => {
 	it('renders a message and responds correctly to props changes', async () => {
@@ -206,5 +207,20 @@ describe('NcRichText', () => {
 		expect(checkbox.exists()).toBeTruthy()
 		await checkbox.vm.$emit('update:checked', true)
 		expect(wrapper.emitted()['interact:todo']).toBeTruthy()
+	})
+
+	it('properly defines syntax in code blocks and highlights it', async () => {
+		const wrapper = mount(NcRichText, {
+			propsData: {
+				text: '```js\nconsole.log(\'hello world\')\n```',
+				autolink: false,
+				useExtendedMarkdown: true,
+			},
+		})
+		expect(wrapper.text()).toEqual('console.log(\'hello world\')')
+		expect(wrapper.find('code').classes()).toEqual(['language-js'])
+		await nextTick()
+		await nextTick()
+		expect(wrapper.find('code').classes()).toEqual(['hljs', 'language-js'])
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/spreed/issues/13687
- install rehype-highlight lib v7.0.1
- use when render markdown
- apply colors from github light/dark theming

Supported languages: https://github.com/wooorm/lowlight/blob/main/lib/common.js

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="270" alt="image" src="https://github.com/user-attachments/assets/6a6e1529-32a6-4fca-9a05-8c95ab1ea49a"> | <img width="238" alt="image" src="https://github.com/user-attachments/assets/554c9ea4-99b8-4fed-a992-7e2a939994dc">
<img width="518" alt="image" src="https://github.com/user-attachments/assets/fa5cc959-f8b9-4257-9fc6-2910aae25d0b"> | <img width="510" alt="image" src="https://github.com/user-attachments/assets/b4215776-166c-4634-9b01-cb2b847b83a3">
<img width="510" alt="image" src="https://github.com/user-attachments/assets/9858c421-a55a-4076-9f8d-4198a738155d"> | <img width="512" alt="image" src="https://github.com/user-attachments/assets/0264fec4-a0cd-4c0d-9458-8d427e861b5c">

### 🚧 Tasks

- [x] Introduce new prop?
  - We don't support language syntax before, so `use-extended-markdown` without providing lang prefix would work as before
- [ ] Color themes?
  - I haven't found a better way to do it (see PR). Suggestions are welcome

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
