### PR TITLE
feat(NcActions): fix listening to wrong event names and add `opened` event / [NcPopover] animation wait

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -384,11 +384,6 @@ export default {
 		ChevronRightIcon,
 		ChevronLeftIcon,
 	},
-	setup() {
-		return {
-			isRtl,
-		}
-	},
 	mixins: [ActionTextMixin],
 
 	inject: {
@@ -461,6 +456,11 @@ export default {
 			type: String,
 			default: null,
 		},
+	},
+	setup() {
+		return {
+			isRtl,
+		}
 	},
 
 	computed: {

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1179,12 +1179,15 @@ export default {
 	},
 
 	emits: [
-		'open',
-		'update:open',
-		'close',
-		'focus',
-		'blur',
 		'click',
+		'blur',
+		'focus',
+
+		'close',
+		'closed',
+		'open',
+		'opened',
+		'update:open',
 	],
 
 	setup(props) {
@@ -1471,10 +1474,17 @@ export default {
 		/**
 		 * Called when popover is shown after the show delay
 		 */
-		onOpen() {
+		onOpened() {
 			this.$nextTick(() => {
 				this.focusFirstAction(null)
 				this.resizePopover()
+
+				/**
+				 * Event emitted when the popover menu is opened.
+				 *
+				 * This event is emitted after `update:open` was emitted and the opening transition finished.
+				 */
+				this.$emit('opened')
 			})
 		},
 
@@ -1901,9 +1911,9 @@ export default {
 					},
 					on: {
 						show: this.openMenu,
-						'apply-show': this.onOpen,
+						'after-show': this.onOpened,
 						hide: this.closeMenu,
-						'apply-hide': this.onClosed,
+						'after-hide': this.onClosed,
 					},
 				},
 				[

--- a/src/components/NcAppNavigationNew/NcAppNavigationNew.vue
+++ b/src/components/NcAppNavigationNew/NcAppNavigationNew.vue
@@ -84,7 +84,7 @@ export default {
 			validator(value) {
 				return ['primary', 'secondary', 'tertiary'].indexOf(value) !== -1
 			},
-		}
+		},
 	},
 
 	emits: ['click'],

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -153,8 +153,8 @@ export default {
 </docs>
 <template>
 	<span ref="main"
-		:title="tooltip"
 		v-click-outside="closeMenu"
+		:title="tooltip"
 		:class="{
 			'avatardiv--unknown': userDoesNotExist,
 			'avatardiv--with-menu': hasMenu,

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -174,7 +174,6 @@ import NcPopoverTriggerProvider from './NcPopoverTriggerProvider.vue'
  * @typedef {import('focus-trap').FocusTargetValueOrFalse} FocusTargetValueOrFalse
  * @typedef {FocusTargetValueOrFalse|() => FocusTargetValueOrFalse} SetReturnFocus
  */
-
 export default {
 	name: 'NcPopover',
 
@@ -239,6 +238,7 @@ export default {
 	data() {
 		return {
 			internalShown: this.shown,
+			animationDuration: 100,
 		}
 	},
 
@@ -254,6 +254,7 @@ export default {
 
 	mounted() {
 		this.checkTriggerA11y()
+		this.animationDuration = parseInt(getComputedStyle(this.$el).getPropertyValue('--animation-quick')) || 100
 	},
 
 	beforeDestroy() {
@@ -385,6 +386,7 @@ export default {
 			await this.useFocusTrap()
 			this.addEscapeStopPropagation()
 
+			setTimeout(() => {
 			/**
 			 * Triggered after the tooltip was visually displayed.
 			 *
@@ -392,15 +394,19 @@ export default {
 			 * run earlier than this where there is no guarantee that the
 			 * tooltip is already visible and in the DOM.
 			 */
-			this.$emit('after-show')
+				this.$emit('after-show')
+			}, this.animationDuration)
 		},
-		afterHide() {
+		async afterHide() {
 			this.clearFocusTrap()
 			this.clearEscapeStopPropagation()
-			/**
-			 * Triggered after the tooltip was visually hidden.
-			 */
-			this.$emit('after-hide')
+
+			setTimeout(() => {
+				/**
+				 * Triggered after the tooltip was visually hidden.
+				 */
+				this.$emit('after-hide')
+			}, this.animationDuration)
 		},
 	},
 }


### PR DESCRIPTION
## NcAcions

Following https://github.com/nextcloud-libraries/nextcloud-vue/pull/6065

The evets are `after-hide` and `after-show`, not `apply-hide` and `apply-show`
https://github.com/nextcloud/nextcloud-vue/blob/ae77137aee5097dcbe8cef6c53eb1ce3bc81c7ee/src/components/NcPopover/NcPopover.vue#L230-L237


## NcPopover
The vue-floating lib does not properly compute how long it needs to wait to know the popup have been shown/hidden.
I investigated and it's [only using `requestAnimationFrame`](https://github.com/Akryum/floating-vue/blob/19857764c4f73dea7ed44a7d970adb968ee7ad90/packages/floating-vue/src/components/Popper.ts#L728-L782) which in that case _isn't_ enough to ensure its completion.
Because we have our own custom animation variables, we need to manually check for it ourselves.

Tested on Server with log entries to see the duration ([we use `--animation-quick`](https://github.com/nextcloud/nextcloud-vue/blob/ed4b48d50d219b5e52fc5bd96eb72329ecba3959/src/components/NcPopover/NcPopover.vue#L511-L521) which is 100ms for us)
| Before | After |
|:---------:|:------:|
|![image](https://github.com/user-attachments/assets/8b36b038-044f-4018-97ea-5a2c89049fb8)|![2025-04-02_10-23](https://github.com/user-attachments/assets/cbb6fedd-badd-47df-8c33-e9d3a14916a8)|