### PR TITLE
fix(NcModal): make 'Close' button the last element for the focus-trap

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -289,6 +289,10 @@ export default {
 
 					<!-- Content -->
 					<div :id="'modal-description-' + randId" class="modal-container">
+						<div class="modal-container__content">
+							<!-- @slot Modal content to render -->
+							<slot />
+						</div>
 						<!-- Close modal -->
 						<NcButton v-if="canClose && closeButtonContained"
 							type="tertiary"
@@ -299,10 +303,6 @@ export default {
 								<Close :size="20" />
 							</template>
 						</NcButton>
-						<div class="modal-container__content">
-							<!-- @slot Modal content to render -->
-							<slot />
-						</div>
 					</div>
 
 					<!-- Navigation button -->


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/spreed/issues/13867
- Button is mounted before content slot, therefor it's the first element to get into focus trap

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/875be1d2-0ccb-4a5b-b94b-809dced35e00) | ![image](https://github.com/user-attachments/assets/69691e23-c5b8-4e5f-b6a4-bf12f8325d9e)
![image](https://github.com/user-attachments/assets/75f8e177-3651-4f9f-a652-886c8d9ccb61) | ![image](https://github.com/user-attachments/assets/4d8f7ae2-7a79-405e-a1b8-7f2e8c291941)

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
