### PR TITLE
feat(NcAppSidebar): add `info` slot

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -1287,6 +1287,9 @@ $top-buttons-spacing: 6px;
 	}
 
 	.app-sidebar-header {
+		// Variable for custom content to be aware of space taken by close button (from top-right corner)
+		--app-sidebar-close-button-offset: calc(var(--default-clickable-area) + #{$top-buttons-spacing});
+
 		> .app-sidebar__close {
 			position: absolute;
 			z-index: 100;
@@ -1321,11 +1324,11 @@ $top-buttons-spacing: 6px;
 					padding-inline-start: 0;
 					flex: 1 1 auto;
 					min-width: 0;
-					padding-inline-end: calc(2 * var(--default-clickable-area) + $top-buttons-spacing);
+					padding-inline-end: calc(var(--default-clickable-area) + var(--app-sidebar-close-button-offset));
 					padding-top: var(--app-sidebar-padding);
 
 					&.app-sidebar-header__desc--without-actions {
-						padding-inline-end: calc(var(--default-clickable-area) + $top-buttons-spacing);
+						padding-inline-end: var(--app-sidebar-close-button-offset);
 					}
 
 					.app-sidebar-header__tertiary-actions {
@@ -1337,7 +1340,7 @@ $top-buttons-spacing: 6px;
 					}
 					.app-sidebar-header__menu {
 						top: $top-buttons-spacing;
-						inset-inline-end: calc(var(--default-clickable-area) + $top-buttons-spacing); // left of the close button
+						inset-inline-end: var(--app-sidebar-close-button-offset); // left of the close button
 						position: absolute;
 					}
 				}
@@ -1350,14 +1353,14 @@ $top-buttons-spacing: 6px;
 			.app-sidebar-header__menu {
 				position: absolute;
 				top: $top-buttons-spacing;
-				inset-inline-end: calc($top-buttons-spacing + var(--default-clickable-area));
+				inset-inline-end: var(--app-sidebar-close-button-offset);
 			}
 			// increase the padding to not overlap the menu
 			.app-sidebar-header__desc {
-				padding-inline-end: calc(var(--default-clickable-area) * 2 + $top-buttons-spacing);
+				padding-inline-end: calc(var(--default-clickable-area) + var(--app-sidebar-close-button-offset));
 
 				&.app-sidebar-header__desc--without-actions {
-					padding-inline-end: calc(var(--default-clickable-area) + $top-buttons-spacing);
+					padding-inline-end: var(--app-sidebar-close-button-offset);
 				}
 			}
 		}

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -571,103 +571,108 @@ export default {
 					'app-sidebar-header--compact': compact,
 				}"
 				class="app-sidebar-header">
-				<!-- container for figure and description, allows easy switching to compact mode -->
-				<div class="app-sidebar-header__info">
-					<!-- sidebar header illustration/figure -->
-					<div v-if="(isSlotPopulated($slots.header?.()) || background) && !empty"
-						:class="{
-							'app-sidebar-header__figure--with-action': hasFigureClickListener
-						}"
-						class="app-sidebar-header__figure"
-						:style="{
-							backgroundImage: `url(${background})`
-						}"
-						tabindex="0"
-						@click="onFigureClick"
-						@keydown.enter="onFigureClick">
-						<slot class="app-sidebar-header__background" name="header" />
-					</div>
-
-					<!-- sidebar details -->
-					<div v-if="!empty"
-						:class="{
-							'app-sidebar-header__desc--with-tertiary-action': canStar || isSlotPopulated($slots['tertiary-actions']?.()),
-							'app-sidebar-header__desc--editable': nameEditable && !subname,
-							'app-sidebar-header__desc--with-subname--editable': nameEditable && subname,
-							'app-sidebar-header__desc--without-actions': !isSlotPopulated($slots['secondary-actions']?.()),
-						}"
-						class="app-sidebar-header__desc">
-						<!-- favourite icon -->
-						<div v-if="canStar || isSlotPopulated($slots['tertiary-actions']?.())" class="app-sidebar-header__tertiary-actions">
-							<slot name="tertiary-actions">
-								<NcButton v-if="canStar"
-									:aria-label="favoriteTranslated"
-									:pressed="isStarred"
-									class="app-sidebar-header__star"
-									variant="secondary"
-									@click.prevent="toggleStarred">
-									<template #icon>
-										<NcLoadingIcon v-if="starLoading" />
-										<IconStar v-else-if="isStarred" :size="20" />
-										<IconStarOutline v-else :size="20" />
-									</template>
-								</NcButton>
-							</slot>
+				<!-- @slot Alternative to the default header info: use for bare NcAppSidebar with tabs.
+					NcAppSidebarHeader would be required to use for accessibility reasons.
+					This will be overridden by `empty` prop.
+				-->
+				<slot v-if="!empty" name="info">
+					<!-- container for figure and description, allows easy switching to compact mode -->
+					<div class="app-sidebar-header__info">
+						<!-- sidebar header illustration/figure -->
+						<div v-if="(isSlotPopulated($slots.header?.()) || background)"
+							:class="{
+								'app-sidebar-header__figure--with-action': hasFigureClickListener
+							}"
+							class="app-sidebar-header__figure"
+							:style="{
+								backgroundImage: `url(${background})`
+							}"
+							tabindex="0"
+							@click="onFigureClick"
+							@keydown.enter="onFigureClick">
+							<slot class="app-sidebar-header__background" name="header" />
 						</div>
 
-						<!-- name -->
-						<div class="app-sidebar-header__name-container">
-							<div class="app-sidebar-header__mainname-container">
-								<!-- main name -->
-								<NcAppSidebarHeader v-show="!nameEditable"
-									class="app-sidebar-header__mainname"
-									:name
-									:linkify="linkifyName"
-									:title
-									:tabindex="nameEditable ? 0 : -1"
-									@click.self="editName" />
-								<template v-if="nameEditable">
-									<form v-click-outside="() => onSubmitName()"
-										class="app-sidebar-header__mainname-form"
-										@submit.prevent="onSubmitName">
-										<input ref="nameInput"
-											v-focus
-											class="app-sidebar-header__mainname-input"
-											type="text"
-											:placeholder="namePlaceholder"
-											:value="name"
-											@keydown.esc.stop="onDismissEditing"
-											@input="onNameInput">
-										<NcButton :aria-label="changeNameTranslated"
-											type="submit"
-											variant="tertiary-no-background">
-											<template #icon>
-												<IconArrowRight :size="20" />
-											</template>
-										</NcButton>
-									</form>
-								</template>
-								<!-- header main menu -->
-								<NcActions v-if="isSlotPopulated($slots['secondary-actions']?.())"
-									class="app-sidebar-header__menu"
-									:force-menu="forceMenu">
-									<slot name="secondary-actions" />
-								</NcActions>
-							</div>
-							<!-- secondary name -->
-							<p v-if="subname.trim() !== '' || $slots['subname']"
-								:title="subtitle || undefined"
-								class="app-sidebar-header__subname">
-								<!-- @slot Alternative to the `subname` prop can be used for more complex conent. It will be rendered within a `p` tag. -->
-								<slot name="subname">
-									{{ subname }}
+						<!-- sidebar details -->
+						<div :class="{
+								'app-sidebar-header__desc--with-tertiary-action': canStar || isSlotPopulated($slots['tertiary-actions']?.()),
+								'app-sidebar-header__desc--editable': nameEditable && !subname,
+								'app-sidebar-header__desc--with-subname--editable': nameEditable && subname,
+								'app-sidebar-header__desc--without-actions': !isSlotPopulated($slots['secondary-actions']?.()),
+							}"
+							class="app-sidebar-header__desc">
+							<!-- favourite icon -->
+							<div v-if="canStar || isSlotPopulated($slots['tertiary-actions']?.())" class="app-sidebar-header__tertiary-actions">
+								<slot name="tertiary-actions">
+									<NcButton v-if="canStar"
+										:aria-label="favoriteTranslated"
+										:pressed="isStarred"
+										class="app-sidebar-header__star"
+										variant="secondary"
+										@click.prevent="toggleStarred">
+										<template #icon>
+											<NcLoadingIcon v-if="starLoading" />
+											<IconStar v-else-if="isStarred" :size="20" />
+											<IconStarOutline v-else :size="20" />
+										</template>
+									</NcButton>
 								</slot>
-							</p>
+							</div>
+
+							<!-- name -->
+							<div class="app-sidebar-header__name-container">
+								<div class="app-sidebar-header__mainname-container">
+									<!-- main name -->
+									<NcAppSidebarHeader v-show="!nameEditable"
+										class="app-sidebar-header__mainname"
+										:name
+										:linkify="linkifyName"
+										:title
+										:tabindex="nameEditable ? 0 : -1"
+										@click.self="editName" />
+									<template v-if="nameEditable">
+										<form v-click-outside="() => onSubmitName()"
+											class="app-sidebar-header__mainname-form"
+											@submit.prevent="onSubmitName">
+											<input ref="nameInput"
+												v-focus
+												class="app-sidebar-header__mainname-input"
+												type="text"
+												:placeholder="namePlaceholder"
+												:value="name"
+												@keydown.esc.stop="onDismissEditing"
+												@input="onNameInput">
+											<NcButton :aria-label="changeNameTranslated"
+												type="submit"
+												variant="tertiary-no-background">
+												<template #icon>
+													<IconArrowRight :size="20" />
+												</template>
+											</NcButton>
+										</form>
+									</template>
+									<!-- header main menu -->
+									<NcActions v-if="isSlotPopulated($slots['secondary-actions']?.())"
+										class="app-sidebar-header__menu"
+										:force-menu="forceMenu">
+										<slot name="secondary-actions" />
+									</NcActions>
+								</div>
+								<!-- secondary name -->
+								<p v-if="subname.trim() !== '' || $slots['subname']"
+									:title="subtitle || undefined"
+									class="app-sidebar-header__subname">
+									<!-- @slot Alternative to the `subname` prop can be used for more complex conent. It will be rendered within a `p` tag. -->
+									<slot name="subname">
+										{{ subname }}
+									</slot>
+								</p>
+							</div>
 						</div>
 					</div>
-				</div>
+				</slot>
 				<!-- a11y fallback for empty content -->
-				<NcAppSidebarHeader v-if="empty"
+				<NcAppSidebarHeader v-else
 					class="app-sidebar-header__mainname--hidden"
 					:name
 					tabindex="-1" />

--- a/src/components/NcAppSidebarHeader/NcAppSidebarHeader.vue
+++ b/src/components/NcAppSidebarHeader/NcAppSidebarHeader.vue
@@ -1,0 +1,37 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { inject } from 'vue'
+import vLinkify from '../../directives/Linkify/index.ts'
+
+defineProps<{
+	/**
+	 * The name used in NcAppSidebar header.
+	 */
+	name: string,
+
+	/**
+	 * Title to display for the name.
+	 */
+	title?: string,
+
+	/**
+	 * Linkify the name.
+	 */
+	linkify?: boolean,
+}>()
+
+const headerRef = inject('NcAppSidebar:header:ref')
+</script>
+
+<template>
+	<h2 ref="headerRef"
+		v-linkify="{ text: name, linkify }"
+		tabindex="-1"
+		:title>
+		{{ name }}
+	</h2>
+</template>

--- a/src/components/NcAppSidebarHeader/index.ts
+++ b/src/components/NcAppSidebarHeader/index.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export { default } from './NcAppSidebarHeader.vue'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,6 +31,7 @@ export { default as NcAppNavigationSpacer } from './NcAppNavigationSpacer/index.
 export { default as NcAppSettingsDialog } from './NcAppSettingsDialog/index.js'
 export { default as NcAppSettingsSection } from './NcAppSettingsSection/index.js'
 export { default as NcAppSidebar } from './NcAppSidebar/index.js'
+export { default as NcAppSidebarHeader } from './NcAppSidebarHeader/index.ts'
 export { default as NcAppSidebarTab } from './NcAppSidebarTab/index.js'
 export { default as NcAvatar } from './NcAvatar/index.js'
 export { default as NcBlurHash } from './NcBlurHash/index.js'

--- a/styleguide.config.cjs
+++ b/styleguide.config.cjs
@@ -233,6 +233,7 @@ module.exports = async () => {
 								name: 'NcAppSidebar',
 								components: [
 									'src/components/NcAppSidebar/NcAppSidebar.vue',
+									'src/components/NcAppSidebarHeader/NcAppSidebarHeader.vue',
 									'src/components/NcAppSidebarTab/NcAppSidebarTab.vue',
 								],
 							},


### PR DESCRIPTION
### ☑️ Resolves

- Allows to put custom content with `info` slot
- Expose `var(--app-sidebar-close-button-offset)` for custom content positioning (respecting the space taken by close button)
- Introduce `NcAppSidebarHeader` for a11y navigation

See https://github.com/nextcloud-libraries/nextcloud-vue/pull/6666/files?w=1 for non-whitespace changes
See https://github.com/nextcloud-libraries/nextcloud-vue/tree/feat/noid/appsidebar-header-empty-slot-vue2 for Vue2 branch to test with apps

### 🖼️ Screenshots

Quick prototype for Talk:

Clean | WIth explanation
-- | --
![image](https://github.com/user-attachments/assets/7cdd3ba4-9b73-4459-b841-9dd4c602f0a9) | ![image](https://github.com/user-attachments/assets/d68791b3-41b9-40bc-b883-38dc1f00d54b)

https://github.com/user-attachments/assets/8815ee43-7b35-4453-a1ef-852bb7cac181

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `stable8` requested
