### PR TITLE
fix(NcRichText): unlock tests, patch component

### DIFF
--- a/cypress/component/richtext.cy.ts
+++ b/cypress/component/richtext.cy.ts
@@ -10,7 +10,7 @@ import { mount } from 'cypress/vue2'
 import NcRichText from '../../src/components/NcRichText/NcRichText.vue'
 
 describe('NcRichText', () => {
-	describe.only('XML-like text (escaped and unescaped)', () => {
+	describe('XML-like text (escaped and unescaped)', () => {
 		const TEST = '<span>text</span> &lt;span&gt;text&lt;/span&gt;'
 		it('renders normal text as passed', () => {
 			mount(NcRichText, {

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -555,7 +555,9 @@ export default {
 				})
 				.processSync(this.text
 					// escape special symbol "<" to not treat text as HTML
-					.replace(/<[^>]+>/g, (match) => match.replace(/</g, '&lt;')),
+					.replace(/<[^>]+>/g, (match) => match.replace(/</g, '&lt;'))
+					// unescape special symbol ">" to parse blockquotes
+					.replace(/&gt;/gmi, '>'),
 				)
 				.result
 

--- a/src/components/NcRichText/remarkUnescape.js
+++ b/src/components/NcRichText/remarkUnescape.js
@@ -7,7 +7,7 @@ import { visit, SKIP } from 'unist-util-visit'
 
 export const remarkUnescape = function() {
 	return function(tree) {
-		visit(tree, (node) => node.type === 'text' || node.type === 'code',
+		visit(tree, (node) => ['text', 'code', 'inlineCode'].includes(node.type),
 			(node, index, parent) => {
 				parent.children.splice(index, 1, {
 					...node,


### PR DESCRIPTION
### ☑️ Resolves

- Fix regression from #6499 🙈 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
