### PR TITLE
fix(NcAppNavigation + NcUserBubble + NcRichContenteditable): RTL support

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -75,7 +75,7 @@
 
 	&:not(.app-navigation-entry--editing) {
 		.app-navigation-entry-link, .app-navigation-entry-button {
-			padding-right: $icon-margin;
+			padding-inline-end: $icon-margin;
 		}
 	}
 
@@ -138,7 +138,7 @@
 	.app-navigation-entry {
 		display: inline-flex;
 		flex-wrap: wrap;
-		padding-left: $icon-size;
+		padding-inline-start: $icon-size;
 	}
 }
 
@@ -146,7 +146,7 @@
 .app-navigation-entry__deleted {
 	display: inline-flex;
 	flex: 1 1 0;
-	padding-left: calc(var(--default-clickable-area) - $icon-margin) !important;
+	padding-inline-start: calc(var(--default-clickable-area) - $icon-margin) !important;
 	.app-navigation-entry__deleted-description {
 		position: relative;
 		overflow: hidden;
@@ -169,8 +169,8 @@
 	}
 	/* counter */
 	.app-navigation-entry__counter-wrapper {
-		// Add slightly more space to the right of the counter
-		margin-right: calc(var(--default-grid-baseline) * 2);
+		// Add slightly more space to the end of the counter
+		margin-inline-end: calc(var(--default-grid-baseline) * 2);
 		display: flex;
 		align-items: center;
 		flex: 0 1 auto;

--- a/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
+++ b/src/components/NcAppNavigationCaption/NcAppNavigationCaption.vue
@@ -267,8 +267,8 @@ export default {
 		box-shadow: none !important;
 		flex-shrink: 1;
 		// padding to align the name with the icon of app navigation items
-		padding: 0 calc(var(--default-grid-baseline, 4px) * 2) 0 calc(var(--default-grid-baseline, 4px) * 2);
-		padding-right: 0;
+		padding-block: 0;
+		padding-inline: calc(var(--default-grid-baseline, 4px) * 2) 0;
 		margin-top: 0px;
 		margin-bottom: var(--default-grid-baseline);
 	}

--- a/src/components/NcAppNavigationItem/NcAppNavigationIconCollapsible.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationIconCollapsible.vue
@@ -64,7 +64,7 @@ export default {
 	position: relative;
 	z-index: 105; // above a, under button
 	color: var(--color-main-text);
-	right: 0;
+	inset-inline-end: 0;
 	&--open {
 		color: var(--color-main-text);
 		&:hover{

--- a/src/components/NcAppNavigationNewItem/NcAppNavigationNewItem.vue
+++ b/src/components/NcAppNavigationNewItem/NcAppNavigationNewItem.vue
@@ -166,7 +166,7 @@ export default {
 	max-width: 100%;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	padding-left: 7px;
+	padding-inline-start: 7px;
 	font-size: 14px;
 }
 

--- a/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
+++ b/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
@@ -93,11 +93,11 @@ export default {
 			box-shadow: none;
 			border: 0;
 			border-radius: var(--body-container-radius);
-			text-align: left;
+			text-align: start;
 			font-weight: normal;
 			font-size: 100%;
 			color: var(--color-main-text);
-			padding-right: 14px;
+			padding-inline-end: 14px;
 			line-height: var(--default-clickable-area);
 
 			&:hover,

--- a/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
+++ b/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
@@ -134,7 +134,7 @@ export default {
 		--auto-complete-result-status-icon-position: calc(var(--auto-complete-result-avatar-size) / 2 * (1 - 1 / sqrt(2)) - var(--auto-complete-result-status-icon-size) / 2);
 		box-sizing: border-box;
 		position: absolute;
-		right: var(--auto-complete-result-status-icon-position);
+		inset-inline-end: var(--auto-complete-result-status-icon-position);
 		bottom: var(--auto-complete-result-status-icon-position);
 		height: var(--auto-complete-result-status-icon-size);
 		width: var(--auto-complete-result-status-icon-size);

--- a/src/components/NcRichContenteditable/NcMentionBubble.vue
+++ b/src/components/NcRichContenteditable/NcMentionBubble.vue
@@ -121,8 +121,7 @@ $bubble-avatar-size: $bubble-height - 2 * $bubble-padding;
 		height: $bubble-height ;
 		-webkit-user-select: none;
 		user-select: none;
-		padding-right: $bubble-padding * 3;
-		padding-left: $bubble-padding;
+		padding-inline: $bubble-padding  $bubble-padding * 3;
 		border-radius: math.div($bubble-height, 2);
 		background-color: var(--color-background-dark);
 	}
@@ -145,7 +144,7 @@ $bubble-avatar-size: $bubble-height - 2 * $bubble-padding;
 
 	&__title {
 		overflow: hidden;
-		margin-left: $bubble-padding;
+		margin-inline-start: $bubble-padding;
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		// Put title in ::before so it is not selectable
@@ -158,7 +157,7 @@ $bubble-avatar-size: $bubble-height - 2 * $bubble-padding;
 	&__select {
 		position: absolute;
 		z-index: -1;
-		left: -100vw;
+		inset-inline-start: -100vw;
 		width: 1px;
 		height: 1px;
 		overflow: hidden;

--- a/src/components/NcUserBubble/NcUserBubble.vue
+++ b/src/components/NcUserBubble/NcUserBubble.vue
@@ -273,7 +273,7 @@ export default {
 					borderRadius: this.size / 2 + 'px',
 				},
 				avatar: {
-					marginLeft: this.margin + 'px',
+					marginInlineStart: this.margin + 'px',
 				},
 			}
 		},
@@ -321,8 +321,8 @@ export default {
 		}
 
 		> :last-child {
-			// border radius left padding
-			padding-right: 8px;
+			// border radius end padding
+			padding-inline-end: 8px;
 		}
 	}
 
@@ -339,8 +339,8 @@ export default {
 	&__name,
 	&__secondary {
 		// proper spacing between avatar, name & slot
-		padding: 0;
-		padding-left: 4px;
+		padding-block: 0;
+		padding-inline: 4px 0;
 	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- Many other components will need to be adjusted as well later.

Another issue to keep in mind: `NcRichContenteditable` is used with dir="auto" in Talk and is attached to the div with `"_input"` class. While we need to make a space for the emoji picker, the spacing is not adjusted to the RTL direction and it remains on the left side. We probably need to take the padding logic (and others) out of the `_input` class and put it in the wrapper class `rich-contenteditable` to follow the implemented language direction.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/aa404ca0-f531-4b8f-8006-cd6978157a8f) | ![image](https://github.com/user-attachments/assets/99d9e43f-adda-440e-8c1a-218f1782f5ca)
![image](https://github.com/user-attachments/assets/50f9cf6e-aa66-4c48-8ae1-0098f6e26eb3) | ![image](https://github.com/user-attachments/assets/d78f2e29-88e7-4e56-a6af-47ab4289d1b9)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
