### PR TITLE
[master] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -545,14 +545,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1912,9 +1912,10 @@
       "peer": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
-      "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1962,9 +1963,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",


### PR DESCRIPTION
# Audit report

This audit fix resolves 39 of the total 48 vulnerabilities found in your project.

## Updated dependencies
* [@babel/helpers](#user-content-\@babel\/helpers)
* [@babel/runtime](#user-content-\@babel\/runtime)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [@vue/test-utils](#user-content-\@vue\/test-utils)
* [anymatch](#user-content-anymatch)
* [bonjour](#user-content-bonjour)
* [braces](#user-content-braces)
* [chokidar](#user-content-chokidar)
* [css-loader](#user-content-css-loader)
* [dns-packet](#user-content-dns-packet)
* [floating-vue](#user-content-floating-vue)
* [http-proxy-middleware](#user-content-http-proxy-middleware)
* [icss-utils](#user-content-icss-utils)
* [ip](#user-content-ip)
* [markdown-to-jsx](#user-content-markdown-to-jsx)
* [micromatch](#user-content-micromatch)
* [multicast-dns](#user-content-multicast-dns)
* [node-forge](#user-content-node-forge)
* [postcss](#user-content-postcss)
* [postcss-modules-extract-imports](#user-content-postcss-modules-extract-imports)
* [postcss-modules-local-by-default](#user-content-postcss-modules-local-by-default)
* [postcss-modules-scope](#user-content-postcss-modules-scope)
* [postcss-modules-values](#user-content-postcss-modules-values)
* [react-styleguidist](#user-content-react-styleguidist)
* [readdirp](#user-content-readdirp)
* [selfsigned](#user-content-selfsigned)
* [vue-frag](#user-content-vue-frag)
* [vue-inbrowser-compiler](#user-content-vue-inbrowser-compiler)
* [vue-inbrowser-compiler-demi](#user-content-vue-inbrowser-compiler-demi)
* [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* [vue-inbrowser-prismjs-highlighter](#user-content-vue-inbrowser-prismjs-highlighter)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-styleguidist](#user-content-vue-styleguidist)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vue2-datepicker](#user-content-vue2-datepicker)
* [webpack-dev-middleware](#user-content-webpack-dev-middleware)
* [webpack-dev-server](#user-content-webpack-dev-server)
## Fixed vulnerabilities

### @babel/helpers <a href="#user-content-\@babel\/helpers" id="\@babel\/helpers">#</a>
* Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups
* Severity: **moderate** (CVSS 6.2)
* Reference: [https://github.com/advisories/GHSA-968p-4wvh-cqc8](https://github.com/advisories/GHSA-968p-4wvh-cqc8)
* Affected versions: <7.26.10
* Package usage:
  * `node_modules/@babel/helpers`

### @babel/runtime <a href="#user-content-\@babel\/runtime" id="\@babel\/runtime">#</a>
* Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups
* Severity: **moderate** (CVSS 6.2)
* Reference: [https://github.com/advisories/GHSA-968p-4wvh-cqc8](https://github.com/advisories/GHSA-968p-4wvh-cqc8)
* Affected versions: <7.26.10
* Package usage:
  * `node_modules/@babel/runtime`
  * `node_modules/vue-styleguidist/node_modules/@babel/runtime`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### @vue/test-utils <a href="#user-content-\@vue\/test-utils" id="\@vue\/test-utils">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=1.3.6
* Package usage:
  * `node_modules/@vue/test-utils`

### anymatch <a href="#user-content-anymatch" id="anymatch">#</a>
* Caused by vulnerable dependency:
  * [micromatch](#user-content-micromatch)
* Affected versions: 1.2.0 - 2.0.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/anymatch`

### bonjour <a href="#user-content-bonjour" id="bonjour">#</a>
* Caused by vulnerable dependency:
  * [multicast-dns](#user-content-multicast-dns)
* Affected versions: >=3.3.1
* Package usage:
  * `node_modules/bonjour`

### braces <a href="#user-content-braces" id="braces">#</a>
* Uncontrolled resource consumption in braces
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-grv7-fg5c-xmjg](https://github.com/advisories/GHSA-grv7-fg5c-xmjg)
* Affected versions: <3.0.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/braces`

### chokidar <a href="#user-content-chokidar" id="chokidar">#</a>
* Caused by vulnerable dependency:
  * [anymatch](#user-content-anymatch)
  * [braces](#user-content-braces)
  * [readdirp](#user-content-readdirp)
* Affected versions: 1.3.0 - 2.1.8
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/chokidar`

### css-loader <a href="#user-content-css-loader" id="css-loader">#</a>
* Caused by vulnerable dependency:
  * [icss-utils](#user-content-icss-utils)
  * [postcss](#user-content-postcss)
  * [postcss-modules-extract-imports](#user-content-postcss-modules-extract-imports)
  * [postcss-modules-local-by-default](#user-content-postcss-modules-local-by-default)
  * [postcss-modules-scope](#user-content-postcss-modules-scope)
  * [postcss-modules-values](#user-content-postcss-modules-values)
* Affected versions: 0.15.0 - 4.3.0
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/css-loader`

### dns-packet <a href="#user-content-dns-packet" id="dns-packet">#</a>
* Caused by vulnerable dependency:
  * [ip](#user-content-ip)
* Affected versions: <=5.2.4
* Package usage:
  * `node_modules/bonjour/node_modules/dns-packet`

### floating-vue <a href="#user-content-floating-vue" id="floating-vue">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-resize](#user-content-vue-resize)
* Affected versions: <=1.0.0-beta.19
* Package usage:
  * `node_modules/floating-vue`

### http-proxy-middleware <a href="#user-content-http-proxy-middleware" id="http-proxy-middleware">#</a>
* Denial of service in http-proxy-middleware
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-c7qv-q95q-8v27](https://github.com/advisories/GHSA-c7qv-q95q-8v27)
* Affected versions: <=2.0.7-beta.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/http-proxy-middleware`

### icss-utils <a href="#user-content-icss-utils" id="icss-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=4.1.1
* Package usage:
  * `node_modules/icss-utils`

### ip <a href="#user-content-ip" id="ip">#</a>
* ip SSRF improper categorization in isPublic
* Severity: **high** (CVSS 8.1)
* Reference: [https://github.com/advisories/GHSA-2p57-rm9w-gvfp](https://github.com/advisories/GHSA-2p57-rm9w-gvfp)
* Affected versions: *
* Package usage:
  * `node_modules/ip`

### markdown-to-jsx <a href="#user-content-markdown-to-jsx" id="markdown-to-jsx">#</a>
* Cross site scripting in markdown-to-jsx
* Severity: **moderate** (CVSS 6.1)
* Reference: [https://github.com/advisories/GHSA-4wx3-54gh-9fr9](https://github.com/advisories/GHSA-4wx3-54gh-9fr9)
* Affected versions: <7.4.0
* Package usage:
  * `node_modules/markdown-to-jsx`

### micromatch <a href="#user-content-micromatch" id="micromatch">#</a>
* Regular Expression Denial of Service (ReDoS) in micromatch
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-952p-6rrq-rcjv](https://github.com/advisories/GHSA-952p-6rrq-rcjv)
* Affected versions: <=4.0.7
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/micromatch`

### multicast-dns <a href="#user-content-multicast-dns" id="multicast-dns">#</a>
* Caused by vulnerable dependency:
  * [dns-packet](#user-content-dns-packet)
* Affected versions: 6.0.0 - 7.2.2
* Package usage:
  * `node_modules/bonjour/node_modules/multicast-dns`

### node-forge <a href="#user-content-node-forge" id="node-forge">#</a>
* Prototype Pollution in node-forge debug API.
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-5rrq-pxf6-6jx5](https://github.com/advisories/GHSA-5rrq-pxf6-6jx5)
* Affected versions: <=1.2.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/node-forge`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`
  * `node_modules/icss-utils/node_modules/postcss`
  * `node_modules/postcss-modules-extract-imports/node_modules/postcss`
  * `node_modules/postcss-modules-local-by-default/node_modules/postcss`
  * `node_modules/postcss-modules-scope/node_modules/postcss`
  * `node_modules/postcss-modules-values/node_modules/postcss`
  * `node_modules/vue-styleguidist/node_modules/postcss`

### postcss-modules-extract-imports <a href="#user-content-postcss-modules-extract-imports" id="postcss-modules-extract-imports">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=2.0.0
* Package usage:
  * `node_modules/postcss-modules-extract-imports`

### postcss-modules-local-by-default <a href="#user-content-postcss-modules-local-by-default" id="postcss-modules-local-by-default">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=3.0.3
* Package usage:
  * `node_modules/postcss-modules-local-by-default`

### postcss-modules-scope <a href="#user-content-postcss-modules-scope" id="postcss-modules-scope">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=2.2.0
* Package usage:
  * `node_modules/postcss-modules-scope`

### postcss-modules-values <a href="#user-content-postcss-modules-values" id="postcss-modules-values">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: <=3.0.0
* Package usage:
  * `node_modules/postcss-modules-values`

### react-styleguidist <a href="#user-content-react-styleguidist" id="react-styleguidist">#</a>
* Caused by vulnerable dependency:
  * [markdown-to-jsx](#user-content-markdown-to-jsx)
  * [webpack-dev-server](#user-content-webpack-dev-server)
* Affected versions: >=5.0.0-beta.9
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/react-styleguidist`

### readdirp <a href="#user-content-readdirp" id="readdirp">#</a>
* Caused by vulnerable dependency:
  * [micromatch](#user-content-micromatch)
* Affected versions: 2.2.0 - 2.2.1
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/readdirp`

### selfsigned <a href="#user-content-selfsigned" id="selfsigned">#</a>
* Caused by vulnerable dependency:
  * [node-forge](#user-content-node-forge)
* Affected versions: 1.1.1 - 1.10.14
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/selfsigned`

### vue-frag <a href="#user-content-vue-frag" id="vue-frag">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: >=1.3.1
* Package usage:
  * `node_modules/vue-frag`

### vue-inbrowser-compiler <a href="#user-content-vue-inbrowser-compiler" id="vue-inbrowser-compiler">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler`

### vue-inbrowser-compiler-demi <a href="#user-content-vue-inbrowser-compiler-demi" id="vue-inbrowser-compiler-demi">#</a>
* Caused by vulnerable dependency:
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler-demi`

### vue-inbrowser-compiler-utils <a href="#user-content-vue-inbrowser-compiler-utils" id="vue-inbrowser-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-demi](#user-content-vue-inbrowser-compiler-demi)
* Affected versions: >=4.50.0
* Package usage:
  * `node_modules/vue-inbrowser-compiler-utils`

### vue-inbrowser-prismjs-highlighter <a href="#user-content-vue-inbrowser-prismjs-highlighter" id="vue-inbrowser-prismjs-highlighter">#</a>
* Caused by vulnerable dependency:
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
* Affected versions: *
* Package usage:
  * `node_modules/vue-inbrowser-prismjs-highlighter`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-styleguidist <a href="#user-content-vue-styleguidist" id="vue-styleguidist">#</a>
* Caused by vulnerable dependency:
  * [@babel/runtime](#user-content-\@babel\/runtime)
  * [css-loader](#user-content-css-loader)
  * [react-styleguidist](#user-content-react-styleguidist)
  * [vue-inbrowser-compiler](#user-content-vue-inbrowser-compiler)
  * [vue-inbrowser-compiler-utils](#user-content-vue-inbrowser-compiler-utils)
  * [vue-inbrowser-prismjs-highlighter](#user-content-vue-inbrowser-prismjs-highlighter)
  * [vue-template-compiler](#user-content-vue-template-compiler)
  * [webpack-dev-server](#user-content-webpack-dev-server)
* Affected versions: *
* Package usage:
  * `node_modules/vue-styleguidist`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vue2-datepicker <a href="#user-content-vue2-datepicker" id="vue2-datepicker">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: <=1.9.8 || 3.0.2 - 3.11.1
* Package usage:
  * `node_modules/vue2-datepicker`

### webpack-dev-middleware <a href="#user-content-webpack-dev-middleware" id="webpack-dev-middleware">#</a>
* Path traversal in webpack-dev-middleware
* Severity: **high** (CVSS 7.4)
* Reference: [https://github.com/advisories/GHSA-wr3j-pwj9-hqq6](https://github.com/advisories/GHSA-wr3j-pwj9-hqq6)
* Affected versions: <=5.3.3
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/webpack-dev-middleware`

### webpack-dev-server <a href="#user-content-webpack-dev-server" id="webpack-dev-server">#</a>
* Caused by vulnerable dependency:
  * [bonjour](#user-content-bonjour)
  * [chokidar](#user-content-chokidar)
  * [http-proxy-middleware](#user-content-http-proxy-middleware)
  * [ip](#user-content-ip)
  * [selfsigned](#user-content-selfsigned)
  * [webpack-dev-middleware](#user-content-webpack-dev-middleware)
* Affected versions: <=4.7.4
* Package usage:
  * `node_modules/vue-styleguidist/node_modules/webpack-dev-server`