### PR TITLE
refactor: deprecate `Tooltip` directive for accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,21 @@ Especially the following are now provided as composables:
 * chore: restructure `package.json` [\#6405](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6405) \([susnux](https://github.com/susnux)\)
 * chore: Refactor changelog to make breaking changes better readable [\#6428](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6428) \([susnux](https://github.com/susnux)\)
 
+## [v8.25.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.25.0) (UNRELEASED)
+
+### 📝 Notes
+The `Tooltip` directive has been deprecated and will be removed in the future.
+In most cases you want to use the native browser tooltips instead by using the native HTML `title` attribute.
+In some rare cases where you really need a formatted tooltip `NcPopover` could be used.
+
+```diff
+ <NcButton
+-    v-tooltip="title"
++    :title="title"
+```
+
+#### Boolean properties
+
 ## [v8.24.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.24.0) (2025-04-02)
 
 ### 📝 Notes

--- a/src/components/NcAppContent/NcAppDetailsToggle.vue
+++ b/src/components/NcAppContent/NcAppDetailsToggle.vue
@@ -4,10 +4,10 @@
 -->
 
 <template>
-	<NcButton v-tooltip="title"
+	<NcButton :aria-label="title"
 		class="app-details-toggle"
 		:class="{ 'app-details-toggle--mobile': isMobile }"
-		:aria-label="title"
+		:title
 		variant="tertiary">
 		<template #icon>
 			<ArrowLeft v-if="isRtl" :size="20" />
@@ -17,29 +17,22 @@
 </template>
 
 <script>
-import NcButton from '../NcButton/index.ts'
-import { t } from '../../l10n.js'
-import Tooltip from '../../directives/Tooltip/index.js'
-
 import { emit } from '@nextcloud/event-bus'
+import { useIsMobile } from '../../composables/useIsMobile/index.js'
+import { isRtl } from '../../utils/rtl.ts'
+import { t } from '../../l10n.js'
 
 import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
 import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
-
-import { useIsMobile } from '../../composables/useIsMobile/index.js'
-import { isRtl } from '../../utils/rtl.ts'
+import NcButton from '../NcButton/index.ts'
 
 export default {
 	name: 'NcAppDetailsToggle',
 
-	directives: {
-		tooltip: Tooltip,
-	},
-
 	components: {
-		NcButton,
 		ArrowRight,
 		ArrowLeft,
+		NcButton,
 	},
 	setup() {
 		return {

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -214,9 +214,9 @@ export default {
 					<div class="icons-menu">
 						<!-- Play-pause toggle -->
 						<button v-if="hasNext && enableSlideshow"
-							v-tooltip.auto="playPauseName"
 							:class="{ 'play-pause-icons--paused': slideshowPaused }"
 							class="play-pause-icons"
+							:title="playPauseName"
 							type="button"
 							@click="togglePlayPause">
 							<!-- Play/pause icons -->
@@ -334,7 +334,6 @@ import { createElementId } from '../../utils/createElementId.ts'
 import NcActions from '../NcActions/index.js'
 import NcButton from '../NcButton/index.ts'
 import Timer from '../../utils/Timer.js'
-import Tooltip from '../../directives/Tooltip/index.js'
 
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import ChevronRight from 'vue-material-design-icons/ChevronRight.vue'
@@ -346,17 +345,13 @@ export default {
 	name: 'NcModal',
 
 	components: {
-		NcActions,
 		ChevronLeft,
 		ChevronRight,
 		Close,
 		Pause,
 		Play,
+		NcActions,
 		NcButton,
-	},
-
-	directives: {
-		tooltip: Tooltip,
 	},
 
 	props: {

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -242,7 +242,6 @@ export default {
 	<div class="rich-contenteditable" :class="$props.class">
 		<div :id="id"
 			ref="contenteditable"
-			v-tooltip="tooltipString"
 			:class="{
 				'rich-contenteditable__input--empty': isEmptyValue,
 				'rich-contenteditable__input--multiline': multiline,
@@ -261,6 +260,7 @@ export default {
 			:aria-controls="tributeId"
 			:aria-expanded="isAutocompleteOpen ? 'true' : 'false'"
 			:aria-activedescendant="autocompleteActiveId"
+			:title="tooltipString"
 			v-bind="$attrs"
 			@focus="moveCursorToEnd"
 			@input="onInput"
@@ -287,7 +287,6 @@ export default {
 import { t } from '../../l10n.js'
 import NcAutoCompleteResult from './NcAutoCompleteResult.vue'
 import richEditor from '../../mixins/richEditor/index.js'
-import Tooltip from '../../directives/Tooltip/index.js'
 import { emojiSearch, emojiAddRecent } from '../../functions/emoji/index.ts'
 import { searchProvider, getLinkWithPicker } from '../NcRichText/index.js'
 import { createElementId } from '../../utils/createElementId.ts'
@@ -309,10 +308,6 @@ smilesCharacters.forEach((char) => {
 
 export default {
 	name: 'NcRichContenteditable',
-
-	directives: {
-		tooltip: Tooltip,
-	},
 
 	mixins: [richEditor],
 

--- a/src/directives/Tooltip/index.js
+++ b/src/directives/Tooltip/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { VTooltip, options } from 'floating-vue'
+import { vTooltip, options } from 'floating-vue'
 import './index.scss'
 
 options.themes.tooltip.html = false
@@ -11,5 +11,10 @@ options.themes.tooltip.delay = { show: 500, hide: 200 }
 options.themes.tooltip.distance = 10
 options.themes.tooltip['arrow-padding'] = 3
 
-export default VTooltip
-export { options }
+export {
+	/**
+	 * @deprecated Use the native `title` attribute instead.
+	 */
+	vTooltip as default,
+	options,
+}


### PR DESCRIPTION
### ☑️ Resolves

- port all usage within this library to native `title` attribute
- deprecate `Tooltip` directive, its recommended to use the browser native tooltips using `title`.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
