### PR TITLE
chore: release v9.0.0-alpha.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ index 0e3a6a705d..416b8b0fb9 100644
   This will return a new version name, make sure it matches what you expect
 - Generate the changelog content from the [release](https://github.com/nextcloud-libraries/nextcloud-vue/releases) page.
   Create a draft release, select the previous tag, click `generate` then paste the content to the `CHANGELOG.md` file
-  1. use the the version as tag AND title (e.g `v4.0.1`)
+  1. use the version as tag AND title (e.g `v4.0.1`)
   2. add the changelog content as description (https://github.com/nextcloud-libraries/nextcloud-vue/releases)
 - Commit, push and create PR
 - Get your PR reviewed and merged

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.0.0-alpha.5",
+  "version": "9.0.0-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "9.0.0-alpha.5",
+      "version": "9.0.0-alpha.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.0.0-alpha.5",
+  "version": "9.0.0-alpha.6",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.0.0-alpha.5...next

New release as per https://github.com/nextcloud-libraries/nextcloud-vue/issues/6106#issue-2538052334.

I don't have the permission to create a draft release and generate a changelog, so someone from the collaborators has to do that.

### Motivation

The Tasks app uses the v9 branch of this library. Since updating to Nextcloud v30, there are some "unpleasant" CSS issues. Those issue can be fixed by creating a new release with latest fixes from `next`.