### PR TITLE
refactor!(NcModal): adjust to boolean props with default `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,14 +85,15 @@ The leading icon slot was changed from `#default` to `#icon` in `Nc*Field` compo
 Some boolean props that have been deprecated in favor of alternatives with default value `false`,
 are now removed. Following components have been adjusted:
 
-|     Component | Removed deprecated prop | New alternative |
-|---------------|-------------------------|-----------------|
-|`NcAppContent` |  `allowSwipeNavigation` | `disabledSwipe` |
-|    `NcAvatar` |        `showUserStatus` |    `hideStatus` |
-|    `NcAvatar` | `showUserStatusCompact` | `verboseStatus` |
-|     `NcModal` |           `enableSwipe` |  `disableSwipe` |
-|     `NcModal` |              `canClose` |       `noClose` |
-|    `NcDialog` |              `canClose` |       `noClose` |
+|     Component | Removed deprecated prop |      New alternative |
+|---------------|-------------------------|----------------------|
+|`NcAppContent` |  `allowSwipeNavigation` |      `disabledSwipe` |
+|    `NcAvatar` |        `showUserStatus` |         `hideStatus` |
+|    `NcAvatar` | `showUserStatusCompact` |      `verboseStatus` |
+|     `NcModal` |  `closeButtonContained` | `closeButtonOutside` |
+|     `NcModal` |           `enableSwipe` |       `disableSwipe` |
+|     `NcModal` |              `canClose` |            `noClose` |
+|    `NcDialog` |              `canClose` |            `noClose` |
 
 Additionally the default value `closeOnClickOutside` for `NcModal` was aligned with `NcDialog` and now defaults to `false`.
 

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -192,7 +192,7 @@ export default {
 			ref="mask"
 			class="modal-mask"
 			:class="{
-				'modal-mask--opaque': dark || !closeButtonContained || hasPrevious || hasNext,
+				'modal-mask--opaque': dark || closeButtonOutside || !closeButtonContained || hasPrevious || hasNext,
 				'modal-mask--light': lightBackdrop,
 			}"
 			:style="cssVariables"
@@ -252,7 +252,7 @@ export default {
 						</NcActions>
 
 						<!-- Close modal -->
-						<NcButton v-if="!noClose && !closeButtonContained"
+						<NcButton v-if="!noClose && closeButtonOutside && !closeButtonContained"
 							:aria-label="closeButtonAriaLabel"
 							class="header-close"
 							variant="tertiary"
@@ -294,7 +294,7 @@ export default {
 							<slot />
 						</div>
 						<!-- Close modal -->
-						<NcButton v-if="!noClose && closeButtonContained"
+						<NcButton v-if="!noClose && !closeButtonOutside && closeButtonContained"
 							:aria-label="closeButtonAriaLabel"
 							class="modal-container__close"
 							variant="tertiary"
@@ -478,8 +478,23 @@ export default {
 		},
 
 		/**
+		 * Pass in `true` if you want the modal 'close' button to be displayed
+		 * outside the modal boundaries, in the top right corner of the window.
+		 *
+		 * @default false
+		 * @since 8.25.0
+		 */
+		closeButtonOutside: {
+			type: Boolean,
+			default: false,
+		},
+
+		/**
 		 * Pass in false if you want the modal 'close' button to be displayed
-		 * outside the modal boundaries, in the top right corner of the window
+		 * outside the modal boundaries, in the top right corner of the window.
+		 *
+		 * @default true
+		 * @deprecated 8.25.0 - Use `closeButtonOutside` instead
 		 */
 		closeButtonContained: {
 			type: Boolean,

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -192,7 +192,7 @@ export default {
 			ref="mask"
 			class="modal-mask"
 			:class="{
-				'modal-mask--opaque': dark || closeButtonOutside || !closeButtonContained || hasPrevious || hasNext,
+				'modal-mask--opaque': dark || closeButtonOutside || hasPrevious || hasNext,
 				'modal-mask--light': lightBackdrop,
 			}"
 			:style="cssVariables"
@@ -252,7 +252,7 @@ export default {
 						</NcActions>
 
 						<!-- Close modal -->
-						<NcButton v-if="!noClose && closeButtonOutside && !closeButtonContained"
+						<NcButton v-if="!noClose && closeButtonOutside"
 							:aria-label="closeButtonAriaLabel"
 							class="header-close"
 							variant="tertiary"
@@ -294,7 +294,7 @@ export default {
 							<slot />
 						</div>
 						<!-- Close modal -->
-						<NcButton v-if="!noClose && !closeButtonOutside && closeButtonContained"
+						<NcButton v-if="!noClose && !closeButtonOutside"
 							:aria-label="closeButtonAriaLabel"
 							class="modal-container__close"
 							variant="tertiary"
@@ -487,18 +487,6 @@ export default {
 		closeButtonOutside: {
 			type: Boolean,
 			default: false,
-		},
-
-		/**
-		 * Pass in false if you want the modal 'close' button to be displayed
-		 * outside the modal boundaries, in the top right corner of the window.
-		 *
-		 * @default true
-		 * @deprecated 8.25.0 - Use `closeButtonOutside` instead
-		 */
-		closeButtonContained: {
-			type: Boolean,
-			default: true,
 		},
 
 		/**

--- a/tests/component/components/NcModal.spec.ts
+++ b/tests/component/components/NcModal.spec.ts
@@ -58,6 +58,39 @@ test('Modal is labelled correctly if `labelId` and `name` are set', async ({ mou
 	await expect(page.getByRole('dialog', { name: 'Real name' })).toBeVisible()
 })
 
+test('Close button is contained within the dialog by default', async ({ mount, page }) => {
+	await mount(NcModal, {
+		props: {
+			show: true,
+			size: 'small',
+			name: 'test modal',
+		},
+	})
+
+	const button = page.getByRole('dialog', { name: 'test modal' })
+		.locator('.modal-container')
+		.getByRole('button', { name: 'Close' })
+
+	await expect(button).toBeVisible()
+})
+
+test('Close button can be moved to the modal header', async ({ mount, page }) => {
+	await mount(NcModal, {
+		props: {
+			closeButtonOutside: true,
+			show: true,
+			size: 'small',
+			name: 'test modal',
+		},
+	})
+
+	const button = page.getByRole('dialog', { name: 'test modal' })
+		.locator('.modal-header')
+		.getByRole('button', { name: 'Close' })
+
+	await expect(button).toBeVisible()
+})
+
 test('Close button is visible when content is scrolled', async ({ mount, page }) => {
 	await mount(NcModal, {
 		props: {


### PR DESCRIPTION
### ☑️ Resolves

- for https://github.com/nextcloud-libraries/nextcloud-vue/issues/6384

Replace `closeButtonContained` with `closeButtonOutside`.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport bugfixes to `stable8` for maintained Vue 2 version.
