### PR TITLE
fix(NcRichContenteditable): do not break adjacent mentions

### DIFF
--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -73,8 +73,6 @@ export default {
 		 */
 		parseContent(content) {
 			let text = content
-			// Consecutive spaces in HTML tags should collapse
-			text = text.replace(/>\s+</g, '><')
 			// Replace break lines with new lines
 			text = text.replace(/<br>/gmi, '\n')
 			// Replace some html special characters
@@ -115,8 +113,10 @@ export default {
 					: `@"${value}"`
 			}
 
-			// Return template and make sure we strip of new lines and tabs
-			return this.renderComponentHtml(data, NcMentionBubble).replace(/[\n\t]/gmi, '')
+			// Return template and make sure we strip off new lines, tabs and consecutive whitespaces
+			return this.renderComponentHtml(data, NcMentionBubble)
+				.replace(/[\n\t]/gmi, '')
+				.replace(/>\s+</g, '><')
 		},
 
 		/**

--- a/tests/unit/mixins/richEditor.spec.js
+++ b/tests/unit/mixins/richEditor.spec.js
@@ -60,10 +60,37 @@ describe('richEditor.js', () => {
 					},
 				},
 			})
-			const input = 'hello @jdoe'
+			const input = 'hello @jdoe!\nhow are you?'
 			const output = editor.vm.renderContent(input)
 
-			expect(output).toMatch(/^hello <span.+role="heading" title="J. Doe"/)
+			expect(output).toMatch(/^hello <span.+role="heading" title="J. Doe".+\/span>!<br>how are you\?$/)
+			expect(output).not.toMatch(/[\n\t]/gmi)
+			expect(output).not.toMatch(/>\s+</g)
+		})
+
+		it('keeps adjacent mentions with user data', () => {
+			const editor = shallowMount(TestEditor, {
+				propsData: {
+					userData: {
+						jdoe: {
+							id: 'jdoe',
+							label: 'J. Doe',
+							source: 'users',
+							icon: 'icon-user',
+						},
+						'guest/47e0a7cf': {
+							id: 'guest/47e0a7cf',
+							label: 'J. Guest',
+							source: 'emails',
+							icon: 'icon-user',
+						},
+					},
+				},
+			})
+			const input = 'hello @jdoe @"guest/47e0a7cf"! how are you?'
+			const output = editor.vm.renderContent(input)
+
+			expect(output).toMatch(/^hello <span.+role="heading" title="J. Doe".+\/span> <span.+role="heading" title="J. Guest".+\/span>! how are you\?$/)
 		})
 
 		it('keep mentions with special characters', () => {

--- a/tests/unit/mixins/richEditor.spec.js
+++ b/tests/unit/mixins/richEditor.spec.js
@@ -29,6 +29,9 @@ describe('richEditor.js', () => {
 			const output = editor.vm.renderContent(input)
 
 			expect(output).toEqual('hard<br>break')
+
+			const parsedOutput = editor.vm.parseContent(output)
+			expect(parsedOutput).toEqual(input)
 		})
 
 		it('no duplicated ampersand (from Linkify)', () => {
@@ -37,6 +40,9 @@ describe('richEditor.js', () => {
 			const output = editor.vm.renderContent(input)
 
 			expect(output).toEqual('hello &amp;')
+
+			const parsedOutput = editor.vm.parseContent(output)
+			expect(parsedOutput).toEqual(input)
 		})
 
 		it('keeps mentions without user data', () => {
@@ -45,6 +51,9 @@ describe('richEditor.js', () => {
 			const output = editor.vm.renderContent(input)
 
 			expect(output).toEqual('hello @foobar')
+
+			const parsedOutput = editor.vm.parseContent(output)
+			expect(parsedOutput).toEqual(input)
 		})
 
 		it('keeps mentions with user data', () => {
@@ -66,6 +75,9 @@ describe('richEditor.js', () => {
 			expect(output).toMatch(/^hello <span.+role="heading" title="J. Doe".+\/span>!<br>how are you\?$/)
 			expect(output).not.toMatch(/[\n\t]/gmi)
 			expect(output).not.toMatch(/>\s+</g)
+
+			const parsedOutput = editor.vm.parseContent(output)
+			expect(parsedOutput).toEqual(input)
 		})
 
 		it('keeps adjacent mentions with user data', () => {
@@ -91,6 +103,9 @@ describe('richEditor.js', () => {
 			const output = editor.vm.renderContent(input)
 
 			expect(output).toMatch(/^hello <span.+role="heading" title="J. Doe".+\/span> <span.+role="heading" title="J. Guest".+\/span>! how are you\?$/)
+
+			const parsedOutput = editor.vm.parseContent(output)
+			expect(parsedOutput).toEqual(input)
 		})
 
 		it('keep mentions with special characters', () => {
@@ -119,6 +134,9 @@ describe('richEditor.js', () => {
 			for (const i in inputs) {
 				const output = editor.vm.renderContent(inputs[i])
 				expect(output).toEqual(outputs[i])
+
+				const parsedOutput = editor.vm.parseContent(output)
+				expect(parsedOutput).toEqual(inputs[i])
 			}
 		})
 	})


### PR DESCRIPTION
### ☑️ Resolves

- when injecting HTML template, newlines, tabs and consecutive whitespaces should be stripped
- when parsing innerHTML (reverse process), collapsing of whitespacing also affecting two adjacent HTML templates
- parsed ids without whitespace will be joined and won't be rendered next time

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![2024-11-15_23h10_42](https://github.com/user-attachments/assets/b5590822-8c79-4fe7-ab1d-7f25d550d679) | ![2024-11-15_23h10_06](https://github.com/user-attachments/assets/205c9852-0771-4b87-8857-e6cafdc36be7)


### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
