### PR TITLE
chore: type check project on CI

### DIFF
--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: Type checking
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-typescript-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    name: Type checking
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
+        with:
+          node-version-file: package.json
+
+      - name: Install dependencies
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+          PUPPETEER_SKIP_DOWNLOAD: true
+        run: npm ci
+
+      - name: Check types
+        run: |
+          npm run --if-present check-types
+          npm run --if-present ts:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "vue-eslint-parser": "^10.1.1",
         "vue-material-design-icons": "^5.3.1",
         "vue-styleguidist": "^4.72.4",
+        "vue-tsc": "^2.2.8",
         "webpack": "^5.98.0",
         "webpack-merge": "^6.0.1"
       },
@@ -27344,6 +27345,55 @@
         "de-indent": "^1.0.2",
         "he": "^1.2.0"
       }
+    },
+    "node_modules/vue-tsc": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.8.tgz",
+      "integrity": "sha512-jBYKBNFADTN+L+MdesNX/TB3XuDSyaWynKMDgR+yCSln0GQ9Tfb7JS2lr46s2LiFUT1WsmfWsSvIElyxzOPqcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "~2.4.11",
+        "@vue/language-core": "2.2.8"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/@vue/language-core": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.8.tgz",
+      "integrity": "sha512-rrzB0wPGBvcwaSNRriVWdNAbHQWSf0NlGqgKHK5mEkXpefjUlVRP62u03KvwZpvKVjRnBIQ/Lwre+Mx9N6juUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "~2.4.11",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^1.0.3",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-tsc/node_modules/alien-signals": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
+      "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:component": "playwright test -c playwright.config.ts",
     "test:component:gui": "playwright test --ui -c playwright.config.ts",
     "test:coverage": "TZ=UTC vitest run --coverage",
+    "ts:check": "vue-tsc --noEmit",
     "update:snapshots": "npm run test:component -- --grep @visual --update-snapshots",
     "watch": "npm run dev:watch"
   },
@@ -154,6 +155,7 @@
     "vue-eslint-parser": "^10.1.1",
     "vue-material-design-icons": "^5.3.1",
     "vue-styleguidist": "^4.72.4",
+    "vue-tsc": "^2.2.8",
     "webpack": "^5.98.0",
     "webpack-merge": "^6.0.1"
   },

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -422,7 +422,7 @@ td.row-size {
 import type { PropType } from 'vue'
 
 import { defineComponent, h, resolveComponent } from 'vue'
-import { ButtonAlignment, ButtonType } from './types.ts'
+import { ButtonAlignment, ButtonType, ButtonVariant } from './types.ts'
 import { isSlotPopulated } from '../../utils/isSlotPopulated.ts'
 
 export default defineComponent({
@@ -566,7 +566,7 @@ export default defineComponent({
 		 * Accepted values: primary, secondary, tertiary, tertiary-no-background, tertiary-on-primary, error, warning, success.
 		 *
 		 * @default 'secondary'
-		 * @since 8.23.0
+		 * @since 8.24.0
 		 */
 		 variant: {
 			type: String as PropType<ButtonVariant | `${ButtonVariant}`>,

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -171,6 +171,7 @@ import type {
 	TimeObj as LibraryTimeObject,
 	// The accepted model value
 	ModelValue as LibraryModelValue,
+	VueDatePickerProps,
 } from '@vuepic/vue-datepicker'
 
 import {
@@ -194,6 +195,8 @@ import { t } from '../../l10n.js'
 import VueDatePicker from '@vuepic/vue-datepicker'
 import NcIconSvgWrapper from '../NcIconSvgWrapper/NcIconSvgWrapper.vue'
 import NcTimezonePicker from '../NcTimezonePicker/NcTimezonePicker.vue'
+
+type LibraryFormatOptions = VueDatePickerProps['format']
 
 const props = withDefaults(defineProps<{
 	/**
@@ -329,9 +332,9 @@ const emit = defineEmits<{
  * We do not directly pass the prop and adjust the interface to not transparently wrap the library.
  * This has show as beeing a pain in the past when we need to switch underlying libraries.
  */
-const value = computed(() => {
+const value = computed<LibraryModelValue>(() => {
 	if (props.modelValue === undefined && props.clearable) {
-		return props.modelValue
+		return null
 	}
 
 	if (props.type === 'week') {
@@ -396,9 +399,11 @@ const placeholderFallback = computed(() => {
  * We use the provided format if possible, otherwise we provide a formatting function
  * which uses the browsers Intl API to format the date / time in the current users locale.
  */
-const realFormat = computed(() => {
+const realFormat = computed<LibraryFormatOptions>(() => {
 	if (props.format) {
-		return props.format
+		// we can cast the type here as in this case its either string
+		// function `(Date) => string` or `([Date, Date]) => string` where we cast to `(Date[]) => string` here.
+		return props.format as LibraryFormatOptions
 	} else if (props.type === 'week') {
 		// cannot format weeks with Intl.
 		return 'RR-II'
@@ -419,7 +424,7 @@ const realFormat = computed(() => {
 
 	if (formatter) {
 		return (input: Date | [Date, Date]) => Array.isArray(input)
-			? formatter.formatRange(...input)
+			? formatter.formatRange(input[0], input[1])
 			: formatter.format(input)
 	}
 

--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -453,7 +453,7 @@ export default defineComponent({
 		},
 	},
 
-	emits: ['closing', 'update:open', 'submit'],
+	emits: ['closing', 'update:open', 'reset', 'submit'],
 
 	setup(props, { emit, slots }) {
 		/**
@@ -559,13 +559,14 @@ export default defineComponent({
 
 		/**
 		 * Handle closing the dialog, optional out transition did not run yet
-		 * @param {unknown} result the result of the callback
+		 * @param result - The result of the callback
 		 */
-		const handleClosing = (result) => {
+		function handleClosing(result?: unknown): void {
 			showModal.value = false
 			/**
 			 * Emitted when the dialog is closing, so the out transition did not finish yet.
-			 * @param result The result of the button callback (`undefined` if closing because of clicking the 'close'-button)
+			 *
+			 * @param result - The result of the button callback (`undefined` if closing because of clicking the 'close'-button)
 			 */
 			emit('closing', result)
 		}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.json",
+  "extends": "@vue/tsconfig",
   "include": ["./src/**/*.js","./src/**/*.ts", "./src/**/*.vue", "**/*.ts"],
   "exclude": ["tests", "vitest.config.ts"],
 


### PR DESCRIPTION
- built on top of https://github.com/nextcloud-libraries/nextcloud-vue/pull/6735

### ☑️ Resolves

1. enforce project to be typescript compliant
2. fix found issues
  - Missing type import in NcButton
  - Wrong types in NcDateTimePicker (less strict types only)
  - Missing event in NcDialog 

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport bugfixes to `stable8` for maintained Vue 2 version.
