### PR TITLE
fix(dialogs/spawnDialog)!: support vue-devtool but loose appContext

### DIFF
--- a/docs/functions/spawnDialog.md
+++ b/docs/functions/spawnDialog.md
@@ -17,7 +17,6 @@ import {
  * @param dialog The dialog component to spawn - the component must emit the 'close' event whenever it is closed
  * @param props Properties to pass to the dialog
  * @param props.container Optionally pass a query selector for the dialog container element
- * @param props.appContext Optionally the app context to use (e.g. for registered components)
  * @param onClose Callback when the dialog is closed (parameters of the 'close' event of the dialog)
  */
 function spawnDialog(
@@ -72,7 +71,7 @@ const ExampleDialog = {
 				},
 				{
 					label: 'Accept',
-					type: 'primary',
+					variant: 'primary',
 					callback: () => 'accepted',
 				},
 			]

--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -2,13 +2,12 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { AppContext, Component } from 'vue'
-import { createVNode, getCurrentInstance, render, toRaw } from 'vue'
+import type { Component } from 'vue'
+import { createApp, toRaw } from 'vue'
 
 interface DialogProps {
 	[index: string]: unknown
 	container?: string
-	appContext?: AppContext
 }
 
 /**
@@ -17,7 +16,6 @@ interface DialogProps {
  * @param dialog The dialog component to spawn
  * @param props Properties to pass to the dialog
  * @param props.container Optionally pass a query selector for the dialog container element
- * @param props.appContext Optionally the app context to use (e.g. for registered components)
  * @param onClose Callback when the dialog is closed
  */
 export function spawnDialog(
@@ -31,21 +29,14 @@ export function spawnDialog(
 		: document.body
 	container.appendChild(el)
 
-	const vueComponent = createVNode(dialog, {
+	const app = createApp(dialog, {
 		...props,
 		onClose: (...rest: unknown[]) => {
 			onClose(...rest.map(v => toRaw(v)))
-			// destroy the component
-			render(null, el)
+			app.unmount()
 			el.remove()
 		},
 	})
 
-	// If there is an instance use it to get access to registered components
-	const appContext = props?.appContext ?? getCurrentInstance()?.appContext
-	if (appContext) {
-		vueComponent.appContext = { ...appContext }
-	}
-
-	render(vueComponent, el)
+	app.mount(el)
 }


### PR DESCRIPTION
### ☑️ Resolves

- Doing small changes from: https://github.com/nextcloud-libraries/nextcloud-vue/issues/6731
- Allows debugging dialog content with `vue-devtools`
- Also, `getCurrentInstance` only works when the dialog is spawned in the setup context, so doesn't even work in a click handler

This looses `appContext`.

Workarounds:
- Always use locally imported components
- When possible - provide data via props
- For `provide/inject` - provide directly from the root dialog component
- For Pinia - should work via `activePinia`, or via provide in the root dialog component

Alternative:
- Pass app/appContext via options and then do hacks - re-provide every provider

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport bugfixes to `stable8` for maintained Vue 2 version.
