### PR TITLE
fix(NcAppNavigation): Fix sidebar position in RTL and mobile mode.

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -327,7 +327,7 @@ export default {
 	max-width: var(--app-navigation-max-width);
 	position: relative;
 	top: 0;
-	left: 0;
+	inset-inline-start: 0;
 	padding: 0px;
 	// Above NcAppContent
 	z-index: 1800;


### PR DESCRIPTION
### ☑️ Resolves  

- Fix #6217 

So, in RTL mode, the sidebar slides from the right not the left like in LTR mode.
Now, we have to adjust apps headers margins and padding for RTL mode to accomedate the toggle button that'll be displayed on the right.


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/bd14f28b-0a66-49c8-abca-1de42b6eca92) | ![image](https://github.com/user-attachments/assets/ad9ff20f-d16a-4065-a6f2-106ec69027be)


Best
