### PR TITLE
chore(stylelint): `csstools/use-logical`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "node-polyfill-webpack-plugin": "^3.0.0",
         "resolve-url-loader": "^5.0.0",
         "sanitize-filename": "^1.6.3",
+        "stylelint-use-logical": "^2.1.2",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.4",
         "url-loader": "^4.1.1",
@@ -26611,6 +26612,19 @@
       "integrity": "sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/stylelint-use-logical": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/stylelint-use-logical/-/stylelint-use-logical-2.1.2.tgz",
+      "integrity": "sha512-4ffvPNk/swH4KS3izExWuzQOuzLmi0gb0uOhvxWJ20vDA5W5xKCjcHHtLoAj1kKvTIX6eGIN5xGtaVin9PD0wg==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": ">= 11 < 17"
+      }
     },
     "node_modules/stylelint/node_modules/ansi-regex": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "node-polyfill-webpack-plugin": "^3.0.0",
     "resolve-url-loader": "^5.0.0",
     "sanitize-filename": "^1.6.3",
+    "stylelint-use-logical": "^2.1.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4",
     "url-loader": "^4.1.1",

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -7,6 +7,7 @@ const stylelintConfig = require('@nextcloud/stylelint-config')
 
 module.exports = {
 	extends: ['@nextcloud/stylelint-config'],
+	plugins: ['stylelint-use-logical'],
 	rules: {
 		// For CSS Modules
 		// If there will be more rules for CSS Modules - consider extending stylelint-config-css-modules
@@ -14,6 +15,28 @@ module.exports = {
 			true,
 			{
 				ignorePseudoClasses: [...stylelintConfig.rules['selector-pseudo-class-no-unknown'][1].ignorePseudoClasses, 'global'],
+			},
+		],
+		'csstools/use-logical': [
+			'always',
+			{
+				severity: 'warning',
+				// Only lint LTR-RTL properties for now
+				except: [
+					// Position properties
+					'top',
+					'bottom',
+					// Position properties with directional suffixes
+					/-top$/,
+					/-bottom$/,
+					// Size properties
+					'width',
+					'max-width',
+					'min-width',
+					'height',
+					'max-height',
+					'min-height',
+				],
 			},
 		],
 	},


### PR DESCRIPTION
### ☑️ Resolves

- Check for using non-logical properties on CI
- Only a warning for now
- Auto-fixable, but each auto-fix should be checked manually
- Alternative: https://github.com/nextcloud-libraries/stylelint-config/pull/121

### 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/20009e7e-07ba-4c49-967a-3ae11cfa32f3)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
