### PR TITLE
fix(NcActions): Remove on `mousemove` listener for auto focus elements

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -5,10 +5,14 @@
 
 @mixin action-active {
 	li.action {
+		&:hover,
 		&.active {
-			background-color: var(--color-background-hover);
 			border-radius: 6px;
 			padding: 0;
+		}
+
+		&:hover {
+			background-color: var(--color-background-hover);
 		}
 	}
 }

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1526,31 +1526,6 @@ export default {
 			return this.$refs.menu.querySelectorAll(focusableSelector)
 		},
 		/**
-		 * Focus nearest focusable item on mouse move.
-		 * DO NOT change the focus if the target is already focused
-		 * this will prevent issues with input being unfocused
-		 * on mouse move
-		 * @param {PointerEvent} event - The mouse move event
-		 */
-		onMouseFocusAction(event) {
-			if (document.activeElement === event.target) {
-				return
-			}
-
-			const menuItem = event.target.closest('li')
-			if (menuItem && this.$refs.menu.contains(menuItem)) {
-				const focusableItem = menuItem.querySelector(focusableSelector)
-				if (focusableItem) {
-					const focusList = this.getFocusableMenuItemElements()
-					const focusIndex = [...focusList].indexOf(focusableItem)
-					if (focusIndex > -1) {
-						this.focusIndex = focusIndex
-						this.focusAction()
-					}
-				}
-			}
-		},
-		/**
 		 * Dispatches the keydown listener to different handlers
 		 *
 		 * @param {object} event The keydown event
@@ -1969,7 +1944,6 @@ export default {
 						},
 						on: {
 							keydown: this.onKeydown,
-							mousemove: this.onMouseFocusAction,
 						},
 						ref: 'menu',
 					}, [


### PR DESCRIPTION
* Resolves #6386 

### ☑️ Resolves

1. This causes issues with the native datetime picker on Safari as the mouse move is also considered outside when hovering a picker popover that overlays other actions.
2. In general this is very unexpected behavior, e.g. click on a text input, type something, move the mouse and keep typing. You expect to write to the same input but the focus is changed to a different while typing.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
