### PR TITLE
refactor: Use boolean props with default value false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,39 @@
 ## [v8.23.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.23.0) (UNRELEASED)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.22.0...v8.23.0)
 
-### 🚀 Enhancements
+### 📝 Notes
 * The individual import path of components, composables, directives, and functions was changed.
   The type of import is (e.g. `components`) is now lowercase and the `dist` will be omitted.
   For example to import the `NcButton` component the path has changed:
-  - from `import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'`.
-  - to `import NcButton from '@nextcloud/vue/components/NcButton'`
+
+  ```ts
+  // Old import
+  import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+  // New way to import
+  import NcButton from '@nextcloud/vue/components/NcButton'
+  ```
 
   The old import paths are still valid, but deprecated and will be removed in version 9.
+
+* Some boolean props have been deprecated in favor of alternatives with default value `false`.
+  This allows to use shorthand notation on the template, as a prop with a default value of `false`
+  will be set to `true` if it is set (without any value) in the template,
+  similar to native HTML boolean attributes.
+  Following components have been adjusted:
+
+  |     Component |        Deprecated prop | New alternative |
+  |---------------|------------------------|-----------------|
+  |     `NcModal` |          `enableSwipe` |  `disableSwipe` |
+  |`NcAppContent` | `allowSwipeNavigation` | `disabledSwipe` |
+
+### 🚀 Enhancements
+* TBD
+
+### 🐛 Fixed bugs
+* TBD
+
+### ♻️ Changed
+* TBD
 
 ## [v8.22.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.22.0) (2024-12-20)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.21.0...v8.22.0)
@@ -23,6 +48,7 @@
 ### 🚀 Enhancements
 * feat(NcAvatar): implement custom javascript hook action for the contacts menu [\#6238](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6238) \([st3iny](https://github.com/st3iny)\)
 * feat(NcAppNavigation): add `n` hotkey to toggle navigation [\#6311](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6311) \([skjnldsv](https://github.com/skjnldsv)\)
+
 ### 🐛 Fixed bugs
 * fix(NcAppNavigationItem): TypeError: this.$refs.actions.$refs.menuButton is undefined [\#6226](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6226) \([wofferl](https://github.com/wofferl)\)
 * fix(NcListItem): Don't require name prop by @artonge in [\#6128](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6128) \([artonge](https://github.com/artonge)\)

--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -67,8 +67,8 @@ The list size must be between the min and the max width value.
 					'app-content-wrapper--show-list': !showDetails,
 					'app-content-wrapper--mobile': isMobile,}">
 				<NcAppDetailsToggle v-if="showDetails" @click.native.stop.prevent="hideDetails" />
-				<slot v-if="!showDetails" name="list" />
 
+				<slot v-if="!showDetails" name="list" />
 				<slot v-else />
 			</div>
 			<div v-else-if="layout === 'vertical-split' || layout === 'horizontal-split'" class="app-content-wrapper">
@@ -131,10 +131,19 @@ export default {
 	props: {
 		/**
 		 * Allows to disable the control by swipe of the app navigation open state
+		 * @deprecated will be removed with the next version - use `disableSwipe` instead
 		 */
 		allowSwipeNavigation: {
 			type: Boolean,
 			default: true,
+		},
+
+		/**
+		 * Allows to disable the control by swipe of the app navigation open state.
+		 */
+		disableSwipe: {
+			type: Boolean,
+			default: false,
 		},
 
 		/**
@@ -175,7 +184,8 @@ export default {
 		},
 
 		/**
-		 * When in mobile view, only the list or the details are shown
+		 * When in mobile view, only the list or the details are shown.
+		 *
 		 * If you provide a list, you need to provide a variable
 		 * that will be set to true by the user when an element of
 		 * the list gets selected. The details will then show a back
@@ -281,7 +291,7 @@ export default {
 	},
 
 	mounted() {
-		if (this.allowSwipeNavigation) {
+		if (this.allowSwipeNavigation && !this.disableSwipe) {
 			this.swiping = useSwipe(this.$el, {
 				onSwipeEnd: this.handleSwipe,
 			})

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -409,13 +409,23 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
 		/**
 		 * Enable swipe between slides
+		 * @deprecated Will be removed in next version - use `disableSwipe` instead
 		 */
 		enableSwipe: {
 			type: Boolean,
 			default: true,
 		},
+		/**
+		 * Disable swipe between slides
+		 */
+		disableSwipe: {
+			type: Boolean,
+			default: false,
+		},
+
 		spreadNavigation: {
 			type: Boolean,
 			default: false,
@@ -731,7 +741,7 @@ export default {
 		 * @param {import('@vueuse/core').SwipeDirection} direction Swipe direction
 		 */
 		handleSwipe(e, direction) {
-			if (this.enableSwipe) {
+			if (this.enableSwipe && !this.disableSwipe) {
 				if (direction === 'left') {
 					// swiping to left to go to the next item
 					this.next(e)


### PR DESCRIPTION
### ☑️ Resolves

Provide `disableSwipe` instead of `allowSwipeNavigation` (`NcAppContent`) and `enableSwipe` (`NcModal`).

Boolean prop should always - when possible - have a default value of `false` to allow shorthand prop assignment in the template. Similar to native HTML boolean attributes:

```html
<!-- native HTML -->
<button disabled>
<!-- boolean Vue prop with default false -->
<NcModal disable-swipe>
```

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
