### PR TITLE
chore: Enable dependabot for the `next` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,21 @@ updates:
     - 3. to review
     - dependencies
 
+  - package-ecosystem: npm
+    directory: "/"
+    target-branch: next
+    schedule:
+      interval: daily
+      timezone: Europe/Paris
+    open-pull-requests-limit: 10
+    labels:
+    - 3. to review
+    - dependencies
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       timezone: Europe/Paris
     open-pull-requests-limit: 10
     labels:


### PR DESCRIPTION
Doing it manually is pretty cumbersome