### PR TITLE
fix: Fix avatar title not shown when component used without menu

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -153,6 +153,7 @@ export default {
 </docs>
 <template>
 	<span ref="main"
+		:title="tooltip"
 		v-click-outside="closeMenu"
 		:class="{
 			'avatardiv--unknown': userDoesNotExist,
@@ -177,7 +178,6 @@ export default {
 			type="tertiary-no-background"
 			class="action-item action-item__menutoggle"
 			:aria-label="avatarAriaLabel"
-			:title="tooltip"
 			@click="toggleMenu">
 			<template #icon>
 				<NcLoadingIcon v-if="contactsMenuLoading" />
@@ -191,7 +191,6 @@ export default {
 			:container="menuContainer"
 			:open.sync="contactsMenuOpenState"
 			:aria-label="avatarAriaLabel"
-			:title="tooltip"
 			@click="toggleMenu">
 			<component :is="item.ncActionComponent"
 				v-for="(item, key) in menu"


### PR DESCRIPTION
### ☑️ Resolves
Right now `title` not visible if `NcAvatar` used without menu. This PR fixes that by moving `title` to parent `span` element.

### 🖼️ Screenshots
<details><summary>:mag: Preview after fix</summary>
<p>

![image](https://github.com/user-attachments/assets/f345f06e-bb92-4ff1-9992-ae4cefb013cd)

</p>
</details> 

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
