### PR TITLE
refactor: drop `string-length` dependency and replace with native solution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.1",
         "splitpanes": "^4.0.3",
-        "string-length": "^6.0.0",
         "striptags": "^3.2.0",
         "tabbable": "^6.2.0",
         "tributejs": "^5.1.3",
@@ -21991,45 +21990,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.19"
-      }
-    },
-    "node_modules/string-length": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-6.0.0.tgz",
-      "integrity": "sha512-1U361pxZHEQ+FeSjzqRpV+cu2vTzYeWeafXFLykiFlv4Vc0n3njgU8HrMbyik5uwm77naWMuVG8fhEF+Ovb1Kg==",
-      "dependencies": {
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-length/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-length/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.1",
     "splitpanes": "^4.0.3",
-    "string-length": "^6.0.0",
     "striptags": "^3.2.0",
     "tabbable": "^6.2.0",
     "tributejs": "^5.1.3",

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -293,7 +293,6 @@ import { createElementId } from '../../utils/createElementId.ts'
 
 import Tribute from 'tributejs/dist/tribute.esm.js'
 import debounce from 'debounce'
-import stringLength from 'string-length'
 
 /**
  * Populate the list of text smiles we want to offer via Tribute.
@@ -420,10 +419,14 @@ export default {
 	],
 
 	setup() {
+		const segmenter = new Intl.Segmenter()
+
 		return {
 			// Constants
 			labelId: createElementId(),
 			tributeId: createElementId(),
+
+			segmenter,
 
 			/**
 			 * Non-reactive property to store Tribute instance
@@ -471,7 +474,8 @@ export default {
 			if (this.isEmptyValue || !this.maxlength) {
 				return false
 			}
-			return stringLength(this.localValue) > this.maxlength
+			const length = [...this.segmenter.segment(this.localValue)].length
+			return length > this.maxlength
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

Remove useless dependencies where we can just use native ES alternatives.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
