### PR TITLE
feat(dialogs/spawnDialog): return promise with the result

### DIFF
--- a/docs/functions/spawnDialog.md
+++ b/docs/functions/spawnDialog.md
@@ -116,15 +116,10 @@ export default {
 		}
 	},
 	methods: {
-		onSpawnDialog() {
+		async onSpawnDialog() {
 			this.timesClicked += 1
-			spawnDialog(
-				ExampleDialog,
-				{
-					timesClicked: this.timesClicked,
-				},
-				(result) => window.alert(`Dialog was ${result}`)
-			)
+			const result = await spawnDialog(ExampleDialog, { timesClicked: this.timesClicked })
+			window.alert(`Dialog was ${result}`)
 		},
 	},
 }


### PR DESCRIPTION
### ☑️ Resolves

- For: https://github.com/nextcloud-libraries/nextcloud-vue/issues/6731
- Non braking alternative for: https://github.com/nextcloud-libraries/nextcloud-vue/pull/6759
- Not only call the `onClose` callback, but also return a promise

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
