### PR TITLE
fix(NcAppContent): don't remove list when showing details in mobile or no-split mode

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -107,8 +107,10 @@ export default {
 					'app-content-wrapper--mobile': isMobile,}">
 				<NcAppDetailsToggle v-if="showDetails" @click.native.stop.prevent="hideDetails" />
 
-				<slot v-if="!showDetails" name="list" />
-				<slot v-else />
+				<div v-show="!showDetails">
+					<slot name="list" />
+				</div>
+				<slot v-if="showDetails" />
 			</div>
 			<div v-else-if="layout === 'vertical-split' || layout === 'horizontal-split'" class="app-content-wrapper">
 				<Splitpanes :horizontal="layout === 'horizontal-split'"


### PR DESCRIPTION
### ☑️ Resolves

- Fix #6204

As mentioned in #6204 the change in 8.10.0 causes the item list to rebuild every time the details of an item are shown.
With a dynamic list like in the news app, where read items are removed from the list when refreshing it, this means that the selected item you looked at the details are gone immediately when you close the details.
It also affects the performance, because of the rebuilding when closing the details, which is notable on mobile devices.

I think there is no technical reason to delete it, so it is better to just hide the list.

