### PR TITLE
feat(dialogs/spawnDialog)!: replace onClose callback with Promise

### DIFF
--- a/docs/functions/spawnDialog.md
+++ b/docs/functions/spawnDialog.md
@@ -19,33 +19,18 @@ type SpawnDialogOptions = {
 	container?: Element | string
 }
 
-export function spawnDialog(
-	dialog: Component,
-	props?: object,
-	onClose?: (...rest: unknown[]) => void,
-): void
-
-export function spawnDialog(
-	dialog: Component,
-	props?: object,
-	options?: SpawnDialogOptions,
-	onClose?: (...rest: unknown[]) => void,
-): void
-
 /**
  * Spawn a single-use Vue dialog instance to get the result when it is closed
  *
  * @param dialog - Dialog component to spawn
  * @param props - Props to pass to the dialog instance
- * @param optionsOrOnClose - Spawning options or a callback when the dialog is closed
- * @param onClose - Callback when the dialog is closed
+ * @param options - Spawning options
  */
 declare function spawnDialog(
 	dialog: Component,
 	props: object = {},
-	optionsOrOnClose: SpawnDialogOptions | ((...rest: unknown[]) => void) = {},
-	onClose: (...rest: unknown[]) => void = () => {},
-): void
+	optionsOrOnClose: SpawnDialogOptions = {},
+): Promise<unknown>
 ```
 
 ## Usage

--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -13,40 +13,20 @@ type SpawnDialogOptions = {
 	container?: Element | string
 }
 
-export function spawnDialog(
-	dialog: Component,
-	props?: object,
-	onClose?: (...rest: unknown[]) => void,
-): Promise<unknown>
-
-export function spawnDialog(
-	dialog: Component,
-	props?: object,
-	options?: SpawnDialogOptions,
-	onClose?: (...rest: unknown[]) => void,
-): Promise<unknown>
-
 /**
  * Spawn a single-use Vue dialog instance to get the result when it is closed
  *
  * @param dialog - Dialog component to spawn
  * @param props - Props to pass to the dialog instance
- * @param optionsOrOnClose - Spawning options or a callback when the dialog is closed
- * @param onClose - Callback when the dialog is closed
+ * @param options - Spawning options
  * @return Promise resolved with the `close` event payload
  */
 export function spawnDialog(
 	dialog: Component,
 	props: object = {},
-	optionsOrOnClose: SpawnDialogOptions | ((...rest: unknown[]) => void) = {},
-	onClose?: (...rest: unknown[]) => void,
+	options: SpawnDialogOptions = {},
 ): Promise<unknown> {
-	if (typeof optionsOrOnClose === 'function') {
-		onClose = optionsOrOnClose
-		optionsOrOnClose = {}
-	}
-
-	let { container } = optionsOrOnClose
+	let { container } = options
 
 	// For backwards compatibility try to use container from props
 	if ('container' in props && typeof props.container === 'string') {
@@ -68,7 +48,6 @@ export function spawnDialog(
 			onClose(...rest: unknown[]) {
 				app.unmount()
 				element.remove()
-				onClose?.(...rest)
 				resolve(rest.length > 1 ? rest : rest[0])
 			},
 			'onVue:unmounted'() {


### PR DESCRIPTION
### ☑️ Resolves

- Breaking alternative for https://github.com/nextcloud-libraries/nextcloud-vue/pull/6758
- For: https://github.com/nextcloud-libraries/nextcloud-vue/issues/6731
- Return promise **instead of** `onClose` callback

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
