### PR TITLE
refactor: replace boolean properties with `default: true` with `defau…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,8 +87,14 @@ are now removed. Following components have been adjusted:
 
 |     Component | Removed deprecated prop | New alternative |
 |---------------|-------------------------|-----------------|
-|     `NcModal` |           `enableSwipe` |  `disableSwipe` |
 |`NcAppContent` |  `allowSwipeNavigation` | `disabledSwipe` |
+|    `NcAvatar` |        `showUserStatus` |    `hideStatus` |
+|    `NcAvatar` | `showUserStatusCompact` | `verboseStatus` |
+|     `NcModal` |           `enableSwipe` |  `disableSwipe` |
+|     `NcModal` |              `canClose` |       `noClose` |
+|    `NcDialog` |              `canClose` |       `noClose` |
+
+Additionally the default value `closeOnClickOutside` for `NcModal` was aligned with `NcDialog` and now defaults to `false`.
 
 #### Mixins are removed
 Mixins only work in Options API and are in general not recommended by Vue anymore:

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -321,18 +321,18 @@ export default {
 			default: undefined,
 		},
 		/**
-		 * Whether or not to display the user-status
+		 * Do not show the user status on the avatar.
 		 */
-		showUserStatus: {
+		hideStatus: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 		/**
-		 * Whether or not to the status-icon should be used instead of online/away
+		 * Show the verbose user status (e.g. "online" / "away") instead of just the status icon.
 		 */
-		showUserStatusCompact: {
+		verboseStatus: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 		/**
 		 * When the user status was preloaded via another source it can be handed in with this property to save the request.
@@ -368,11 +368,11 @@ export default {
 			default: 32,
 		},
 		/**
-		 * Placeholder avatars will be automatically generated when this is set to true
+		 * Do not automatically generate a placeholder avatars if there is no real avatar is available.
 		 */
-		allowPlaceholder: {
+		noPlaceholder: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 		/**
 		 * Disable the tooltip
@@ -441,13 +441,13 @@ export default {
 			return t('Avatar of {displayName}', { displayName: this.displayName ?? this.user })
 		},
 		canDisplayUserStatus() {
-			return this.showUserStatus
+			return !this.hideStatus
 				&& this.hasStatus
 				&& ['online', 'away', 'busy', 'dnd'].includes(this.userStatus.status)
 		},
 		showUserStatusIconOnAvatar() {
-			return this.showUserStatus
-				&& this.showUserStatusCompact
+			return !this.hideStatus
+				&& !this.verboseStatus
 				&& this.hasStatus
 				&& this.userStatus.status !== 'dnd'
 				&& this.userStatus.icon
@@ -488,7 +488,7 @@ export default {
 		 * True if initials should be shown as the user icon fallback
 		 */
 		showInitials() {
-			return this.allowPlaceholder && this.userDoesNotExist && !(this.iconClass || this.$slots.icon?.())
+			return !this.noPlaceholder && this.userDoesNotExist && !(this.iconClass || this.$slots.icon?.())
 		},
 
 		avatarStyle() {
@@ -582,7 +582,7 @@ export default {
 				return p.innerHTML
 			}
 
-			if (this.showUserStatus && (this.userStatus.icon || this.userStatus.message)) {
+			if (!this.hideStatus && (this.userStatus.icon || this.userStatus.message)) {
 				// NcAction's URL icons are inverted in dark mode, so we need to pass SVG image in the icon slot
 				const emojiIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
 					<text x="50%" y="50%" text-anchor="middle" style="dominant-baseline: central; font-size: 85%">${escape(this.userStatus.icon)}</text>
@@ -615,7 +615,7 @@ export default {
 		this.loadAvatarUrl()
 		subscribe('settings:avatar:updated', this.loadAvatarUrl)
 		subscribe('settings:display-name:updated', this.loadAvatarUrl)
-		if (this.showUserStatus && this.user && !this.isNoUser) {
+		if (!this.hideStatus && this.user && !this.isNoUser) {
 			if (!this.preloadedUserStatus) {
 				this.fetchUserStatus(this.user)
 			} else {
@@ -631,7 +631,7 @@ export default {
 	beforeUnmount() {
 		unsubscribe('settings:avatar:updated', this.loadAvatarUrl)
 		unsubscribe('settings:display-name:updated', this.loadAvatarUrl)
-		if (this.showUserStatus && this.user && !this.isNoUser) {
+		if (!this.hideStatus && this.user && !this.isNoUser) {
 			unsubscribe('user_status:status.updated', this.handleUserStatusUpdated)
 		}
 	},

--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -54,7 +54,7 @@ You can also use the default slot to inject custom content.
 	<div style="display: flex; gap: 12px;">
 		<NcButton @click="showDialog = true">Show dialog</NcButton>
 		<NcButton @click="showLongDialog = true">Show long dialog</NcButton>
-		<NcDialog v-if="showDialog" name="Warning" :can-close="false">
+		<NcDialog v-if="showDialog" name="Warning" no-close>
 			<template #actions>
 				<NcButton @click="showDialog = false">Ok</NcButton>
 			</template>
@@ -351,17 +351,17 @@ export default defineComponent({
 		},
 
 		/**
-		 * Set to false to no show a close button on the dialog
-		 * @default true
+		 * Do not show the close button for the dialog.
+		 * @default false
 		 */
-		canClose: {
+		noClose: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 
 		/**
 		 * Close the dialog if the user clicked outside of the dialog
-		 * Only relevant if `canClose` is set to true.
+		 * Only relevant if `noClose` is not set.
 		 */
 		closeOnClickOutside: {
 			type: Boolean,
@@ -585,7 +585,7 @@ export default defineComponent({
 		 * Properties to pass to the underlying NcModal
 		 */
 		const modalProps = computed(() => ({
-			canClose: props.canClose,
+			noClose: props.noClose,
 			container: props.container === undefined ? 'body' : props.container,
 			// we do not pass the name as we already have the name as the headline
 			// name: props.name,

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -252,7 +252,7 @@ export default {
 						</NcActions>
 
 						<!-- Close modal -->
-						<NcButton v-if="canClose && !closeButtonContained"
+						<NcButton v-if="!noClose && !closeButtonContained"
 							:aria-label="closeButtonAriaLabel"
 							class="header-close"
 							type="tertiary"
@@ -294,7 +294,7 @@ export default {
 							<slot />
 						</div>
 						<!-- Close modal -->
-						<NcButton v-if="canClose && closeButtonContained"
+						<NcButton v-if="!noClose && closeButtonContained"
 							type="tertiary"
 							class="modal-container__close"
 							:aria-label="closeButtonAriaLabel"
@@ -435,20 +435,21 @@ export default {
 		},
 
 		/**
-		 * Declare if the modal can be closed
+		 * Do not show the close button for the dialog.
+		 * @default false
 		 */
-		canClose: {
+		noClose: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 
 		/**
 		 * Close the modal if the user clicked outside the modal
-		 * Only relevant if `canClose` is set to true.
+		 * Only relevant if `noClose` is not set.
 		 */
 		closeOnClickOutside: {
 			type: Boolean,
-			default: true,
+			default: false,
 		},
 
 		/**
@@ -669,19 +670,21 @@ export default {
 		},
 		close(data) {
 			// do not fire event if forbidden
-			if (this.canClose) {
-				// We set internalShow here, so the out transitions properly run before the component is destroyed
-				this.internalShow = false
-				this.$emit('update:show', false)
-
-				// delay closing for animation
-				setTimeout(() => {
-					/**
-					 * Emitted when the closing animation is finished
-					 */
-					this.$emit('close', data)
-				}, 300)
+			if (this.noClose) {
+				return
 			}
+
+			// We set internalShow here, so the out transitions properly run before the component is destroyed
+			this.internalShow = false
+			this.$emit('update:show', false)
+
+			// delay closing for animation
+			setTimeout(() => {
+				/**
+				 * Emitted when the closing animation is finished
+				 */
+				this.$emit('close', data)
+			}, 300)
 		},
 
 		/**

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -169,7 +169,7 @@ export default {
 		/**
 		 * Controls whether to display the trailing button.
 		 */
-		 showTrailingButton: {
+		showTrailingButton: {
 			type: Boolean,
 			default: true,
 		},

--- a/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
@@ -6,7 +6,6 @@
 <template>
 	<NcModal v-if="show"
 		:size="modalSize"
-		:can-close="true"
 		class="reference-picker-modal"
 		@close="onCancel">
 		<div ref="modal_content"

--- a/tests/unit/components/NcAvatar/NcAvatar.spec.ts
+++ b/tests/unit/components/NcAvatar/NcAvatar.spec.ts
@@ -62,7 +62,7 @@ describe('NcAvatar.vue', () => {
 				user: 'janedoe',
 				displayName: 'J. Doe',
 				preloadedUserStatus: status,
-				showUserStatus: false,
+				hideStatus: true,
 			},
 		})
 

--- a/tests/unit/components/NcModal/modal.spec.js
+++ b/tests/unit/components/NcModal/modal.spec.js
@@ -8,8 +8,8 @@ import { describe, expect, it } from 'vitest'
 import NcModal from '../../../../src/components/NcModal/NcModal.vue'
 
 describe('NcModal', () => {
-	it('closes on click outside with `canClose`', async () => {
-		const wrapper = mount(NcModal, { props: { canClose: true, title: 'modal' } })
+	it('closes on click outside without `noClose`', async () => {
+		const wrapper = mount(NcModal, { props: { noClose: false, closeOnClickOutside: true, title: 'modal' } })
 		expect(wrapper.html().includes('modal-wrapper')).toBe(true)
 
 		expect(wrapper.emitted('update:show')).toBe(undefined)
@@ -19,8 +19,8 @@ describe('NcModal', () => {
 		expect(wrapper.emitted('update:show')).toEqual([[false]])
 	})
 
-	it('not closes on click outside when `canClose` is false', async () => {
-		const wrapper = mount(NcModal, { props: { canClose: false, title: 'modal' } })
+	it('not closes on click outside when `noClose` is true', async () => {
+		const wrapper = mount(NcModal, { props: { noClose: true, title: 'modal' } })
 		expect(wrapper.html().includes('modal-wrapper')).toBe(true)
 
 		expect(wrapper.emitted('update:show')).toBe(undefined)
@@ -30,8 +30,8 @@ describe('NcModal', () => {
 		expect(wrapper.emitted('update:show')).toEqual(undefined)
 	})
 
-	it('not closes on click outside when `canClose` is true but `closeOnClickOutside` is false', async () => {
-		const wrapper = mount(NcModal, { props: { canClose: true, closeOnClickOutside: false, title: 'modal' } })
+	it('not closes on click outside when `noClose` is false but `closeOnClickOutside` is false', async () => {
+		const wrapper = mount(NcModal, { props: { noClose: false, closeOnClickOutside: false, title: 'modal' } })
 		expect(wrapper.html().includes('modal-wrapper')).toBe(true)
 
 		expect(wrapper.emitted('update:show')).toBe(undefined)


### PR DESCRIPTION
### ☑️ Resolves

- `NcAvatar`
  - old: `showUserStatus`
  - new:`hideStatus`
- `NcAvatar`
  - old:`showUserStatusCompact`
  - new: `verboseStatus`
-  `NcModa`
   - old: `canClose`
   - new: `noClose`
- `NcDialog`
  - old: `canClose`
  - new: `noClose`

Additionally the default value `closeOnClickOutside` for `NcModal` was aligned with `NcDialog` and now defaults to `false`.

### 🚧 Tasks

- [ ] Afterwards adjust master

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
