### PR TITLE
doc: Do not override assets while building the styleguide

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -14,7 +14,7 @@
 ### Avatar with image
 
 ```vue
-	<NcAvatar url="https://nextcloud.com/wp-content/themes/next/assets/img/common/nextcloud-square-logo.png" />
+	<NcAvatar url="favicon-touch.png" />
 ```
 
 ### Avatar with material design icon

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -32,6 +32,10 @@ module.exports = async () => {
 			path.join(__dirname, 'styleguide/assets/additional.css'),
 			path.join(__dirname, 'styleguide/assets/styleguide.css'),
 		],
+
+		assetsDir: path.join(__dirname, 'styleguide/assets/img'),
+		styleguideDir: 'styleguide/build',
+
 		pagePerSection: true,
 		minimize: true,
 		verbose: false,


### PR DESCRIPTION
The output directory needs to be different from the input, otherwise the assets are overwritten and we can not use them (e.g. for the avatar).

This needs adjustments in Netlify to use `styleguide/build` for deployment instead of just `styleguide`. @juliusknorr 