### PR TITLE
feat(functions): Provide `formatDateTime` function

### DIFF
--- a/docs/functions/formatDateTime.md
+++ b/docs/functions/formatDateTime.md
@@ -1,0 +1,49 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+```ts static
+import { formatDateTime } from '@nextcloud/vue/functions/formatDateTime'
+```
+
+Format a `Date` object or a timestamp as a humanized string, also called relative time.
+Examples of such strings: *"last year"*, *"in one month"*, *"3 hours ago"*.
+
+## Definitions
+
+```ts static
+/**
+ * Format a given time as "relative time" also called "humanizing".
+ *
+ * @param timestamp Timestamp or Date object
+ * @param options Options for the formatting
+ */
+declare function formatDateTime(
+	timestamp: Date|number = Date.now(),
+	options: FormatDateOptions = {},
+): string;
+
+interface FormatDateOptions {
+  /**
+	 * Ignore seconds when displaying the relative time and just show `a few seconds ago`.
+   *
+	 * @default false
+	 */
+	ignoreSeconds?: boolean
+
+	/**
+	 * The relative time formatting option to use.
+   *
+	 * @default 'long
+	 */
+	relativeTime?: 'long' | 'short' | 'narrow'
+
+	/**
+	 * Language to use.
+   *
+	 * @default 'current language'
+	 */
+	language?: string
+}
+```

--- a/src/components/NcDateTime/NcDateTime.vue
+++ b/src/components/NcDateTime/NcDateTime.vue
@@ -98,7 +98,7 @@ h4 {
 
 <script>
 import { computed } from 'vue'
-import { useFormatDateTime } from '../../composables/useFormatDateTime.ts'
+import { useFormatDateTime } from '../../composables/useFormatDateTime/index.ts'
 
 export default {
 	name: 'NcDateTime',

--- a/src/composables/index.js
+++ b/src/composables/index.js
@@ -5,6 +5,6 @@
 
 export * from './useIsFullscreen/index.js'
 export * from './useIsMobile/index.js'
-export * from './useFormatDateTime.ts'
+export * from './useFormatDateTime/index.ts'
 export * from './useHotKey/index.js'
 export * from './useIsDarkTheme/index.ts'

--- a/src/composables/useFormatDateTime/index.ts
+++ b/src/composables/useFormatDateTime/index.ts
@@ -5,7 +5,7 @@
 
 import { getCanonicalLocale, getLanguage } from '@nextcloud/l10n'
 import { computed, onUnmounted, ref, onMounted, watch, unref, type Ref } from 'vue'
-import { t } from '../l10n.js'
+import { t } from '../../l10n.js'
 
 const FEW_SECONDS_AGO = {
 	long: t('a few seconds ago'),

--- a/src/composables/useFormatDateTime/index.ts
+++ b/src/composables/useFormatDateTime/index.ts
@@ -3,29 +3,31 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getCanonicalLocale, getLanguage } from '@nextcloud/l10n'
-import { computed, onUnmounted, ref, onMounted, watch, unref, type Ref } from 'vue'
-import { t } from '../../l10n.js'
+import type { FormatDateOptions } from '../../functions/formatDateTime/index.ts'
+import type { Ref } from 'vue'
 
-const FEW_SECONDS_AGO = {
-	long: t('a few seconds ago'),
-	short: t('seconds ago'), // FOR TRANSLATORS: Shorter version of 'a few seconds ago'
-	narrow: t('sec. ago'), // FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
-}
+import { getCanonicalLocale } from '@nextcloud/l10n'
+import { computed, onUnmounted, ref, onMounted, watch, unref } from 'vue'
+import { formatDateTime } from '../../functions/formatDateTime/index.ts'
 
-interface FormatDateOptions {
+interface FormatDateComposableOptions {
 	/**
 	 * The format used for displaying, or if relative time is used the format used for the title
+	 * @default  '{ timeStyle: "medium", dateStyle: "short" }'
 	 */
 	format?: Intl.DateTimeFormatOptions
+
+	/**
+	 * Wether to display the timestamp as time from now.
+	 * @default 'long'
+	 */
+	relativeTime?: false | FormatDateOptions['relativeTime']
+
 	/**
 	 * Ignore seconds when displaying the relative time and just show `a few seconds ago`
+	 * @default false
 	 */
 	ignoreSeconds?: boolean
-	/**
-	 * Wether to display the timestamp as time from now
-	 */
-	relativeTime?: false | 'long' | 'short' | 'narrow'
 }
 
 type MaybeRef<T> = T | Ref<T>
@@ -33,22 +35,19 @@ type MaybeRef<T> = T | Ref<T>
 /**
  * Composable for formatting time stamps using current users locale and language
  *
- * @param {Date | number | import('vue').Ref<Date> | import('vue').Ref<number>} timestamp Current timestamp
- * @param {object} opts Optional options
- * @param {Intl.DateTimeFormatOptions} opts.format The format used for displaying, or if relative time is used the format used for the title (optional)
- * @param {boolean} opts.ignoreSeconds Ignore seconds when displaying the relative time and just show `a few seconds ago`
- * @param {false | 'long' | 'short' | 'narrow'} opts.relativeTime Wether to display the timestamp as time from now (optional)
+ * @param timestamp Current timestamp
+ * @param opts Options
  */
 export function useFormatDateTime(
 	timestamp: MaybeRef<Date|number> = Date.now(),
-	opts: MaybeRef<FormatDateOptions> = {},
+	opts: MaybeRef<FormatDateComposableOptions> = {},
 ) {
 	// Current time as Date.now is not reactive
 	const currentTime = ref(Date.now())
 	// The interval ID for the window
 	let intervalId: number|undefined
 
-	const options = ref({
+	const options = ref<Required<FormatDateComposableOptions>>({
 		format: {
 			timeStyle: 'medium',
 			dateStyle: 'short',
@@ -57,10 +56,18 @@ export function useFormatDateTime(
 		ignoreSeconds: false,
 		...unref(opts),
 	})
-	const wrappedOptions = computed<Required<FormatDateOptions>>(() => ({ ...unref(opts), ...options.value }))
+
+	const wrappedOptions = computed(() => ({ ...unref(opts), ...options.value }))
 
 	/** ECMA Date object of the timestamp */
 	const date = computed(() => new Date(unref(timestamp)))
+
+	/** Interval to update the value */
+	const updateInterval = computed(() => (
+		(wrappedOptions.value.ignoreSeconds || Math.abs(currentTime.value - date.value.getTime()) > 60000)
+			? 30000
+			: 1000
+	))
 
 	const formattedFullTime = computed<string>(() => {
 		const formatter = new Intl.DateTimeFormat(getCanonicalLocale(), wrappedOptions.value.format)
@@ -70,38 +77,10 @@ export function useFormatDateTime(
 	/** Time string formatted for main text */
 	const formattedTime = computed<string>(() => {
 		if (wrappedOptions.value.relativeTime !== false) {
-			const formatter = new Intl.RelativeTimeFormat(getLanguage(), { numeric: 'auto', style: wrappedOptions.value.relativeTime })
-
-			const diff = date.value.getTime() - currentTime.value
-			const seconds = diff / 1000
-			if (Math.abs(seconds) < 59.5) {
-				if (wrappedOptions.value.ignoreSeconds) {
-					return FEW_SECONDS_AGO[wrappedOptions.value.relativeTime]
-				} else {
-					return formatter.format(Math.round(seconds), 'second')
-				}
-			}
-			const minutes = seconds / 60
-			if (Math.abs(minutes) <= 59) {
-				return formatter.format(Math.round(minutes), 'minute')
-			}
-			const hours = minutes / 60
-			if (Math.abs(hours) < 23.5) {
-				return formatter.format(Math.round(hours), 'hour')
-			}
-			const days = hours / 24
-			if (Math.abs(days) < 6.5) {
-				return formatter.format(Math.round(days), 'day')
-			}
-			if (Math.abs(days) < 27.5) {
-				const weeks = days / 7
-				return formatter.format(Math.round(weeks), 'week')
-			}
-			const months = days / 30
-			if (Math.abs(months) < 11.5) {
-				return formatter.format(Math.round(months), 'month')
-			}
-			return formatter.format(Math.round(days / 365), 'year')
+			// This access is needed to trigger a re-calculation if the value changed
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const _ = currentTime.value
+			return formatDateTime(date.value, wrappedOptions.value as FormatDateOptions)
 		}
 		return formattedFullTime.value
 	})
@@ -111,14 +90,14 @@ export function useFormatDateTime(
 		window.clearInterval(intervalId)
 		intervalId = undefined
 		if (wrappedOptions.value.relativeTime) {
-			intervalId = window.setInterval(() => { currentTime.value = Date.now() }, 1000)
+			intervalId = window.setInterval(() => { currentTime.value = Date.now() }, updateInterval.value)
 		}
 	})
 
 	// Start the interval for setting the current time if relative time is enabled
 	onMounted(() => {
 		if (wrappedOptions.value.relativeTime !== false) {
-			intervalId = window.setInterval(() => { currentTime.value = Date.now() }, 1000)
+			intervalId = window.setInterval(() => { currentTime.value = Date.now() }, updateInterval.value)
 		}
 	})
 

--- a/src/functions/formatDateTime/index.ts
+++ b/src/functions/formatDateTime/index.ts
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getLanguage } from '@nextcloud/l10n'
+import { t } from '../../l10n.js'
+
+const FEW_SECONDS_AGO = {
+	long: t('a few seconds ago'),
+	short: t('seconds ago'), // FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+	narrow: t('sec. ago'), // FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+}
+
+export interface FormatDateOptions {
+	/**
+	 * Ignore seconds when displaying the relative time and just show `a few seconds ago`
+	 * @default false
+	 */
+	ignoreSeconds?: boolean
+	/**
+	 * The relative time formatting option to use
+	 * @default 'long
+	 */
+	relativeTime?: 'long' | 'short' | 'narrow'
+	/**
+	 * Language to use
+	 * @default 'current language'
+	 */
+	language?: string
+}
+
+/**
+ * Format a given time as "relative time" also called "humanizing".
+ *
+ * @param timestamp Timestamp or Date object
+ * @param opts Options for the formatting
+ */
+export function formatDateTime(
+	timestamp: Date|number = Date.now(),
+	opts: FormatDateOptions = {},
+): string {
+	const options = {
+		relativeTime: 'long' as const,
+		ignoreSeconds: false,
+		...opts,
+	}
+
+	/** ECMA Date object of the timestamp */
+	const date = new Date(timestamp)
+
+	const formatter = new Intl.RelativeTimeFormat(options.language ? [options.language, getLanguage()] : getLanguage(), { numeric: 'auto', style: options.relativeTime })
+	const diff = date.getTime() - Date.now()
+	const seconds = diff / 1000
+
+	if (Math.abs(seconds) < 59.5) {
+		if (options.ignoreSeconds) {
+			return FEW_SECONDS_AGO[options.relativeTime]
+		} else {
+			return formatter.format(Math.round(seconds), 'second')
+		}
+	}
+	const minutes = seconds / 60
+	if (Math.abs(minutes) <= 59) {
+		return formatter.format(Math.round(minutes), 'minute')
+	}
+	const hours = minutes / 60
+	if (Math.abs(hours) < 23.5) {
+		return formatter.format(Math.round(hours), 'hour')
+	}
+	const days = hours / 24
+	if (Math.abs(days) < 6.5) {
+		return formatter.format(Math.round(days), 'day')
+	}
+	if (Math.abs(days) < 27.5) {
+		const weeks = days / 7
+		return formatter.format(Math.round(weeks), 'week')
+	}
+	const months = days / 30
+	if (Math.abs(months) < 11.5) {
+		return formatter.format(Math.round(months), 'month')
+	}
+	return formatter.format(Math.round(days / 365), 'year')
+}

--- a/tests/unit/composables/useFormatDateTime.spec.js
+++ b/tests/unit/composables/useFormatDateTime.spec.js
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { useFormatDateTime } from '../../../src/composables/useFormatDateTime.ts'
+import { useFormatDateTime } from '../../../src/composables/useFormatDateTime/index.ts'
 import { isRef, nextTick, ref } from 'vue'
 
 describe('useFormatDateTime composable', () => {
 	beforeAll(() => {
 		jest.spyOn(console, 'error').mockImplementation(() => {})
 	})
+
 	afterAll(() => {
 		jest.restoreAllMocks()
 	})
@@ -65,76 +66,5 @@ describe('useFormatDateTime composable', () => {
 		ctx.options.value.ignoreSeconds = true
 		await nextTick()
 		expect(ctx.formattedTime.value).toBe('a few seconds ago')
-	})
-
-	describe('relative time intervals', () => {
-		const time = ref(Date.now())
-		const ctx = useFormatDateTime(time, { ignoreSeconds: false, relativeTime: 'long' })
-
-		test('t < 60s -> seconds', async () => {
-			time.value = Date.now() - (50 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/\d sec/)
-		})
-
-		test('t >= 60s -> minutes', async () => {
-			time.value = Date.now() - (60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/minute/)
-		})
-
-		test('t >= 60min -> hour', async () => {
-			time.value = Date.now() - (60 * 60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/hour/)
-		})
-
-		test('t <= 23h -> hour', async () => {
-			time.value = Date.now() - (23 * 60 * 60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/hour/)
-		})
-
-		test('t >= 24h -> days', async () => {
-			time.value = Date.now() - (24 * 60 * 60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/day/)
-		})
-
-		test('t <= 6days -> days', async () => {
-			time.value = Date.now() - (6 * 24 * 60 * 60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/day/)
-		})
-
-		test('t >= 7 days -> weeks', async () => {
-			time.value = Date.now() - (7 * 24 * 60 * 60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/week/)
-		})
-
-		test('t < 28 days -> weeks', async () => {
-			time.value = Date.now() - (21 * 24 * 60 * 60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/week/)
-		})
-
-		test('t >= 28 days -> months', async () => {
-			time.value = Date.now() - (28 * 24 * 60 * 60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/month/)
-		})
-
-		test('t <= 11 month -> month', async () => {
-			time.value = Date.now() - (335 * 24 * 60 * 60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/month/)
-		})
-
-		test('t >= 12 month -> years', async () => {
-			time.value = Date.now() - (365 * 24 * 60 * 60 * 1000)
-			await nextTick()
-			expect(ctx.formattedTime.value).toMatch(/year/)
-		})
 	})
 })

--- a/tests/unit/functions/formatDateTime.spec.ts
+++ b/tests/unit/functions/formatDateTime.spec.ts
@@ -1,0 +1,64 @@
+/* eslint-disable no-multi-spaces */
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { formatDateTime, type FormatDateOptions } from '../../../src/functions/formatDateTime/index.ts'
+
+const NOW_DATE = new Date('2022-02-02T22:22:22Z')
+const NOW = NOW_DATE.getTime()
+
+describe('formatDateTime()', () => {
+	beforeAll(() => {
+		jest.spyOn(console, 'error').mockImplementation(() => {})
+		jest.useFakeTimers()
+			.setSystemTime(NOW_DATE)
+	})
+
+	afterAll(() => {
+		jest.restoreAllMocks()
+			.useRealTimers()
+	})
+
+	test.each([
+		[NOW_DATE,                            'now'],
+		[NOW,                                 'now'],
+		[NOW -                      5 * 1000, '5 seconds ago'],
+		[NOW -                 2 * 60 * 1000, '2 minutes ago'],
+		[NOW -            3 * 60 * 60 * 1000, '3 hours ago'],
+		[NOW -       4 * 24 * 60 * 60 * 1000, '4 days ago'],
+		[NOW -      14 * 24 * 60 * 60 * 1000, '2 weeks ago'],
+		[NOW - 2 * 365 * 24 * 60 * 60 * 1000, '2 years ago'],
+	])('Shows relative times', (time: Date|number, expected: string) => {
+		const formattedTime = formatDateTime(time, { ignoreSeconds: false, relativeTime: 'long' })
+		expect(formattedTime).toContain(expected)
+	})
+
+	test.each([
+		['long', 'a few seconds ago'],
+		['short', 'seconds ago'],
+		['narrow', 'sec. ago'],
+	] as const)('Shows different relative times', (relativeTime: FormatDateOptions['relativeTime'], expected: string) => {
+		const formattedTime = formatDateTime(NOW - 5000, { ignoreSeconds: true, relativeTime })
+		expect(formattedTime).toBe(expected)
+	})
+
+	test.each([
+		['50 seconds',                 50 * 1000], // t  < 60s      -> seconds
+		['1 minute',                   60 * 1000], // t >= 60s      -> minutes
+		['59 minutes',            59 * 60 * 1000], // t  < 60min    -> minutes
+		['1 hour',                60 * 60 * 1000], // t >= 60min    -> hours
+		['23 hours',         23 * 60 * 60 * 1000], // t  < 24h      -> hours
+		['tomorrow',         24 * 60 * 60 * 1000], // t >= 24h      -> days
+		['6 day',       6 *  24 * 60 * 60 * 1000], // t  <  7days   -> days
+		['next week',   7 *  24 * 60 * 60 * 1000], // t >=  7days   -> weeks
+		['4 weeks',    27 *  24 * 60 * 60 * 1000], // t  < 28days   -> weeks
+		['next month', 28 *  24 * 60 * 60 * 1000], // t >= 28days   -> months
+		['11 months', 335 *  24 * 60 * 60 * 1000], // t  < 12months -> months
+		['next year', 360 *  24 * 60 * 60 * 1000], // t >= 12months -> years
+	])('relative time intervals', (expected: string, time: number) => {
+		const formattedTime = formatDateTime(NOW + time, { ignoreSeconds: false, relativeTime: 'long' })
+		expect(formattedTime).toContain(expected)
+	})
+})


### PR DESCRIPTION
### ☑️ Resolves

Split the `useFormatDateTime` composable into a general function without reactivity and the composable that uses it.
This allows to also use this logic in other places.

### 🖼️ Screenshots

No visual changes.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
