### PR TITLE
feat(NcDateTimePicker): add time range picker and align naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ Especially the following are now provided as composables:
   - `NcModal`
   - `NcPopover`
 - `NcDateTimePicker`
-  - The `range` property was removed in favor of `type="range"` (datetime ranges) and `type="range-date"` (date only ranges).
+  - The `range` property was removed in favor of `type="datetime-range"` (datetime ranges), `type="date-range"` (date only ranges), and `type="time-range"` (time only ranges).
   - The `lang` property was replaced with the `locale` property.
   - The `formatter` property was removed.
   

--- a/tests/component/components/NcDateTimePicker.spec.ts
+++ b/tests/component/components/NcDateTimePicker.spec.ts
@@ -23,8 +23,9 @@ const testcases = [
 	['week', new Date(2000, 0, 2, 3, 4), '1999-52'],
 	['month', new Date(2000, 0, 2, 3, 4), '01/2000'],
 	['year', new Date(2000, 0, 2, 3, 4), '2000'],
-	['range', [new Date(2000, 0, 1), new Date(2000, 0, 7)] as [Date, Date], /Jan 1\s–\s7, 2000/i],
-	['range-datetime', [new Date(2000, 0, 1, 2, 3), new Date(2000, 0, 7, 8, 9)] as [Date, Date], /Jan 1, 2000, 2:03\sAM\s–\sJan 7, 2000, 8:09\sAM/i],
+	['date-range', [new Date(2000, 0, 1), new Date(2000, 0, 7)] as [Date, Date], /Jan 1\s–\s7, 2000/i],
+	['time-range', [new Date(2000, 0, 1, 2, 3), new Date(2000, 0, 1, 8, 9)] as [Date, Date], /2:03\s(AM\s)?–\s8:09\sAM/i],
+	['datetime-range', [new Date(2000, 0, 1, 2, 3), new Date(2000, 0, 7, 8, 9)] as [Date, Date], /Jan 1, 2000, 2:03\sAM\s–\sJan 7, 2000, 8:09\sAM/i],
 ] as const
 
 for (const [type, modelValue, expectedValue] of testcases) {


### PR DESCRIPTION
### ☑️ Resolves

1. Add a time range picker mode
2. Align type names to `TYPE(-range)?`
3. Fix some issues related to time mode (also without range)

### 🖼️ Screenshots

![Screenshot 2025-04-05 at 18-05-34 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/531e41ca-72bd-464d-b436-05821feb5438)

![Screenshot 2025-04-05 at 18-05-43 Nextcloud Vue Style Guide](https://github.com/user-attachments/assets/1fffbe69-ed9b-4d93-bdd8-3e3939dc6969)



### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport bugfixes to `stable8` for maintained Vue 2 version.
