### PR TITLE
docs: add missing `useIsDarkTheme` import

### DIFF
--- a/styleguide/global.requires.js
+++ b/styleguide/global.requires.js
@@ -12,6 +12,7 @@ import { isA11yActivation } from '../src/functions/a11y/index.ts'
 import { EmojiSkinTone, emojiSearch, emojiAddRecent, getCurrentSkinTone, setCurrentSkinTone } from '../src/functions/emoji/index.ts'
 import { spawnDialog } from '../src/functions/dialog/index.ts'
 import usernameToColor from '../src/functions/usernameToColor/index.js'
+import { useIsDarkTheme } from '../src/composables/useIsDarkTheme/index.ts'
 import NcDialog from '../src/components/NcDialog/index.js'
 
 const USER_GROUPS = [


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/6214