### PR TITLE
docs: adjust version number for `variant` props

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1167,7 +1167,7 @@ export default {
 		 * Accepted values: primary, secondary, tertiary, tertiary-no-background, tertiary-on-primary, error, warning, success.
 		 * If left empty, the default button style will be applied.
 		 *
-		 * @since 8.23.0
+		 * @since 8.24.0
 		 */
 		variant: {
 			type: String,

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -588,7 +588,7 @@ export default {
 		 * Accepted values: primary, secondary, tertiary, tertiary-no-background, tertiary-on-primary, error, warning, success.
 		 *
 		 * @default 'secondary'
-		 * @since 8.23.0
+		 * @since 8.24.0
 		 */
 		 variant: {
 			type: String,

--- a/src/components/NcChip/NcChip.vue
+++ b/src/components/NcChip/NcChip.vue
@@ -177,7 +177,7 @@ const props = defineProps({
 	 * Set the chips design variant-
 	 *
 	 * This sets the background style of the chip, similar to NcButton's `variant`.
-	 * @since 8.23.0
+	 * @since 8.24.0
 	 */
 	variant: {
 		type: String,

--- a/src/components/NcDialogButton/NcDialogButton.vue
+++ b/src/components/NcDialogButton/NcDialogButton.vue
@@ -103,7 +103,7 @@ const props = defineProps({
 	 * The button variant, see NcButton.
 	 *
 	 * @type {'primary'|'secondary'|'tertiary'|'error'|'warning'|'success'}
-	 * @since 8.23.0
+	 * @since 8.24.0
 	 */
 	variant: {
 		type: String,


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/pull/6472#discussion_r1993071083

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
