### PR TITLE
fix(NcTextField): don't fire value updating events twice

### DIFF
--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -123,8 +123,7 @@ export default {
 <template>
 	<NcInputField v-bind="propsAndAttrsToForward"
 		ref="inputField"
-		v-on="$listeners"
-		@input="handleInput">
+		v-on="$listeners">
 		<!-- Default slot for the leading icon -->
 		<slot />
 
@@ -263,10 +262,6 @@ export default {
 		 */
 		select() {
 			this.$refs.inputField.select()
-		},
-
-		handleInput(event) {
-			this.model = event.target.value
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

- Events are fired twice:
  - Once in `@input="handleInput"` which results in `$emit('update:value', $event.target.value)`
  - Once in `v-on="$listeners"` which equivalent to `@update:value="$emit('update:value', $event)"`
- Before `v-model` compatibility it was only for `update:value` event. Now also for all the `modelValue` events

Handling input manually is not needed, it's handled by `NcInputField`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/baaa897e-7a5d-424a-b43b-33a7438a9102) | ![image](https://github.com/user-attachments/assets/b175d041-e2b2-4c37-8040-c9766e839e83)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
