### PR TITLE
refactor: use `NcIconSvgWrapper` with `directional` property where needed

### DIFF
--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -355,9 +355,12 @@ export default {
 			<span v-else class="action-button__text">{{ text }}</span>
 
 			<!-- right(in LTR) or left(in RTL) arrow icon when there is a sub-menu -->
-			<ChevronRightIcon v-if="isMenu && !isRtl" :size="20" class="action-button__menu-icon" />
-			<ChevronLeftIcon v-else-if="isMenu && isRtl" :size="20" class="action-button__menu-icon" />
-			<CheckIcon v-else-if="isChecked === true" :size="20" class="action-button__pressed-icon" />
+			<NcIconSvgWrapper v-if="isMenu"
+				class="action-button__menu-icon"
+				directional
+				:path="mdiChevronRight" />
+			<NcIconSvgWrapper v-else-if="isChecked" :path="mdiCheck" class="action-button__pressed-icon" />
+
 			<span v-else-if="isChecked === false" class="action-button__pressed-icon material-design-icon" />
 
 			<!-- fake slot to gather inner text -->
@@ -367,12 +370,10 @@ export default {
 </template>
 
 <script>
-import CheckIcon from 'vue-material-design-icons/Check.vue'
-import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
-import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
-import ActionTextMixin from '../../mixins/actionText.js'
-import { isRtl } from '../../utils/rtl.ts'
+import { mdiCheck, mdiChevronRight } from '@mdi/js'
 import { NC_ACTIONS_IS_SEMANTIC_MENU } from '../NcActions/useNcActions.ts'
+import ActionTextMixin from '../../mixins/actionText.js'
+import NcIconSvgWrapper from '../NcIconSvgWrapper/NcIconSvgWrapper.vue'
 
 /**
  * Button component to be used in Actions
@@ -381,9 +382,7 @@ export default {
 	name: 'NcActionButton',
 
 	components: {
-		CheckIcon,
-		ChevronRightIcon,
-		ChevronLeftIcon,
+		NcIconSvgWrapper,
 	},
 
 	mixins: [ActionTextMixin],
@@ -464,7 +463,8 @@ export default {
 
 	setup() {
 		return {
-			isRtl,
+			mdiCheck,
+			mdiChevronRight,
 		}
 	},
 

--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -74,8 +74,7 @@ export default {
 				<!-- allow the custom font to inject a ::before
 					not possible on input[type=submit] -->
 				<label v-show="!disabled" :for="id" class="action-text-editable__label">
-					<ArrowLeft v-if="isRtl" :size="20" />
-					<ArrowRight v-else :size="20" />
+					<NcIconSvgWrapper directional :path="mdiArrowRight" />
 				</label>
 			</form>
 		</span>
@@ -83,20 +82,17 @@ export default {
 </template>
 
 <script>
-import ActionTextMixin from '../../mixins/actionText.js'
+import { mdiArrowRight } from '@mdi/js'
 import { createElementId } from '../../utils/createElementId.ts'
 
-import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
-import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
-
-import { isRtl } from '../../utils/rtl.ts'
+import ActionTextMixin from '../../mixins/actionText.js'
+import NcIconSvgWrapper from '../NcIconSvgWrapper/index.js'
 
 export default {
 	name: 'NcActionTextEditable',
 
 	components: {
-		ArrowLeft,
-		ArrowRight,
+		NcIconSvgWrapper,
 	},
 
 	mixins: [ActionTextMixin],
@@ -134,7 +130,7 @@ export default {
 
 	setup() {
 		return {
-			isRtl,
+			mdiArrowRight,
 		}
 	},
 


### PR DESCRIPTION
### ☑️ Resolves

Simplify RTL handling for icons a bit.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
