### PR TITLE
fix(NcRichContenteditable): remove value linkify

### DIFF
--- a/src/mixins/richEditor/index.js
+++ b/src/mixins/richEditor/index.js
@@ -4,7 +4,6 @@
  */
 
 import NcMentionBubble from '../../components/NcRichContenteditable/NcMentionBubble.vue'
-import Linkify from '../../utils/Linkify.js'
 
 import escapeHtml from 'escape-html'
 import stripTags from 'striptags'
@@ -51,8 +50,7 @@ export default {
 					// When splitting, the string is always putting the userIds
 					// on the uneven indexes. We only want to generate the mentions html
 					if (!part.startsWith('@')) {
-						// This part doesn't contain a mention, let's make sure links are parsed
-						return Linkify(part)
+						return part
 					}
 
 					// Extracting the id, nuking the leading @ and all "

--- a/tests/unit/mixins/richEditor.spec.js
+++ b/tests/unit/mixins/richEditor.spec.js
@@ -34,17 +34,6 @@ describe('richEditor.js', () => {
 			expect(parsedOutput).toEqual(input)
 		})
 
-		it('no duplicated ampersand (from Linkify)', () => {
-			const editor = shallowMount(TestEditor, { propsData: { userData: {} } })
-			const input = 'hello &'
-			const output = editor.vm.renderContent(input)
-
-			expect(output).toEqual('hello &amp;')
-
-			const parsedOutput = editor.vm.parseContent(output)
-			expect(parsedOutput).toEqual(input)
-		})
-
 		it('keeps mentions without user data', () => {
 			const editor = shallowMount(TestEditor, { propsData: { userData: {} } })
 			const input = 'hello @foobar'


### PR DESCRIPTION
### ☑️ Resolves

NcRichContenteditable has a hidden feature: when a content is set outside (not inputted ⚠️), it's linkified.

- Origin is https://github.com/nextcloud-libraries/nextcloud-vue/pull/1669/
- But it doesn't specify motivation

@juliusknorr @mejo- Could you confirm you don't rely on this behavior in text/collectives?

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/46692029-65cb-46e2-a3f2-5dee5909239e) | ![image](https://github.com/user-attachments/assets/dbac0a04-facf-4819-8ca1-f36f844b64b9)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
