### PR TITLE
[DRAFT] feat(NcPopover): add fullscreen mobile mode

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -955,6 +955,7 @@ import GenRandomId from '../../utils/GenRandomId.js'
 
 import { t } from '../../l10n.js'
 import { useTrapStackControl } from '../../composables/useTrapStackControl.ts'
+import { useIsSmallMobile } from '../../composables/useIsMobile/index.js'
 import { useElementBounding, useWindowSize } from '@vueuse/core'
 import Vue, { ref, computed, toRef } from 'vue'
 
@@ -1196,22 +1197,27 @@ export default {
 		const { top, bottom } = useElementBounding(triggerButton)
 		const { top: boundaryTop, bottom: boundaryBottom } = useElementBounding(toRef(props, 'boundariesElement'))
 		const { height: windowHeight } = useWindowSize()
-		const maxMenuHeight = computed(() => Math.max(
-			// Either expand to the top
-			Math.min(
-				// max height is the top position of the trigger minus the header height minus the wedge and the padding
-				top.value - 84,
-				// and also limited to the space in the boundary
-				top.value - boundaryTop.value,
-			),
-			// or expand to the bottom
-			Math.min(
-				// the max height is the window height minus current position of the trigger minus the wedge and padding
-				windowHeight.value - bottom.value - 34,
-				// and limit to the available space in the boundary
-				boundaryBottom.value - bottom.value,
-			),
-		))
+		const isSmallMobile = useIsSmallMobile()
+		const maxMenuHeight = computed(() => !isSmallMobile.value
+			? Math.max(
+				// Either expand to the top
+				Math.min(
+					// max height is the top position of the trigger minus the header height minus the wedge and the padding
+					top.value - 84,
+					// and also limited to the space in the boundary
+					top.value - boundaryTop.value,
+				),
+				// or expand to the bottom
+				Math.min(
+					// the max height is the window height minus current position of the trigger minus the wedge and padding
+					windowHeight.value - bottom.value - 34,
+					// and limit to the available space in the boundary
+					boundaryBottom.value - bottom.value,
+				),
+			)
+			// Do not limit on mobile with full screen mode
+			: Infinity,
+		)
 
 		return {
 			triggerButton,
@@ -1886,6 +1892,7 @@ export default {
 						popupRole: this.config.popupRole,
 						setReturnFocus: this.config.withFocusTrap ? this.$refs.triggerButton?.$el : null,
 						focusTrap: this.config.withFocusTrap,
+						withMobileMode: true,
 					},
 					// For some reason the popover component
 					// does not react to props given under the 'props' key,
@@ -2084,11 +2091,8 @@ export default {
 // We overwrote the popover base class, so we can style
 // the popover__inner for actions only.
 .v-popper--theme-dropdown.v-popper__popper.action-item__popper .v-popper__wrapper {
-	border-radius: var(--border-radius-large);
-
 	.v-popper__inner {
-		border-radius: var(--border-radius-large);
-		padding: 4px;
+		padding: var(--default-grid-baseline);
 		max-height: calc(100vh - var(--header-height));
 		overflow: auto;
 	}


### PR DESCRIPTION
### ☑️ Resolves

- Add classic mobile menu mode for NcPopover
  - Optional
  - Enabled for NcActions by default

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/1dcc55c6-c029-4e7d-aaed-d13d5b0a14dc) | ![image](https://github.com/user-attachments/assets/d97a2195-2189-471c-9b50-7f06939888af)
![image](https://github.com/user-attachments/assets/68133195-be6e-4baf-a21d-462da8f67757) | ![image](https://github.com/user-attachments/assets/c175b5df-8976-4f36-ba7b-ba92985acbed)
![image](https://github.com/user-attachments/assets/842aed1b-6778-4ba9-97f6-4340d4f4b478) | ![image](https://github.com/user-attachments/assets/3d984c0d-a75d-4d39-b602-11444183850b)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
