### PR TITLE
chore: adjust package engines versions

### DIFF
--- a/.github/workflows/command-l10n-update.yml
+++ b/.github/workflows/command-l10n-update.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout ${{ needs.init.outputs.head_ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}
           fetch-depth: 0
@@ -50,21 +50,10 @@ jobs:
           git config --local user.email "nextcloud-command@users.noreply.github.com"
           git config --local user.name "nextcloud-command"
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@v3
-        id: package-engines-versions
+      - name: Set up node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
         with:
-          fallbackNode: '^20'
-          fallbackNpm: '^10'
-
-      - name: Set up node ${{ steps.package-engines-versions.outputs.nodeVersion }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ steps.package-engines-versions.outputs.nodeVersion }}
-          cache: npm
-
-      - name: Set up npm ${{ steps.package-engines-versions.outputs.npmVersion }}
-        run: npm i -g npm@"${{ steps.package-engines-versions.outputs.npmVersion }}"
+          node-version-file: package.json
 
       - name: Install dependencies & build l10n
         run: |

--- a/.github/workflows/command-playwright-update.yml
+++ b/.github/workflows/command-playwright-update.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout ${{ needs.init.outputs.head_ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.COMMAND_BOT_PAT }}
           fetch-depth: 0
@@ -51,21 +51,10 @@ jobs:
           git config --local user.email "nextcloud-command@users.noreply.github.com"
           git config --local user.name "nextcloud-command"
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@v3
-        id: package-engines-versions
+      - name: Set up node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
         with:
-          fallbackNode: '^20'
-          fallbackNpm: '^10'
-
-      - name: Set up node ${{ steps.package-engines-versions.outputs.nodeVersion }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ steps.package-engines-versions.outputs.nodeVersion }}
-          cache: npm
-
-      - name: Set up npm ${{ steps.package-engines-versions.outputs.npmVersion }}
-        run: npm i -g npm@"${{ steps.package-engines-versions.outputs.npmVersion }}"
+          node-version-file: package.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -9,22 +9,12 @@ jobs:
 
     name: Pot check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@v3
-        id: versions
+      - name: Set up node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
         with:
-          fallbackNode: '^12'
-          fallbackNpm: '^6'
-
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
+          node-version-file: package.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -53,22 +53,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
-        id: versions
-        with:
-          fallbackNode: '^20'
-          fallbackNpm: '^10'
-
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+      - name: Set up node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
         with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+          node-version-file: package.json
 
       - name: Install dependencies
         env:

--- a/.github/workflows/lint-stylelint.yml
+++ b/.github/workflows/lint-stylelint.yml
@@ -25,22 +25,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
-        id: versions
-        with:
-          fallbackNode: '^20'
-          fallbackNpm: '^10'
-
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+      - name: Set up node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
         with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+          node-version-file: package.json
 
       - name: Install dependencies
         env:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -57,22 +57,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
-        id: versions
+      - name: Set up node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
         with:
-          fallbackNode: '^20'
-          fallbackNpm: '^10'
-
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-        with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+          node-version-file: package.json
 
       - name: Install dependencies & build
         env:

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -27,24 +27,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ matrix.branches }}
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
-        id: versions
+      - name: Set up node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
         with:
-          fallbackNode: '^20'
-          fallbackNpm: '^10'
-
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
-        with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+          node-version-file: package.json
 
       - name: Fix npm audit
         id: npm-audit

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,22 +26,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
-        id: versions
-        with:
-          fallbackNode: '^20'
-          fallbackNpm: '^10'
-
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+      - name: Set up node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
         with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+          node-version-file: package.json
 
       - name: Install dependencies & build
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,10 +4,9 @@
 name: Playwright Tests
 
 on:
-  push:
-    branches: [ main, next ]
   pull_request:
-    branches: [ main, next ]
+    branches: [ main ]
+
 jobs:
   playwright-tests:
     timeout-minutes: 60
@@ -18,26 +17,13 @@ jobs:
         shardIndex: [1, 2]
         shardTotal: [2]
 
-    outputs:
-      nodeVersion: ${{ steps.versions.outputs.nodeVersion }}
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Read package.json node and npm engines version
-      uses: skjnldsv/read-package-engines-version-actions@v3
-      id: versions
+    - name: Set up node
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
       with:
-        fallbackNode: '^20'
-        fallbackNpm: '^10'
-
-    - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-    - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-      run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
+        node-version-file: package.json
 
     - name: Install dependencies
       run: npm ci
@@ -63,10 +49,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: actions/setup-node@v4
       with:
-        node-version: ${{ needs.playwright-tests.outputs.nodeVersion }}
+        node-version-file: package.json
 
     - name: Install dependencies
       run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,8 +98,8 @@
         "webpack-merge": "^6.0.1"
       },
       "engines": {
-        "node": "^20.11.0",
-        "npm": "^10.0.0"
+        "node": "^20.11.0 || ^22",
+        "npm": "^10 || ^11"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -160,8 +160,20 @@
     "webpack-merge": "^6.0.1"
   },
   "engines": {
-    "node": "^20.11.0",
-    "npm": "^10.0.0"
+    "node": "^20.11.0 || ^22",
+    "npm": "^10 || ^11"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "^10",
+      "onFail": "error"
+    },
+    "runtime": {
+      "name": "node",
+      "version": "^22",
+      "onFail": "error"
+    }
   },
   "overrides": {
     "mdast-util-gfm": {


### PR DESCRIPTION
### ☑️ Resolves

This package does not even target Node.JS so we could even drop the `node` dependency for `engines.
But lets at least allow the current LTS version (22) along side with LTS 20.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport bugfixes to `stable8` for maintained Vue 2 version.
