### PR TITLE
fix(NcRichContenteditable): fix pasted text handling

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -782,23 +782,13 @@ export default {
 			const text = clipboardData.getData('text')
 			const selection = window.getSelection()
 
-			// If no selection, replace the whole data
-			if (!selection.rangeCount) {
-				this.updateValue(text)
-				return
-			}
-
 			// Generate text and insert
 			const range = selection.getRangeAt(0)
-			selection.deleteFromDocument()
+			range.deleteContents()
 			range.insertNode(document.createTextNode(text))
 
-			// Put cursor at the end of the selection
-			const newRange = document.createRange()
-			newRange.setStart(event.target, range.endOffset)
-			newRange.collapse(true)
-			selection.removeAllRanges()
-			selection.addRange(newRange)
+			// Collapse the range to the end position
+			range.collapse(false)
 
 			// Propagate data
 			this.updateValue(this.$refs.contenteditable.innerHTML)

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -800,7 +800,8 @@ export default {
 		 * @param {string} htmlOrText the html content (or raw text with @mentions)
 		 */
 		updateValue(htmlOrText) {
-			const text = this.parseContent(htmlOrText)
+			// Browsers keep <br> after erasing contenteditable
+			const text = this.parseContent(htmlOrText).replace(/^\n$/, '')
 			this.localValue = text
 			this.model = text
 		},


### PR DESCRIPTION
### ☑️ Resolves

- Fix #4821

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![pasted-text](https://github.com/user-attachments/assets/d84927c2-1355-4b25-b6fa-570bee7bfbae) | ![pasted-text-fixed](https://github.com/user-attachments/assets/4e0f53cc-ea55-4c73-9660-2e025f6818a7)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
