### PR TITLE
chore: migrate `GetParent` to Typescript

### DIFF
--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -4,7 +4,7 @@
  */
 
 import actionGlobal from './actionGlobal.js'
-import GetParent from '../utils/GetParent.js'
+import { getParent } from '../utils/getParent.ts'
 
 export default {
 	mixins: [actionGlobal],
@@ -83,7 +83,7 @@ export default {
 			this.$emit('click', event)
 
 			if (this.closeAfterClick) {
-				const parent = GetParent(this, 'NcActions')
+				const parent = getParent(this, 'NcActions')
 				if (parent && parent.closeMenu) {
 					parent.closeMenu(false)
 				}

--- a/src/utils/getParent.ts
+++ b/src/utils/getParent.ts
@@ -3,14 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { ComponentPublicInstance } from 'vue'
+
 /**
  * Get the first parent component matching the provided name
  *
- * @param {object} context the context to search from (usually this)
- * @param {string} name the parent name
- * @return {object|undefined} the parent component
+ * @param context - The component to search from (usually this)
+ * @param name - The parent name
  */
-const GetParent = function(context, name) {
+export function getParent(context: ComponentPublicInstance, name: string) {
 	let parent = context.$parent
 	while (parent) {
 		if (parent.$options.name === name) {
@@ -19,5 +20,3 @@ const GetParent = function(context, name) {
 		parent = parent.$parent
 	}
 }
-
-export default GetParent

--- a/tests/unit/utils/getParent.spec.ts
+++ b/tests/unit/utils/getParent.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+
+import { getParent } from '../../../src/utils/getParent.ts'
+
+const CParent = defineComponent({
+	name: 'CParent',
+	template: '<div><slot /></div>',
+})
+
+const CChild = defineComponent({
+	name: 'CChild',
+	template: '<div>hello</div>',
+	inject: ['foundParent'],
+	mounted() {
+		(this.foundParent as (x: unknown) => void)(getParent(this, 'CParent'))
+	},
+	computed: {
+		parent() {
+			return getParent(this, 'CParent')
+		},
+	},
+})
+
+const CWrapper = defineComponent({
+	name: 'CWrapper',
+	template: '<div><slot /></div>',
+})
+
+describe('utils: getParent', () => {
+	it('finds direct parent', () => {
+		const foundParent = vi.fn()
+		const component = defineComponent({
+			template: '<CParent><CChild ref="child" /></CParent>',
+			components: { CChild, CParent },
+			provide: {
+				foundParent,
+			},
+		})
+
+		mount(component)
+		expect(foundParent).toBeCalledWith({})
+	})
+
+	it('finds indirect parent', () => {
+		const foundParent = vi.fn()
+		const component = defineComponent({
+			template: '<CParent><CWrapper><CChild ref="child" /></CWrapper></CParent>',
+			components: { CChild, CParent, CWrapper },
+			provide: {
+				foundParent,
+			},
+		})
+
+		mount(component)
+		expect(foundParent).toBeCalledWith({})
+	})
+
+	it('finds indirect parent in native elements', () => {
+		const foundParent = vi.fn()
+		const component = defineComponent({
+			template: '<CParent><div><CChild ref="child" /></div></CParent>',
+			components: { CChild, CParent },
+			provide: {
+				foundParent,
+			},
+		})
+
+		mount(component)
+		expect(foundParent).toBeCalledWith({})
+	})
+
+	it('does not find parent if there is none', () => {
+		const foundParent = vi.fn()
+		const component = defineComponent({
+			template: '<div><CChild ref="child" /></div>',
+			components: { CChild },
+			provide: {
+				foundParent,
+			},
+		})
+
+		mount(component)
+		expect(foundParent).toBeCalledTimes(1)
+		expect(foundParent).toBeCalledWith(undefined)
+	})
+})


### PR DESCRIPTION
### ☑️ Resolves

- For #841 
- Also added tests - only used by NcActions

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport bugfixes to `stable8` for maintained Vue 2 version.
