### PR TITLE
docs(readme): add a hint about mdast-util-gfm-autolink-literal issue 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@
 | v7.x [stable7] | Nextcloud 25 - 27     | https://stable7--nextcloud-vue-components.netlify.app |
 | v6.x [stable6] | Nextcloud 24 - 25     | https://stable6--nextcloud-vue-components.netlify.app |
 
+## 🧩 Compatibility
+
+For `NcRichText` component an external library `mdast-util-gfm-autolink-literal` is used. If your app requires compatibility with Safari <16.4, consider locking it in your app package.json file:
+```json
+"overrides": {
+  "mdast-util-gfm": {
+    "mdast-util-gfm-autolink-literal": "2.0.0"
+  }
+}
+```
+
 ## 📦 Install
 
 ```bash
@@ -38,7 +49,7 @@ Import corresponding components and other modules on use. Check the documentatio
 import NcButton from '@nextcloud/vue/components/NcButton'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 
-// (Deprecated) Old import path 
+// (Deprecated) Old import path
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import { useHotKey } from '@nextcloud/vue/dist/Composables/useHotKey.js'
 ```
@@ -80,7 +91,7 @@ Vue.use(NextcloudVuePlugin)
    - Sign-off you commits for the [Developer Certificate of Origin (DCO)](https://developercertificate.org/)
 6. Get your PR reviewed
    - If you don't receive a feedback in a week, feel free to mention the maintainers, for example, last developers worked on the module
-7. Get your PR merged 
+7. Get your PR merged
 
 Please read the [Code of Conduct](https://nextcloud.com/community/code-of-conduct/). This document offers some guidance to ensure Nextcloud participants can cooperate effectively in a positive and inspiring atmosphere and to explain how together we can strengthen and support each other.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "focus-trap": "^7.4.3",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
+        "mdast-util-gfm-autolink-literal": "2.0.0",
         "p-queue": "^8.1.0",
         "rehype-external-links": "^3.0.0",
         "rehype-highlight": "^7.0.2",
@@ -20518,6 +20519,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.0.tgz",
       "integrity": "sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "ccount": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "focus-trap": "^7.4.3",
     "linkify-string": "^4.0.0",
     "md5": "^2.3.0",
+    "mdast-util-gfm-autolink-literal": "2.0.0",
     "p-queue": "^8.1.0",
     "rehype-external-links": "^3.0.0",
     "rehype-highlight": "^7.0.2",


### PR DESCRIPTION
### ☑️ Resolves

- Ref https://github.com/nextcloud/server/issues/51506

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
