### PR TITLE
fix(NcPopover): emit `after-show` after `focus-trap` init to correctly return focus when content set focus initially (e.g. `NcEmojiPicker`)

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -376,29 +376,29 @@ export default {
 			}
 		},
 
-		afterShow() {
+		async afterShow() {
 			this.removeFloatingVueAriaDescribedBy()
 
-			this.$nextTick(() => {
-				/**
-				 * Triggered after the tooltip was visually displayed.
-				 *
-				 * This is different from the 'show' and 'apply-show' which
-				 * run earlier than this where there is no guarantee that the
-				 * tooltip is already visible and in the DOM.
-				 */
-				this.$emit('after-show')
-				this.useFocusTrap()
-				this.addEscapeStopPropagation()
-			})
+			await this.$nextTick()
+			await this.useFocusTrap()
+			this.addEscapeStopPropagation()
+
+			/**
+			 * Triggered after the tooltip was visually displayed.
+			 *
+			 * This is different from the 'show' and 'apply-show' which
+			 * run earlier than this where there is no guarantee that the
+			 * tooltip is already visible and in the DOM.
+			 */
+			this.$emit('after-show')
 		},
 		afterHide() {
+			this.clearFocusTrap()
+			this.clearEscapeStopPropagation()
 			/**
 			 * Triggered after the tooltip was visually hidden.
 			 */
 			this.$emit('after-hide')
-			this.clearFocusTrap()
-			this.clearEscapeStopPropagation()
 		},
 	},
 }

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -170,6 +170,11 @@ import { createFocusTrap } from 'focus-trap'
 import { getTrapStack } from '../../utils/focusTrap.js'
 import NcPopoverTriggerProvider from './NcPopoverTriggerProvider.vue'
 
+/**
+ * @typedef {import('focus-trap').FocusTargetValueOrFalse} FocusTargetValueOrFalse
+ * @typedef {FocusTargetValueOrFalse|() => FocusTargetValueOrFalse} SetReturnFocus
+ */
+
 export default {
 	name: 'NcPopover',
 
@@ -214,11 +219,11 @@ export default {
 		/**
 		 * Set element to return focus to after focus trap deactivation
 		 *
-		 * @type {import('focus-trap').FocusTargetValueOrFalse}
+		 * @type {SetReturnFocus}
 		 */
 		setReturnFocus: {
 			default: undefined,
-			type: [HTMLElement, SVGElement, String, Boolean],
+			type: [HTMLElement, SVGElement, String, Boolean, Function],
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/6341

`after-show` was triggered before the end of init, including focusing on the elements using `focus-trap`.

This broke `focus-trap` auto return focus when `NcPopover` content focused an element on `after-show`, making it the element to return focus to.

Same for `after-hide`.

Additionally, fixed types of related `setReturnFocus`, which allows function

![image](https://github.com/user-attachments/assets/c835cdeb-c925-4676-bf66-24e7ee18a008)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
focus moves to `body` | focus returns to the trigger
![before](https://github.com/user-attachments/assets/ec5459b2-fe33-4dfe-8820-d5db9efdc3a3) | ![after](https://github.com/user-attachments/assets/584e382d-9c10-4cf6-b426-3626193b0518)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
