### PR TITLE
[next] fix(NcPopover): add `passive: true` to `transitionend` event listener

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -379,7 +379,7 @@ export default {
 				 * tooltip is already visible and in the DOM.
 				 */
 				this.$emit('after-show')
-			}, { once: true })
+			}, { once: true, passive: true })
 
 			this.removeFloatingVueAriaDescribedBy()
 
@@ -397,7 +397,7 @@ export default {
 				 * tooltip is already visible and in the DOM.
 				 */
 				this.$emit('after-hide')
-			}, { once: true })
+			}, { once: true, passive: true })
 
 			this.clearFocusTrap()
 			this.clearEscapeStopPropagation()


### PR DESCRIPTION
Tiny nitpick from https://github.com/nextcloud-libraries/nextcloud-vue/pull/6687