### PR TITLE
Fix useModelMigration in async components

### DIFF
--- a/src/components/NcActionCheckbox/NcActionCheckbox.vue
+++ b/src/components/NcActionCheckbox/NcActionCheckbox.vue
@@ -139,8 +139,8 @@ export default {
 		'update:model-value',
 	],
 
-	setup() {
-		const model = useModelMigration('checked', 'update:checked')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'checked', 'update:checked')
 		return {
 			model,
 		}

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -416,8 +416,8 @@ export default {
 		'update:model-value',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'update:value')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'update:value')
 		return {
 			model,
 		}

--- a/src/components/NcActionRadio/NcActionRadio.vue
+++ b/src/components/NcActionRadio/NcActionRadio.vue
@@ -158,12 +158,12 @@ export default {
 		'change',
 	],
 
-	setup(props) {
+	setup(props, {emit}) {
 		if (typeof props.modelValue === 'boolean') {
 			Vue.util.warn('[NcActionRadio] Boolean type of `modelValue` is deprecated and will be removed in next versions')
 		}
 
-		const model = useModelMigration('checked', 'update:checked')
+		const model = useModelMigration(props, emit, 'checked', 'update:checked')
 		return {
 			model,
 		}

--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -166,8 +166,8 @@ export default {
 		'submit',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'update:value')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'update:value')
 		return {
 			model,
 			isRtl,

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -477,8 +477,8 @@ export default {
 		'update:model-value',
 	],
 
-	setup() {
-		const model = useModelMigration('checked', 'update:checked')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'checked', 'update:checked')
 		return {
 			model,
 		}

--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -318,8 +318,8 @@ export default {
 		'input',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'update:value', true)
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'update:value', true)
 		return {
 			model,
 		}

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -302,8 +302,8 @@ export default {
 		'update:timezone-id',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'update:value')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'update:value')
 		return {
 			model,
 			timezoneDialogHeaderId: `timezone-dialog-header-${GenRandomId()}`,

--- a/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
+++ b/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
@@ -218,8 +218,8 @@ export default {
 		'update:model-value',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'input')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'input')
 		return {
 			model,
 		}

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -272,8 +272,8 @@ export default {
 		'trailing-button-click',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'update:value', true)
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'update:value', true)
 		return {
 			model,
 		}

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -248,8 +248,8 @@ export default {
 		'update:model-value',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'update:value')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'update:value')
 		return {
 			model,
 		}

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -438,9 +438,9 @@ export default {
 		'smart-picker-submit',
 	],
 
-	setup() {
+	setup(props, {emit}) {
 		const uid = GenRandomId(5)
-		const model = useModelMigration('value', 'update:value', true)
+		const model = useModelMigration(props, emit, 'value', 'update:value', true)
 		return {
 			model,
 			// Constants

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -990,12 +990,12 @@ export default {
 		'update:model-value',
 	],
 
-	setup() {
+	setup(props, {emit}) {
 		const clickableArea = Number.parseInt(window.getComputedStyle(document.body).getPropertyValue('--default-clickable-area'))
 		const gridBaseLine = Number.parseInt(window.getComputedStyle(document.body).getPropertyValue('--default-grid-baseline'))
 		const avatarSize = clickableArea - 2 * gridBaseLine
 
-		const model = useModelMigration('value', 'input')
+		const model = useModelMigration(props, emit, 'value', 'input')
 
 		return {
 			avatarSize,

--- a/src/components/NcSelectTags/NcSelectTags.vue
+++ b/src/components/NcSelectTags/NcSelectTags.vue
@@ -293,8 +293,8 @@ export default {
 		' ',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'input')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'input')
 		const noop = () => {}
 		return {
 			model,

--- a/src/components/NcSettingsInputText/NcSettingsInputText.vue
+++ b/src/components/NcSettingsInputText/NcSettingsInputText.vue
@@ -133,8 +133,8 @@ export default {
 		'change',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'update:value')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'update:value')
 		return {
 			model,
 		}

--- a/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
+++ b/src/components/NcSettingsSelectGroup/NcSettingsSelectGroup.vue
@@ -137,8 +137,8 @@ export default {
 		'update:model-value',
 		'error',
 	],
-	setup() {
-		const model = useModelMigration('value', 'input')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'input')
 		return {
 			model,
 		}

--- a/src/components/NcTextArea/NcTextArea.vue
+++ b/src/components/NcTextArea/NcTextArea.vue
@@ -267,8 +267,8 @@ export default {
 		'update:model-value',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'update:value', true)
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'update:value', true)
 		return {
 			model,
 		}

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -226,8 +226,8 @@ export default {
 		'update:model-value',
 	],
 
-	setup() {
-		const model = useModelMigration('value', 'update:value')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'update:value')
 		return {
 			model,
 		}

--- a/src/components/NcTimezonePicker/NcTimezonePicker.vue
+++ b/src/components/NcTimezonePicker/NcTimezonePicker.vue
@@ -101,8 +101,8 @@ export default {
 		/** Same as update:modelValue for Vue 2 compatibility */
 		'update:model-value',
 	],
-	setup() {
-		const model = useModelMigration('value', 'input')
+	setup(props, {emit}) {
+		const model = useModelMigration(props, emit, 'value', 'input')
 		return {
 			model,
 		}


### PR DESCRIPTION
It was using getCurrentInstance() which, as I understand it, isn't part of vue's public API anymore and isn't guaranteed to work in every situation.

Makes call site a bit uglier, but I don't think there's a better way to do it.

### ☑️ Resolves

- Fix #6607

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
