### PR TITLE
fix(NcActions): trigger forgotten closed event and correctly handle open

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1369,6 +1369,15 @@ export default {
 			})
 		},
 
+		onClosed() {
+			/**
+			 * Event emitted when the popover menu is closed.
+			 *
+			 * This event is emitted after `update:open` was emitted and the closing transition finished.
+			 */
+			 this.$emit('closed')
+		},
+
 		/**
 		 * Handle resizing the popover to make sure users can discover there is more to scroll
 		 */
@@ -1760,7 +1769,8 @@ export default {
 					setReturnFocus: this.config.withFocusTrap ? this.$refs.triggerButton?.$el : null,
 					focusTrap: this.config.withFocusTrap,
 					onShow: this.openMenu,
-					onApplyShow: this.onOpen,
+					onAfterShow: this.onOpened,
+					onAfterClose: this.onClosed,
 					onHide: this.closeMenu,
 				},
 				{


### PR DESCRIPTION
### ☑️ Resolves

- Regression from: https://github.com/nextcloud-libraries/nextcloud-vue/pull/6685/
  - `onOpen` is not defined
  - `closed` is not triggered

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/user-attachments/assets/69ca30ac-9f91-4fd1-adfb-01ec0145229a) | ![after](https://github.com/user-attachments/assets/2b0e6c99-9de4-4349-b660-c99405754f7c)

![image](https://github.com/user-attachments/assets/7e554182-e52e-4ebe-b08f-5973f7635708)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport bugfixes to `stable8` for maintained Vue 2 version.
