### PR TITLE
fix(NcAvatar): keep line-height only for 'initials' avatars

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -517,12 +517,11 @@ export default {
 		},
 
 		avatarStyle() {
-			const style = {
+			return {
 				'--size': this.size + 'px',
-				lineHeight: this.size + 'px',
+				lineHeight: this.showInitials ? (this.size + 'px') : 0,
 				fontSize: Math.round(this.size * 0.45) + 'px',
 			}
-			return style
 		},
 		initialsWrapperStyle() {
 			const { r, g, b } = usernameToColor(this.userIdentifier)


### PR DESCRIPTION
### ☑️ Resolves

- Fix unnecessary scrolling, if NcAvatar is in the list
  - There might be an invisible symbol rendered, which causes DOM element to be larger than its actual size
  - If there is no image, but only initials - line-height centers them in the circle, and scroll-height is correct

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![2025-03-31_19h30_49](https://github.com/user-attachments/assets/ca5db8c7-9911-4328-a2f2-cf4f6844d74c) | ![2025-03-31_19h30_28](https://github.com/user-attachments/assets/f4d8be85-078f-4f0b-9e06-5d629fabd63f)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 3️⃣ Backport to `next` requested with a Vue 3 upgrade
