### PR TITLE
[next] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10421,9 +10421,9 @@
       "license": "ISC"
     },
     "node_modules/elliptic": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
-      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 40 of the total 46 vulnerabilities found in your project.

## Updated dependencies
* [@playwright/experimental-ct-core](#user-content-\@playwright\/experimental-ct-core)
* [@playwright/experimental-ct-vue](#user-content-\@playwright\/experimental-ct-vue)
* [@vitejs/plugin-vue](#user-content-\@vitejs\/plugin-vue)
* [anymatch](#user-content-anymatch)
* [bonjour](#user-content-bonjour)
* [braces](#user-content-braces)
* [chokidar](#user-content-chokidar)
* [copy-webpack-plugin](#user-content-copy-webpack-plugin)
* [css-loader](#user-content-css-loader)
* [dns-packet](#user-content-dns-packet)
* [elliptic](#user-content-elliptic)
* [esbuild](#user-content-esbuild)
* [http-proxy-middleware](#user-content-http-proxy-middleware)
* [icss-utils](#user-content-icss-utils)
* [ip](#user-content-ip)
* [markdown-to-jsx](#user-content-markdown-to-jsx)
* [micromatch](#user-content-micromatch)
* [multicast-dns](#user-content-multicast-dns)
* [node-forge](#user-content-node-forge)
* [postcss](#user-content-postcss)
* [postcss-modules-extract-imports](#user-content-postcss-modules-extract-imports)
* [postcss-modules-local-by-default](#user-content-postcss-modules-local-by-default)
* [postcss-modules-scope](#user-content-postcss-modules-scope)
* [postcss-modules-values](#user-content-postcss-modules-values)
* [react-styleguidist](#user-content-react-styleguidist)
* [readdirp](#user-content-readdirp)
* [selfsigned](#user-content-selfsigned)
* [serialize-javascript](#user-content-serialize-javascript)
* [terser-webpack-plugin](#user-content-terser-webpack-plugin)
* [vite](#user-content-vite)
* [vite-plugin-css-injected-by-js](#user-content-vite-plugin-css-injected-by-js)
* [vite-plugin-node-polyfills](#user-content-vite-plugin-node-polyfills)
* [vue-inbrowser-compiler](#user-content-vue-inbrowser-compiler)
* [vue-inbrowser-compiler-demi](#user-content-vue-inbrowser-compiler-demi)
* [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* [vue-inbrowser-prismjs-highlighter](#user-content-vue-inbrowser-prismjs-highlighter)
* [vue-styleguidist](#user-content-vue-styleguidist)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [webpack-dev-middleware](#user-content-webpack-dev-middleware)
* [webpack-dev-server](#user-content-webpack-dev-server)
## Fixed vulnerabilities

### @playwright/experimental-ct-core <a href="#user-content-\@playwright\/experimental-ct-core" id="\@playwright\/experimental-ct-core">#</a>
* Caused by vulnerable dependency:
  * [vite](#user-content-vite)
* Affected versions: *
* Package usage:
  * `node_modules/@playwright/experimental-ct-core`

### @playwright/experimental-ct-vue <a href="#user-content-\@playwright\/experimental-ct-vue" id="\@playwright\/experimental-ct-vue">#</a>
* Caused by vulnerable dependency:
  * [@playwright/experimental-ct-core](#user-content-\@playwright\/experimental-ct-core)
  * [@vitejs/plugin-vue](#user-content-\@vitejs\/plugin-vue)
* Affected versions: >=0.0.6
* Package usage:
  * `node_modules/@playwright/experimental-ct-vue`

### @vitejs/plugin-vue <a href="#user-content-\@vitejs\/plugin-vue" id="\@vitejs\/plugin-vue">#</a>
* Caused by vulnerable dependency:
  * [vite](#user-content-vite)
* Affected versions: >=1.8.0
* Package usage:
  * `node_modules/@vitejs/plugin-vue`

### anymatch <a href="#user-content-anymatch" id="anymatch">#</a>
* Caused by vulnerable dependency:
  * [micromatch](#user-content-micromatch)
* Affected versions: 1.2.0 - 2.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/anymatch`

### bonjour <a href="#user-content-bonjour" id="bonjour">#</a>
* Caused by vulnerable dependency:
  * [multicast-dns](#user-content-multicast-dns)
* Affected versions: >=3.3.1
* Package usage:
  * `node_modules/bonjour`

### braces <a href="#user-content-braces" id="braces">#</a>
* Uncontrolled resource consumption in braces
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-grv7-fg5c-xmjg](https://github.com/advisories/GHSA-grv7-fg5c-xmjg)
* Affected versions: <3.0.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/braces`

### chokidar <a href="#user-content-chokidar" id="chokidar">#</a>
* Caused by vulnerable dependency:
  * [anymatch](#user-content-anymatch)
  * [braces](#user-content-braces)
  * [readdirp](#user-content-readdirp)
* Affected versions: 1.3.0 - 2.1.8
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/chokidar`

### copy-webpack-plugin <a href="#user-content-copy-webpack-plugin" id="copy-webpack-plugin">#</a>
* Caused by vulnerable dependency:
  * [serialize-javascript](#user-content-serialize-javascript)
* Affected versions: 4.3.0 - 9.0.0
* Package usage:
  * `node_modules/copy-webpack-plugin`
  * `node_modules/vue-styleguidist/node_modules/react-styleguidist/node_modules/copy-webpack-plugin`

### css-loader <a href="#user-content-css-loader" id="css-loader">#</a>
* Caused by vulnerable dependency:
  * [icss-utils](#user-content-icss-utils)
  * [postcss](#user-content-postcss)
  * [postcss-modules-extract-imports](#user-content-postcss-modules-extract-imports)
  * [postcss-modules-local-by-default](#user-content-postcss-modules-local-by-default)
  * [postcss-modules-scope](#user-content-postcss-modules-scope)
  * [postcss-modules-values](#user-content-postcss-modules-values)
* Affected versions: 0.15.0 - 4.3.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/css-loader`

### dns-packet <a href="#user-content-dns-packet" id="dns-packet">#</a>
* Caused by vulnerable dependency:
  * [ip](#user-content-ip)
* Affected versions: <=5.2.4
* Package usage:
  * `node_modules/bonjour/node_modules/dns-packet`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Elliptic's private key extraction in ECDSA upon signing a malformed input (e.g. a string)
* Severity: **critical** 🚨
* Reference: [https://github.com/advisories/GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh)
* Affected versions: <=6.6.0
* Package usage:
  * `node_modules/elliptic`

### esbuild <a href="#user-content-esbuild" id="esbuild">#</a>
* esbuild enables any website to send any requests to the development server and read the response
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-67mh-4wv8-2f99](https://github.com/advisories/GHSA-67mh-4wv8-2f99)
* Affected versions: <=0.24.2
* Package usage:
  * `node_modules/@playwright/experimental-ct-core/node_modules/esbuild`
  * `node_modules/esbuild`

### http-proxy-middleware <a href="#user-content-http-proxy-middleware" id="http-proxy-middleware">#</a>
* Denial of service in http-proxy-middleware
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-c7qv-q95q-8v27](https://github.com/advisories/GHSA-c7qv-q95q-8v27)
* Affected versions: <=2.0.7-beta.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/http-proxy-middleware`

### icss-utils <a href="#user-content-icss-utils" id="icss-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=4.1.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/icss-utils`

### ip <a href="#user-content-ip" id="ip">#</a>
* ip SSRF improper categorization in isPublic
* Severity: **high** (CVSS 8.1)
* Reference: [https://github.com/advisories/GHSA-2p57-rm9w-gvfp](https://github.com/advisories/GHSA-2p57-rm9w-gvfp)
* Affected versions: *
* Package usage:
  * `node_modules/ip`

### markdown-to-jsx <a href="#user-content-markdown-to-jsx" id="markdown-to-jsx">#</a>
* Cross site scripting in markdown-to-jsx
* Severity: **moderate** (CVSS 6.1)
* Reference: [https://github.com/advisories/GHSA-4wx3-54gh-9fr9](https://github.com/advisories/GHSA-4wx3-54gh-9fr9)
* Affected versions: <7.4.0
* Package usage:
  * `node_modules/markdown-to-jsx`

### micromatch <a href="#user-content-micromatch" id="micromatch">#</a>
* Regular Expression Denial of Service (ReDoS) in micromatch
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-952p-6rrq-rcjv](https://github.com/advisories/GHSA-952p-6rrq-rcjv)
* Affected versions: <=4.0.7
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/micromatch`

### multicast-dns <a href="#user-content-multicast-dns" id="multicast-dns">#</a>
* Caused by vulnerable dependency:
  * [dns-packet](#user-content-dns-packet)
* Affected versions: 6.0.0 - 7.2.2
* Package usage:
  * `node_modules/bonjour/node_modules/multicast-dns`

### node-forge <a href="#user-content-node-forge" id="node-forge">#</a>
* Prototype Pollution in node-forge debug API.
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-5rrq-pxf6-6jx5](https://github.com/advisories/GHSA-5rrq-pxf6-6jx5)
* Affected versions: <=1.2.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/node-forge`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss`

### postcss-modules-extract-imports <a href="#user-content-postcss-modules-extract-imports" id="postcss-modules-extract-imports">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=2.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-extract-imports`

### postcss-modules-local-by-default <a href="#user-content-postcss-modules-local-by-default" id="postcss-modules-local-by-default">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=3.0.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-local-by-default`

### postcss-modules-scope <a href="#user-content-postcss-modules-scope" id="postcss-modules-scope">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=2.2.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-scope`

### postcss-modules-values <a href="#user-content-postcss-modules-values" id="postcss-modules-values">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=3.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-values`

### react-styleguidist <a href="#user-content-react-styleguidist" id="react-styleguidist">#</a>
* Caused by vulnerable dependency:
  * [copy-webpack-plugin](#user-content-copy-webpack-plugin)
  * [markdown-to-jsx](#user-content-markdown-to-jsx)
  * [terser-webpack-plugin](#user-content-terser-webpack-plugin)
  * [webpack-dev-server](#user-content-webpack-dev-server)
* Affected versions: >=5.0.0-beta.9
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/react-styleguidist`

### readdirp <a href="#user-content-readdirp" id="readdirp">#</a>
* Caused by vulnerable dependency:
  * [micromatch](#user-content-micromatch)
* Affected versions: 2.2.0 - 2.2.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/readdirp`

### selfsigned <a href="#user-content-selfsigned" id="selfsigned">#</a>
* Caused by vulnerable dependency:
  * [node-forge](#user-content-node-forge)
* Affected versions: 1.1.1 - 1.10.14
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/selfsigned`

### serialize-javascript <a href="#user-content-serialize-javascript" id="serialize-javascript">#</a>
* Cross-site Scripting (XSS) in serialize-javascript
* Severity: **moderate** (CVSS 5.4)
* Reference: [https://github.com/advisories/GHSA-76p7-773f-r4q5](https://github.com/advisories/GHSA-76p7-773f-r4q5)
* Affected versions: <6.0.2
* Package usage:
  * `node_modules/serialize-javascript`
  * `node_modules/terser-webpack-plugin/node_modules/serialize-javascript`
  * `node_modules/vue-styleguidist/node_modules/serialize-javascript`

### terser-webpack-plugin <a href="#user-content-terser-webpack-plugin" id="terser-webpack-plugin">#</a>
* Caused by vulnerable dependency:
  * [serialize-javascript](#user-content-serialize-javascript)
* Affected versions: <=5.1.3
* Package usage:
  * `node_modules/terser-webpack-plugin`

### vite <a href="#user-content-vite" id="vite">#</a>
* Caused by vulnerable dependency:
  * [esbuild](#user-content-esbuild)
* Affected versions: 0.11.0 - 6.1.1
* Package usage:
  * `node_modules/@playwright/experimental-ct-core/node_modules/vite`
  * `node_modules/vite`

### vite-plugin-css-injected-by-js <a href="#user-content-vite-plugin-css-injected-by-js" id="vite-plugin-css-injected-by-js">#</a>
* Caused by vulnerable dependency:
  * [vite](#user-content-vite)
* Affected versions: *
* Package usage:
  * `node_modules/vite-plugin-css-injected-by-js`

### vite-plugin-node-polyfills <a href="#user-content-vite-plugin-node-polyfills" id="vite-plugin-node-polyfills">#</a>
* Caused by vulnerable dependency:
  * [vite](#user-content-vite)
* Affected versions: >=0.3.2
* Package usage:
  * `node_modules/vite-plugin-node-polyfills`

### vue-inbrowser-compiler <a href="#user-content-vue-inbrowser-compiler" id="vue-inbrowser-compiler">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler`

### vue-inbrowser-compiler-demi <a href="#user-content-vue-inbrowser-compiler-demi" id="vue-inbrowser-compiler-demi">#</a>
* Caused by vulnerable dependency:
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler-demi`

### vue-inbrowser-compiler-utils <a href="#user-content-vue-inbrowser-compiler-utils" id="vue-inbrowser-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-demi](#user-content-vue-inbrowser-compiler-demi)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler-utils`

### vue-inbrowser-prismjs-highlighter <a href="#user-content-vue-inbrowser-prismjs-highlighter" id="vue-inbrowser-prismjs-highlighter">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* Affected versions: *
* Package usage:
  * `node_modules/vue-inbrowser-prismjs-highlighter`

### vue-styleguidist <a href="#user-content-vue-styleguidist" id="vue-styleguidist">#</a>
* Caused by vulnerable dependency:
  * [copy-webpack-plugin](#user-content-copy-webpack-plugin)
  * [css-loader](#user-content-css-loader)
  * [react-styleguidist](#user-content-react-styleguidist)
  * [terser-webpack-plugin](#user-content-terser-webpack-plugin)
  * [vue-inbrowser-compiler](#user-content-vue-inbrowser-compiler)
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
  * [vue-inbrowser-prismjs-highlighter](#user-content-vue-inbrowser-prismjs-highlighter)
  * [vue-template-compiler](#user-content-vue-template-compiler)
  * [webpack-dev-server](#user-content-webpack-dev-server)
* Affected versions: *
* Package usage:
  * `node_modules/vue-styleguidist`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### webpack-dev-middleware <a href="#user-content-webpack-dev-middleware" id="webpack-dev-middleware">#</a>
* Path traversal in webpack-dev-middleware
* Severity: **high** (CVSS 7.4)
* Reference: [https://github.com/advisories/GHSA-wr3j-pwj9-hqq6](https://github.com/advisories/GHSA-wr3j-pwj9-hqq6)
* Affected versions: <=5.3.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/webpack-dev-middleware`

### webpack-dev-server <a href="#user-content-webpack-dev-server" id="webpack-dev-server">#</a>
* Caused by vulnerable dependency:
  * [bonjour](#user-content-bonjour)
  * [chokidar](#user-content-chokidar)
  * [http-proxy-middleware](#user-content-http-proxy-middleware)
  * [ip](#user-content-ip)
  * [selfsigned](#user-content-selfsigned)
  * [webpack-dev-middleware](#user-content-webpack-dev-middleware)
* Affected versions: <=4.7.4
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/webpack-dev-server`