### PR TITLE
fix(NcEmojiPicker): return focus steals actual focus

### DIFF
--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -195,6 +195,7 @@ This component allows the user to pick an emoji.
 
 <script>
 import { Picker, Emoji, EmojiIndex } from 'emoji-mart-vue-fast'
+import { isFocusable } from 'tabbable'
 import { t } from '../../l10n.js'
 import { getCurrentSkinTone, setCurrentSkinTone } from '../../functions/emoji/emoji.ts'
 import { useTrapStackControl } from '../../composables/useTrapStackControl.ts'
@@ -408,7 +409,10 @@ export default {
 
 		afterHide() {
 			// Manually return focus to the trigger button, as we disabled focus-trap
-			this.$refs.popover.$el.querySelector('button, [role="button"]')?.focus()
+			// But only if there is no focus target outside the picker, for example, input element that received focus by click closing the emoji picker
+			if (!document.activeElement || this.$refs.picker.$el.contains(document.activeElement) || !isFocusable(document.activeElement)) {
+				this.$refs.popover.$el.querySelector('button, [role="button"]')?.focus()
+			}
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

Like in a `focus-trap`, we should only return focus on close if the closing action didn't add the focus already, for example, when the emoji picker was closed by clicking on an input field.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
