### PR TITLE
fix: make sure model event in `v-model` is the first to avoid regression

### DIFF
--- a/src/composables/useModelMigration.ts
+++ b/src/composables/useModelMigration.ts
@@ -28,12 +28,12 @@ export function useModelMigration(oldModelName, oldModelEvent, required = false)
 		},
 
 		set(value) {
-			// Old nextcloud-vue v8 event
-			vm.$emit(oldModelEvent, value)
 			// New nextcloud-vue v9 event
 			vm.$emit('update:modelValue', value)
 			// Vue 2 fallback for kebab-case event names in templates (recommended by Vue 3 style guide)
 			vm.$emit('update:model-value', value)
+			// Old nextcloud-vue v8 event
+			vm.$emit(oldModelEvent, value)
 		},
 	})
 


### PR DESCRIPTION
### ☑️ Resolves

- Regression from: https://github.com/nextcloud-libraries/nextcloud-vue/pull/6172
- Fixes: https://github.com/nextcloud/server/issues/49335/
- https://github.com/nextcloud/server/pull/49343/

`v-model` event was fired later than the original like `input` or `update:value`. As a result - old event handlers were executed before the model value is actually updated

Solution: trigger the event defined in the `model` option first. Also, `update:modelValue` should be before `update:model-value`, but it was correct

To test: log model value from value update event from any component with `v-model`

```vue
<NcSelect
  v-model="value"
  @input="log('input', value)"
  @update:model-value="log('model-value', value)"
  @update:modelValue="log('modelValue', value)"
/>

<NcInputField
  v-model="value"
  @update:value="log('value', value)"
  @update:model-value="log('model-value', value)"
  @update:modelValue="log('modelValue', value)"
/>
```

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/0ec7e12d-9304-4aaf-9e5d-a0ac8fb8a49e) | ![image](https://github.com/user-attachments/assets/1cb081a7-a565-46ce-a84b-71c2b4af327f)
![image](https://github.com/user-attachments/assets/217a4d09-7218-48fe-a7dd-c595c9c28946) | ![image](https://github.com/user-attachments/assets/65bc4bc6-7412-42c2-87cc-d044f5013554)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
