### PR TITLE
chore(NcAppSidebarTabs): remove internal component from docs

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -231,7 +231,8 @@ module.exports = async () => {
 							{
 								name: 'NcAppSidebar',
 								components: [
-									'src/components/NcAppSidebar*/*.vue',
+									'src/components/NcAppSidebar/NcAppSidebar.vue',
+									'src/components/NcAppSidebarTab/NcAppSidebarTab.vue',
 								],
 							},
 							{


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud-libraries/nextcloud-vue/issues/6252

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
