### PR TITLE
[next] fix(NcSelect): `required` doesn't work

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -991,7 +991,7 @@ export default {
 				return null
 			}
 			// The <input> itself does not have any value so we set the `required` attribute conditionally
-			return this.value === null || (Array.isArray(this.value) && this.value.length === 0)
+			return this.modelValue === null || (Array.isArray(this.modelValue) && this.modelValue.length === 0)
 		},
 
 		localCalculatePosition() {


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/6121

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
