### PR TITLE
style(NcCheckboxRadioSwitch): fix styles in disabled state

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -690,6 +690,10 @@ export default {
 		:deep(.checkbox-radio-switch__icon) > * {
 			color: var(--color-main-text)
 		}
+		&.checkbox-content,
+		&.checkbox-content :deep(*:not(a)) {
+			cursor: default !important;
+		}
 	}
 
 	&:not(&--disabled, &--checked):focus-within &__content,


### PR DESCRIPTION
### ☑️ Resolves

- set default cursor to content of disable component
- unless there is a nested clickable link (like interactive todo lists in NcRichtext)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/73566c2e-8016-474c-a2d0-fd52715d6e88) | ![image](https://github.com/user-attachments/assets/6cc5462f-8ed2-4c80-b890-b86da62f9be6)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
