### PR TITLE
[next] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -537,14 +537,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1904,9 +1904,10 @@
       "peer": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -4420,9 +4421,9 @@
       }
     },
     "node_modules/@playwright/experimental-ct-core/node_modules/vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.15.tgz",
+      "integrity": "sha512-6ANcZRivqL/4WtwPGTKNaosuNJr5tWiftOC7liM7G9+rMb8+oeJeyzymDu4rTN93seySBmbjSfsS3Vzr19KNtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7218,9 +7219,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -19297,10 +19298,11 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }


### PR DESCRIPTION
# Audit report

This audit fix resolves 36 of the total 39 vulnerabilities found in your project.

## Updated dependencies
* [@babel/helpers](#user-content-\@babel\/helpers)
* [@babel/runtime](#user-content-\@babel\/runtime)
* [@playwright/experimental-ct-core](#user-content-\@playwright\/experimental-ct-core)
* [@playwright/experimental-ct-vue](#user-content-\@playwright\/experimental-ct-vue)
* [anymatch](#user-content-anymatch)
* [axios](#user-content-axios)
* [bonjour](#user-content-bonjour)
* [braces](#user-content-braces)
* [chokidar](#user-content-chokidar)
* [css-loader](#user-content-css-loader)
* [dns-packet](#user-content-dns-packet)
* [http-proxy-middleware](#user-content-http-proxy-middleware)
* [icss-utils](#user-content-icss-utils)
* [ip](#user-content-ip)
* [markdown-to-jsx](#user-content-markdown-to-jsx)
* [micromatch](#user-content-micromatch)
* [multicast-dns](#user-content-multicast-dns)
* [node-forge](#user-content-node-forge)
* [postcss](#user-content-postcss)
* [postcss-modules-extract-imports](#user-content-postcss-modules-extract-imports)
* [postcss-modules-local-by-default](#user-content-postcss-modules-local-by-default)
* [postcss-modules-scope](#user-content-postcss-modules-scope)
* [postcss-modules-values](#user-content-postcss-modules-values)
* [prismjs](#user-content-prismjs)
* [react-styleguidist](#user-content-react-styleguidist)
* [readdirp](#user-content-readdirp)
* [selfsigned](#user-content-selfsigned)
* [vite](#user-content-vite)
* [vue-inbrowser-compiler](#user-content-vue-inbrowser-compiler)
* [vue-inbrowser-compiler-demi](#user-content-vue-inbrowser-compiler-demi)
* [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* [vue-inbrowser-prismjs-highlighter](#user-content-vue-inbrowser-prismjs-highlighter)
* [vue-styleguidist](#user-content-vue-styleguidist)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [webpack-dev-middleware](#user-content-webpack-dev-middleware)
* [webpack-dev-server](#user-content-webpack-dev-server)
## Fixed vulnerabilities

### @babel/helpers <a href="#user-content-\@babel\/helpers" id="\@babel\/helpers">#</a>
* Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups
* Severity: **moderate** (CVSS 6.2)
* Reference: [https://github.com/advisories/GHSA-968p-4wvh-cqc8](https://github.com/advisories/GHSA-968p-4wvh-cqc8)
* Affected versions: <7.26.10
* Package usage:
  * `node_modules/@babel/helpers`

### @babel/runtime <a href="#user-content-\@babel\/runtime" id="\@babel\/runtime">#</a>
* Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups
* Severity: **moderate** (CVSS 6.2)
* Reference: [https://github.com/advisories/GHSA-968p-4wvh-cqc8](https://github.com/advisories/GHSA-968p-4wvh-cqc8)
* Affected versions: <7.26.10
* Package usage:
  * `node_modules/@babel/runtime`
  * `node_modules/vue-styleguidist/node_modules/@babel/runtime`

### @playwright/experimental-ct-core <a href="#user-content-\@playwright\/experimental-ct-core" id="\@playwright\/experimental-ct-core">#</a>
* Caused by vulnerable dependency:
  * [vite](#user-content-vite)
* Affected versions: <=1.51.0-beta-1741803045000
* Package usage:
  * `node_modules/@playwright/experimental-ct-core`

### @playwright/experimental-ct-vue <a href="#user-content-\@playwright\/experimental-ct-vue" id="\@playwright\/experimental-ct-vue">#</a>
* Caused by vulnerable dependency:
  * [@playwright/experimental-ct-core](#user-content-\@playwright\/experimental-ct-core)
* Affected versions: 1.33.0-alpha-1679605230000 - 1.51.0-beta-1741803045000
* Package usage:
  * `node_modules/@playwright/experimental-ct-vue`

### anymatch <a href="#user-content-anymatch" id="anymatch">#</a>
* Caused by vulnerable dependency:
  * [micromatch](#user-content-micromatch)
* Affected versions: 1.2.0 - 2.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/anymatch`

### axios <a href="#user-content-axios" id="axios">#</a>
* axios Requests Vulnerable To Possible SSRF and Credential Leakage via Absolute URL
* Severity: **high**
* Reference: [https://github.com/advisories/GHSA-jr5f-v2jv-69x6](https://github.com/advisories/GHSA-jr5f-v2jv-69x6)
* Affected versions: <1.8.2
* Package usage:
  * `node_modules/axios`

### bonjour <a href="#user-content-bonjour" id="bonjour">#</a>
* Caused by vulnerable dependency:
  * [multicast-dns](#user-content-multicast-dns)
* Affected versions: >=3.3.1
* Package usage:
  * `node_modules/bonjour`

### braces <a href="#user-content-braces" id="braces">#</a>
* Uncontrolled resource consumption in braces
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-grv7-fg5c-xmjg](https://github.com/advisories/GHSA-grv7-fg5c-xmjg)
* Affected versions: <3.0.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/braces`

### chokidar <a href="#user-content-chokidar" id="chokidar">#</a>
* Caused by vulnerable dependency:
  * [anymatch](#user-content-anymatch)
  * [braces](#user-content-braces)
  * [readdirp](#user-content-readdirp)
* Affected versions: 1.3.0 - 2.1.8
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/chokidar`

### css-loader <a href="#user-content-css-loader" id="css-loader">#</a>
* Caused by vulnerable dependency:
  * [icss-utils](#user-content-icss-utils)
  * [postcss](#user-content-postcss)
  * [postcss-modules-extract-imports](#user-content-postcss-modules-extract-imports)
  * [postcss-modules-local-by-default](#user-content-postcss-modules-local-by-default)
  * [postcss-modules-scope](#user-content-postcss-modules-scope)
  * [postcss-modules-values](#user-content-postcss-modules-values)
* Affected versions: 0.15.0 - 4.3.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/css-loader`

### dns-packet <a href="#user-content-dns-packet" id="dns-packet">#</a>
* Caused by vulnerable dependency:
  * [ip](#user-content-ip)
* Affected versions: <=5.2.4
* Package usage:
  * `node_modules/bonjour/node_modules/dns-packet`

### http-proxy-middleware <a href="#user-content-http-proxy-middleware" id="http-proxy-middleware">#</a>
* Denial of service in http-proxy-middleware
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-c7qv-q95q-8v27](https://github.com/advisories/GHSA-c7qv-q95q-8v27)
* Affected versions: <=2.0.7-beta.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/http-proxy-middleware`

### icss-utils <a href="#user-content-icss-utils" id="icss-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=4.1.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/icss-utils`

### ip <a href="#user-content-ip" id="ip">#</a>
* ip SSRF improper categorization in isPublic
* Severity: **high** (CVSS 8.1)
* Reference: [https://github.com/advisories/GHSA-2p57-rm9w-gvfp](https://github.com/advisories/GHSA-2p57-rm9w-gvfp)
* Affected versions: *
* Package usage:
  * `node_modules/ip`

### markdown-to-jsx <a href="#user-content-markdown-to-jsx" id="markdown-to-jsx">#</a>
* Cross site scripting in markdown-to-jsx
* Severity: **moderate** (CVSS 6.1)
* Reference: [https://github.com/advisories/GHSA-4wx3-54gh-9fr9](https://github.com/advisories/GHSA-4wx3-54gh-9fr9)
* Affected versions: <7.4.0
* Package usage:
  * `node_modules/markdown-to-jsx`

### micromatch <a href="#user-content-micromatch" id="micromatch">#</a>
* Regular Expression Denial of Service (ReDoS) in micromatch
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-952p-6rrq-rcjv](https://github.com/advisories/GHSA-952p-6rrq-rcjv)
* Affected versions: <=4.0.7
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/micromatch`

### multicast-dns <a href="#user-content-multicast-dns" id="multicast-dns">#</a>
* Caused by vulnerable dependency:
  * [dns-packet](#user-content-dns-packet)
* Affected versions: 6.0.0 - 7.2.2
* Package usage:
  * `node_modules/bonjour/node_modules/multicast-dns`

### node-forge <a href="#user-content-node-forge" id="node-forge">#</a>
* Prototype Pollution in node-forge debug API.
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-5rrq-pxf6-6jx5](https://github.com/advisories/GHSA-5rrq-pxf6-6jx5)
* Affected versions: <=1.2.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/node-forge`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss`

### postcss-modules-extract-imports <a href="#user-content-postcss-modules-extract-imports" id="postcss-modules-extract-imports">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=2.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-extract-imports`

### postcss-modules-local-by-default <a href="#user-content-postcss-modules-local-by-default" id="postcss-modules-local-by-default">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=3.0.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-local-by-default`

### postcss-modules-scope <a href="#user-content-postcss-modules-scope" id="postcss-modules-scope">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=2.2.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-scope`

### postcss-modules-values <a href="#user-content-postcss-modules-values" id="postcss-modules-values">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=3.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/postcss-modules-values`

### prismjs <a href="#user-content-prismjs" id="prismjs">#</a>
* PrismJS DOM Clobbering vulnerability
* Severity: **moderate** (CVSS 4.9)
* Reference: [https://github.com/advisories/GHSA-x7hr-w5r2-h6wg](https://github.com/advisories/GHSA-x7hr-w5r2-h6wg)
* Affected versions: <1.30.0
* Package usage:
  * `node_modules/prismjs`

### react-styleguidist <a href="#user-content-react-styleguidist" id="react-styleguidist">#</a>
* Caused by vulnerable dependency:
  * [markdown-to-jsx](#user-content-markdown-to-jsx)
  * [webpack-dev-server](#user-content-webpack-dev-server)
* Affected versions: >=5.0.0-beta.9
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/react-styleguidist`

### readdirp <a href="#user-content-readdirp" id="readdirp">#</a>
* Caused by vulnerable dependency:
  * [micromatch](#user-content-micromatch)
* Affected versions: 2.2.0 - 2.2.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/readdirp`

### selfsigned <a href="#user-content-selfsigned" id="selfsigned">#</a>
* Caused by vulnerable dependency:
  * [node-forge](#user-content-node-forge)
* Affected versions: 1.1.1 - 1.10.14
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/selfsigned`

### vite <a href="#user-content-vite" id="vite">#</a>
* Caused by vulnerable dependency:
  * [esbuild](#user-content-esbuild)
* Affected versions: 0.11.0 - 6.1.1
* Package usage:
  * `node_modules/@playwright/experimental-ct-core/node_modules/vite`

### vue-inbrowser-compiler <a href="#user-content-vue-inbrowser-compiler" id="vue-inbrowser-compiler">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler`

### vue-inbrowser-compiler-demi <a href="#user-content-vue-inbrowser-compiler-demi" id="vue-inbrowser-compiler-demi">#</a>
* Caused by vulnerable dependency:
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler-demi`

### vue-inbrowser-compiler-utils <a href="#user-content-vue-inbrowser-compiler-utils" id="vue-inbrowser-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-demi](#user-content-vue-inbrowser-compiler-demi)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler-utils`

### vue-inbrowser-prismjs-highlighter <a href="#user-content-vue-inbrowser-prismjs-highlighter" id="vue-inbrowser-prismjs-highlighter">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* Affected versions: *
* Package usage:
  * `node_modules/vue-inbrowser-prismjs-highlighter`

### vue-styleguidist <a href="#user-content-vue-styleguidist" id="vue-styleguidist">#</a>
* Caused by vulnerable dependency:
  * [@babel/runtime](#user-content-\@babel\/runtime)
  * [css-loader](#user-content-css-loader)
  * [react-styleguidist](#user-content-react-styleguidist)
  * [vue-inbrowser-compiler](#user-content-vue-inbrowser-compiler)
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
  * [vue-inbrowser-prismjs-highlighter](#user-content-vue-inbrowser-prismjs-highlighter)
  * [vue-template-compiler](#user-content-vue-template-compiler)
  * [webpack-dev-server](#user-content-webpack-dev-server)
* Affected versions: *
* Package usage:
  * `node_modules/vue-styleguidist`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### webpack-dev-middleware <a href="#user-content-webpack-dev-middleware" id="webpack-dev-middleware">#</a>
* Path traversal in webpack-dev-middleware
* Severity: **high** (CVSS 7.4)
* Reference: [https://github.com/advisories/GHSA-wr3j-pwj9-hqq6](https://github.com/advisories/GHSA-wr3j-pwj9-hqq6)
* Affected versions: <=5.3.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/webpack-dev-middleware`

### webpack-dev-server <a href="#user-content-webpack-dev-server" id="webpack-dev-server">#</a>
* Caused by vulnerable dependency:
  * [bonjour](#user-content-bonjour)
  * [chokidar](#user-content-chokidar)
  * [http-proxy-middleware](#user-content-http-proxy-middleware)
  * [ip](#user-content-ip)
  * [selfsigned](#user-content-selfsigned)
  * [webpack-dev-middleware](#user-content-webpack-dev-middleware)
* Affected versions: <=4.7.4
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/webpack-dev-server`