### PR TITLE
feat(dialogs/spawnDialogs)!: do not toRaw the result 

### DIFF
--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { Component } from 'vue'
-import { createApp, toRaw } from 'vue'
+import { createApp } from 'vue'
 
 type SpawnDialogOptions = {
 	/**
@@ -62,7 +62,7 @@ export function spawnDialog(
 		...props,
 		container,
 		onClose: (...rest: unknown[]) => {
-			onClose(...rest.map(v => toRaw(v)))
+			onClose(...rest)
 			app.unmount()
 			element.remove()
 		},


### PR DESCRIPTION
### ☑️ Resolves

- Chained on https://github.com/nextcloud-libraries/nextcloud-vue/pull/6757
- For: https://github.com/nextcloud-libraries/nextcloud-vue/issues/6731
- Do not `toRaw` the result

`toRaw` is only actual for libraries like `@nextcloud/dialogs` where the library can `toRaw` the result before emitting the event.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
