### PR TITLE
fix(NcColorPicker): remove unused invalid styles

### DIFF
--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -513,8 +513,6 @@ export default {
 		}
 
 		&-active-color {
-			width: calc(var(--default-clickable-area) - 10 px);
-			height: calc(var(--default-clickable-area) - 10 px);
 			border-radius: 17px;
 		}
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/6510

The styles are unused because they are invalid and overwritten, so we can just drop them.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
