### PR TITLE
fix(NcAppNavigationItem): TypeError: this.$refs.actions.$refs.menuButton is undefined

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -753,10 +753,10 @@ export default {
 			}
 			if (this.focused) {
 				e.preventDefault()
-				this.$refs.actions.$refs.menuButton.$el.focus()
+				this.$refs.actions.$refs.triggerButton.$el.focus()
 				this.focused = false
 			} else {
-				this.$refs.actions.$refs.menuButton.$el.blur()
+				this.$refs.actions.$refs.triggerButton.$el.blur()
 			}
 		},
 


### PR DESCRIPTION
### ☑️ Resolves 

- Fix #6225

menuButton was renamed to triggerButton in e817174f4

```
@@ -1883,7 +1900,7 @@ export default {
                                                        disabled: this.disabled,
                                                },
                                                slot: 'trigger',
-                                               ref: 'menuButton',
+                                               ref: 'triggerButton',
                                                attrs: {
                                                        id: this.triggerRandomId,
                                                        'aria-label': this.menuName ? null : this.ariaLabel,

```

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
