### PR TITLE
fix(NcModal): Enforce opaque backdrop if needed

### DIFF
--- a/src/utils/ValidateSlot.js
+++ b/src/utils/ValidateSlot.js
@@ -26,8 +26,8 @@ const ValidateSlot = (slots, allowed, vm) => {
 
 		// if html element or not a vue component or vue component not in allowed tags
 		if (isHtmlElement || !isVueComponent || isForbiddenComponent) {
-			// only warn when html elment or forbidden component
-			// sometimes text nodes are present which are hardly removeable by the developer and spam the warnings
+			// only warn when html element or forbidden component
+			// sometimes text nodes are present which are hardly removable by the developer and spam the warnings
 			if (isHtmlElement || isForbiddenComponent) {
 				Vue.util.warn(`${isHtmlElement ? node.tag : node.componentOptions.tag} is not allowed inside the ${vm.$options.name} component`, vm)
 			}


### PR DESCRIPTION
* Resolves https://github.com/nextcloud-libraries/nextcloud-vue/issues/6431

### ☑️ Resolves

If there is anything directly rendered on the backdrop we need to ensure that it has enough contrast. This means we need the opaque backdrop always if:
- `dark` prop is set
- Any button is rendered
- Actions are rendered
- A modal header is rendered

Also fixed on doc example as that really bugged me...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
