### PR TITLE
fix(NcColorPicker): close popover on submit event

### DIFF
--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -71,7 +71,7 @@ export default {
 <template>
 	<div class="container1">
 		<NcButton @click="open = !open"> Click Me </NcButton>
-		<NcColorPicker :model-value="color" @update:model-value="updateColor" :shown.sync="open" @submit="open = false" v-slot="{ attrs }">
+		<NcColorPicker :model-value="color" @update:model-value="updateColor" :shown.sync="open" v-slot="{ attrs }">
 			<div v-bind="attrs" :style="{'background-color': color}" class="color1" />
 		</NcColorPicker>
 	</div>
@@ -150,57 +150,59 @@ export default {
 		<template #trigger="slotProps">
 			<slot v-bind="slotProps" />
 		</template>
-		<div role="dialog"
-			class="color-picker"
-			aria-modal="true"
-			:aria-label="t('Color picker')"
-			:class="{ 'color-picker--advanced-fields': advanced && advancedFields }">
-			<Transition name="slide" mode="out-in">
-				<div v-if="!advanced" class="color-picker__simple">
-					<label v-for="({ color, name }, index) in normalizedPalette"
-						:key="index"
-						:style="{ backgroundColor: color }"
-						class="color-picker__simple-color-circle"
-						:class="{ 'color-picker__simple-color-circle--active' : color === currentColor }">
-						<Check v-if="color === currentColor" :size="20" :fill-color="contrastColor" />
-						<input type="radio"
-							class="hidden-visually"
-							:aria-label="name"
-							:name="`color-picker-${uid}`"
-							:checked="color === currentColor"
-							@click="pickColor(color)">
-					</label>
+		<template #default="slotProps">
+			<div role="dialog"
+				class="color-picker"
+				aria-modal="true"
+				:aria-label="t('Color picker')"
+				:class="{ 'color-picker--advanced-fields': advanced && advancedFields }">
+				<Transition name="slide" mode="out-in">
+					<div v-if="!advanced" class="color-picker__simple">
+						<label v-for="({ color, name }, index) in normalizedPalette"
+							:key="index"
+							:style="{ backgroundColor: color }"
+							class="color-picker__simple-color-circle"
+							:class="{ 'color-picker__simple-color-circle--active' : color === currentColor }">
+							<Check v-if="color === currentColor" :size="20" :fill-color="contrastColor" />
+							<input type="radio"
+								class="hidden-visually"
+								:aria-label="name"
+								:name="`color-picker-${uid}`"
+								:checked="color === currentColor"
+								@click="pickColor(color)">
+						</label>
+					</div>
+					<Chrome v-else
+						v-model="currentColor"
+						class="color-picker__advanced"
+						:disable-alpha="true"
+						:disable-fields="!advancedFields"
+						@input="pickColor" />
+				</Transition>
+				<div v-if="!paletteOnly" class="color-picker__navigation">
+					<NcButton v-if="advanced"
+						type="tertiary"
+						:aria-label="ariaBack"
+						@click="handleBack">
+						<template #icon>
+							<ArrowLeft :size="20" />
+						</template>
+					</NcButton>
+					<NcButton v-else
+						type="tertiary"
+						:aria-label="ariaMore"
+						@click="handleMoreSettings">
+						<template #icon>
+							<DotsHorizontal :size="20" />
+						</template>
+					</NcButton>
+					<NcButton type="primary"
+						@click="handleConfirm(slotProps.hide)">
+						{{ t('Choose') }}
+					</NcButton>
 				</div>
-				<Chrome v-else
-					v-model="currentColor"
-					class="color-picker__advanced"
-					:disable-alpha="true"
-					:disable-fields="!advancedFields"
-					@input="pickColor" />
-			</Transition>
-			<div v-if="!paletteOnly" class="color-picker__navigation">
-				<NcButton v-if="advanced"
-					type="tertiary"
-					:aria-label="ariaBack"
-					@click="handleBack">
-					<template #icon>
-						<ArrowLeft :size="20" />
-					</template>
-				</NcButton>
-				<NcButton v-else
-					type="tertiary"
-					:aria-label="ariaMore"
-					@click="handleMoreSettings">
-					<template #icon>
-						<DotsHorizontal :size="20" />
-					</template>
-				</NcButton>
-				<NcButton type="primary"
-					@click="handleConfirm">
-					{{ t('Choose') }}
-				</NcButton>
 			</div>
-		</div>
+		</template>
 	</NcPopover>
 </template>
 
@@ -363,13 +365,14 @@ export default {
 
 		/**
 		 * Submit a picked colour and close picker
+		 * @param {Function} hideCallback callback to close popover
 		 */
-		handleConfirm() {
+		handleConfirm(hideCallback) {
 			/**
 			 * Emits a hexadecimal string e.g. '#ffffff'
 			 */
 			this.$emit('submit', this.currentColor)
-			this.handleClose()
+			hideCallback()
 
 			this.advanced = false
 		},

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -157,8 +157,8 @@ See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/
 		</NcPopoverTriggerProvider>
 
 		<!-- This will be the content of the popover -->
-		<template #popper>
-			<slot />
+		<template #popper="slotProps">
+			<slot name="default" v-bind="slotProps" />
 		</template>
 	</Dropdown>
 </template>


### PR DESCRIPTION
### ☑️ Resolves

- Fix stale button (`submit` should close Popover by the code, but it's not)
- Whitespaces hidden: https://github.com/nextcloud-libraries/nextcloud-vue/pull/6336/files?w=1

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![2024-12-27_13h10_28](https://github.com/user-attachments/assets/bedcf337-67c7-4047-9c56-22cc776d5ef4) | ![2024-12-27_13h09_37](https://github.com/user-attachments/assets/480dd903-8a80-4bf9-bc11-6090bfc11870)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
