### PR TITLE
fix(NcRichContenteditable): add correct tooltip

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -244,8 +244,10 @@ msgstr ""
 msgid "Medium skin tone"
 msgstr ""
 
-msgid "Message limit of {count} characters reached"
-msgstr ""
+msgid "Message limit of %n character reached"
+msgid_plural "Message limit of %n characters reached"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Month picker"
 msgstr ""

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -284,7 +284,7 @@ export default {
 </template>
 
 <script>
-import { t } from '../../l10n.js'
+import { n, t } from '../../l10n.js'
 import NcAutoCompleteResult from './NcAutoCompleteResult.vue'
 import richEditor from '../../mixins/richEditor/index.js'
 import { emojiSearch, emojiAddRecent } from '../../functions/emoji/index.ts'
@@ -483,11 +483,7 @@ export default {
 			if (!this.isOverMaxlength) {
 				return null
 			}
-			return {
-				content: t('Message limit of {count} characters reached', { count: this.maxlength }),
-				shown: true,
-				trigger: 'manual',
-			}
+			return n('Message limit of %n character reached', 'Message limit of %n characters reached', this.maxlength)
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

regression of the migration from Tooltip directive to native tooltips. It needs to be a string not an object.
Also use `n` as you never can know how plurals are translated (there are possible more than two plural forms).

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
