### PR TITLE
revert: import remark-gfm library in NcRichText as module, not async

### DIFF
--- a/tests/unit/components/NcRichText/NcRichText.spec.js
+++ b/tests/unit/components/NcRichText/NcRichText.spec.js
@@ -202,8 +202,6 @@ describe('NcRichText', () => {
 				interactive: true,
 			},
 		})
-		await nextTick()
-		await nextTick()
 		expect(wrapper.text()).toEqual('task item')
 		const checkbox = wrapper.findComponent({ name: 'NcCheckboxRadioSwitch' })
 		expect(checkbox.exists()).toBeTruthy()


### PR DESCRIPTION
### ☑️ Resolves

- This reverts commit 49ce673235268a63e765859caeabec6800dba136. (#6259)

After some testing, I'm not happy with the results. async load of ~40kB comes with side effect of resizing of components, which doesn't look good in long lists (Talk)

### 🖼️ Screenshots

🏚️ Before

https://github.com/user-attachments/assets/13d6f094-169e-4be4-b34b-f8adafa82ad9

🏡 After

https://github.com/user-attachments/assets/8816a340-d674-41f4-a513-808cf86fc2c3

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
