### PR TITLE
fix(NcDateTimePicker): localize the default formatting

### DIFF
--- a/tests/component/components/NcDateTimePicker.spec.ts
+++ b/tests/component/components/NcDateTimePicker.spec.ts
@@ -23,8 +23,8 @@ const testcases = [
 	['week', new Date(2000, 0, 2, 3, 4), '1999-52'],
 	['month', new Date(2000, 0, 2, 3, 4), '01/2000'],
 	['year', new Date(2000, 0, 2, 3, 4), '2000'],
-	['range', [new Date(2000, 0, 1), new Date(2000, 0, 7)] as [Date, Date], 'Jan 1 – 7, 2000'],
-	['range-datetime', [new Date(2000, 0, 1, 2, 3), new Date(2000, 0, 7, 8, 9)] as [Date, Date], 'Jan 1, 2000, 2:03 AM – Jan 7, 2000, 8:09 AM'],
+	['range', [new Date(2000, 0, 1), new Date(2000, 0, 7)] as [Date, Date], /Jan 1\s–\s7, 2000/i],
+	['range-datetime', [new Date(2000, 0, 1, 2, 3), new Date(2000, 0, 7, 8, 9)] as [Date, Date], /Jan 1, 2000, 2:03\sAM\s–\sJan 7, 2000, 8:09\sAM/i],
 ] as const
 
 for (const [type, modelValue, expectedValue] of testcases) {

--- a/tests/component/components/NcDateTimePicker.spec.ts
+++ b/tests/component/components/NcDateTimePicker.spec.ts
@@ -18,17 +18,37 @@ test('aria-label set on input element', async ({ mount, page }) => {
 })
 
 const testcases = [
-	['datetime', new Date(2000, 0, 2, 3, 4), '2000-01-02 03:04'],
-	['date', new Date(2000, 0, 2, 3, 4), '2000-01-02'],
+	['datetime', new Date(2000, 0, 2, 3, 4), 'Jan 2, 2000, 3:04 AM'],
+	['date', new Date(2000, 0, 2, 3, 4), 'Jan 2, 2000'],
 	['week', new Date(2000, 0, 2, 3, 4), '1999-52'],
-	['month', new Date(2000, 0, 2, 3, 4), '2000-01'],
+	['month', new Date(2000, 0, 2, 3, 4), '01/2000'],
 	['year', new Date(2000, 0, 2, 3, 4), '2000'],
-	['range', [new Date(2000, 0, 1), new Date(2000, 0, 7)] as [Date, Date], '2000-01-01 - 2000-01-07'],
-	['range-datetime', [new Date(2000, 0, 1, 2, 3), new Date(2000, 0, 7, 8, 9)] as [Date, Date], '2000-01-01 02:03 - 2000-01-07 08:09'],
+	['range', [new Date(2000, 0, 1), new Date(2000, 0, 7)] as [Date, Date], 'Jan 1 – 7, 2000'],
+	['range-datetime', [new Date(2000, 0, 1, 2, 3), new Date(2000, 0, 7, 8, 9)] as [Date, Date], 'Jan 1, 2000, 2:03 AM – Jan 7, 2000, 8:09 AM'],
 ] as const
 
 for (const [type, modelValue, expectedValue] of testcases) {
 	test(`Handle intially specified date with type: ${type}`, async ({ mount, page }) => {
+		await mount(NcDateTimePicker, {
+			props: {
+				modelValue,
+				type,
+			},
+		})
+
+		await expect(page.getByRole('textbox')).toHaveValue(expectedValue)
+	})
+}
+
+const l10nTestcases = [
+	['datetime', new Date(2000, 0, 2, 3, 4), 'en-GB', '2 Jan 2000, 03:04'],
+	['date', new Date(2000, 0, 2, 3, 4), 'es-ES', '2 ene 2000'],
+	['month', new Date(2000, 0, 2, 3, 4), 'de-DE', '01.2000'],
+] as const
+
+for (const [type, modelValue, locale, expectedValue] of l10nTestcases) {
+	test(`Handle localized formatting for date with type: ${type} formatted in locale ${locale}`, async ({ mount, page }) => {
+		page.addScriptTag({ content: `document.getElementsByTagName('html')[0].dataset.locale = "${locale}";` })
 		await mount(NcDateTimePicker, {
 			props: {
 				modelValue,
@@ -49,7 +69,7 @@ test('Today is selected by default', async ({ mount, page }) => {
 		},
 	})
 
-	await expect(page.getByRole('textbox')).toHaveValue('2000-01-22')
+	await expect(page.getByRole('textbox')).toHaveValue('Jan 22, 2000')
 
 	// see also menu is checked
 	await page.getByRole('textbox').click()


### PR DESCRIPTION
### ☑️ Resolves

- Should fix the problem mentioned in #6720 by providing localized formatting by default

Instead of using some default format like ISO or US layout, we should use a format that works for all users.
So this migrates the default formatting to `Intl.DateTimeFormat`.

### 🖼️ Screenshots

Before | After :us:  | After :de: 
---|---|--
![Screenshot 2025-04-05 at 12-51-37 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/7cb75874-fc54-4104-837e-786bba33db1b)|![Screenshot 2025-04-05 at 12-52-41 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/153c389a-511a-41e1-83de-98311982ec0e)|![Screenshot 2025-04-05 at 12-51-57 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/594914b0-de27-4c06-9b74-d3f9482a2321)
![Screenshot 2025-04-05 at 12-51-26 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/2093dfc5-34ac-42f2-8249-9e4f4ef846da)|![Screenshot 2025-04-05 at 12-52-35 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/2d50ebf6-79a5-4f2b-a5a8-71940e347ac3)|![Screenshot 2025-04-05 at 12-52-03 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/ba1d1b47-273b-44c6-bfff-1e5f48a3d799)
![Screenshot 2025-04-05 at 12-51-13 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/da5bda55-bde3-4a49-bc1d-f007103fd882)|![Screenshot 2025-04-05 at 12-52-30 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/a9c5d869-88b6-463c-864e-8e800e734c5b)|![Screenshot 2025-04-05 at 12-52-11 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/595a04d0-10b7-4893-a037-30882b5d2dd7)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport bugfixes to `stable8` for maintained Vue 2 version.
