### PR TITLE
fix(NcRichContenteditable): prevent content from overflowing

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -1010,6 +1010,9 @@ export default {
 <style lang="scss" scoped>
 // Standalone styling, independent from server
 .rich-contenteditable {
+	--contenteditable-block-offset: calc(2 * var(--default-grid-baseline));
+	--contenteditable-inline-start-offset: calc(2 * var(--default-grid-baseline));
+	--contenteditable-inline-end-offset: calc(2 * var(--default-grid-baseline));
 	position: relative;
 	width: auto;
 
@@ -1049,7 +1052,8 @@ export default {
 		overflow-y: auto;
 		width: auto;
 		margin: 0;
-		padding: 8px;
+		padding-block: var(--contenteditable-block-offset);
+		padding-inline: var(--contenteditable-inline-start-offset) var(--contenteditable-inline-end-offset);
 		cursor: text;
 		white-space: pre-wrap;
 		word-break: break-word;
@@ -1073,8 +1077,8 @@ export default {
 			content: attr(aria-placeholder);
 			color: var(--color-text-maxcontrast);
 			position: absolute;
-			width: calc(100% - 2 * 8px);
-			height: calc(100% - 2 * 8px);
+			width: calc(100% - var(--contenteditable-inline-start-offset) - var(--contenteditable-inline-end-offset));
+			height: calc(100% - 2 * var(--contenteditable-block-offset));
 			overflow: hidden;
 			white-space: nowrap;
 			text-overflow: ellipsis;

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -1015,7 +1015,7 @@ export default {
 
 	&__label {
 		position: absolute;
-		margin-inline: 14px 0;
+		margin-inline: 14px;
 		max-width: fit-content;
 		inset-block-start: 11px;
 		inset-inline: 0;
@@ -1040,7 +1040,7 @@ export default {
 		border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0;
 		background-color: var(--color-main-background);
 		padding-inline: 5px;
-		margin-inline-start: 9px;
+		margin-inline: 9px;
 
 		transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick);
 	}
@@ -1073,6 +1073,11 @@ export default {
 			content: attr(aria-placeholder);
 			color: var(--color-text-maxcontrast);
 			position: absolute;
+			width: calc(100% - 2 * 8px);
+			height: calc(100% - 2 * 8px);
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
 		}
 
 		&[contenteditable='false']:not(&--disabled) {


### PR DESCRIPTION
### ☑️ Resolves

- Fix overflowing of content with long label/placeholder

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="461" alt="image" src="https://github.com/user-attachments/assets/3d42eb19-af0e-4153-b273-15096b111dce" /> | <img width="464" alt="image" src="https://github.com/user-attachments/assets/ad10087c-56c2-494b-9cf2-40a51f49c36a" />
<img width="255" alt="image" src="https://github.com/user-attachments/assets/b350abb4-fb94-4212-9120-49ff24f0e68b" /> | <img width="254" alt="image" src="https://github.com/user-attachments/assets/879238d6-e2f8-4925-bdf7-8f61e691b72b" />

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
