### PR TITLE
fix: timezone width breaking the timeslots

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1190,6 +1190,8 @@ body {
 	min-height: var(--default-clickable-area);
 	min-width: 260px;
 	margin: 0 0 var(--default-grid-baseline);
+	/* to make sure the timezone doesnt push the timeslots in a certain width container*/
+	max-width: 260px;
 
 	&.vs--open {
 		--vs-border-width: var(--border-width-input-focused, 2px);


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/calendar/issues/6570

if someone has a better idea, please let me know

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---

after
![Screenshot from 2025-01-06 11-56-57](https://github.com/user-attachments/assets/b7b073a1-7404-407b-9169-38a7e83ad324)



### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
