### PR TITLE
[next] fix(NcActionButton): order in components

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -384,11 +384,7 @@ export default {
 		ChevronRightIcon,
 		ChevronLeftIcon,
 	},
-	setup() {
-		return {
-			isRTL: isRTL(),
-		}
-	},
+
 	mixins: [ActionTextMixin],
 
 	inject: {
@@ -464,6 +460,12 @@ export default {
 	},
 
 	emits: ['update:modelValue'],
+
+	setup() {
+		return {
+			isRTL: isRTL(),
+		}
+	},
 
 	computed: {
 		/**


### PR DESCRIPTION
### ☑️ Resolves

- Fix the `vue/order-in-components` lint warning