### PR TITLE
fix(NcDateTimePicker): selected and hover time is not readable

### DIFF
--- a/src/components/NcDateTimePicker/index.scss
+++ b/src/components/NcDateTimePicker/index.scss
@@ -413,9 +413,14 @@
 
 		.mx-time-option,
 		.mx-time-item {
-			&.active,
-			&:hover {
+			&.active {
+				background-color: var(--color-primary-element);
 				color: var(--color-primary-element-text);
+			}
+
+			&:hover {
+				background-color: var(--color-background-hover);
+				color: var(--color-main-text);
 			}
 
 			&.disabled {


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/6491

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/01cc4dbf-9af9-428b-8400-1de20e956c46) | ![image](https://github.com/user-attachments/assets/09bf185c-f1a9-4495-ad82-6799ac90c106)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
