### PR TITLE
fix(dialogs/spawnDialog): dialog cannot be closed

### DIFF
--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -33,7 +33,7 @@ export function spawnDialog(
 
 	const vueComponent = createVNode(dialog, {
 		...props,
-		onclose: (...rest: unknown[]) => {
+		onClose: (...rest: unknown[]) => {
 			onClose(...rest.map(v => toRaw(v)))
 			// destroy the component
 			render(null, el)


### PR DESCRIPTION
### ☑️ Resolves

- `onClose` in `spawnDialog` doesn't work
- In Vue 3 event handler must be passed as `on{Event}`

More improvements are coming soon for:
- Instance access and unmounting
- Typings
- Correcting Params

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![before](https://github.com/user-attachments/assets/c24fd064-37bd-4c8c-8a55-4ef25605f71a) | ![after](https://github.com/user-attachments/assets/3ffaa0b5-def6-4d5c-a85b-26530f6b6579)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport bugfixes to `stable8` for maintained Vue 2 version.
