### PR TITLE
fix(dialogs/spawnDialog): enhance `spawnDialog` types

### DIFF
--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -2,8 +2,29 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { Component } from 'vue'
-import { createApp } from 'vue'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { createApp, type Component } from 'vue'
+
+type ComponentProps<T extends Component> = T extends new (...args: any) => { $props: infer P }
+	? P extends Record<string, any>
+		? P
+		: never
+	: never
+
+type DialogComponent<T extends Component> = 'onClose' extends keyof ComponentProps<T>
+	? T
+	: 'Please provide a Dialog Component that supports `@close` event'
+
+type NormalizedPayload<T> = T extends []
+	? void
+	: T extends [infer F]
+		? F
+		: T
+
+type ClosePayload<T> = T extends { onClose?: (...args: infer P) => any }
+	? P
+	: never
 
 type SpawnDialogOptions = {
 	/**
@@ -21,11 +42,11 @@ type SpawnDialogOptions = {
  * @param options - Spawning options
  * @return Promise resolved with the `close` event payload
  */
-export function spawnDialog(
-	dialog: Component,
-	props: object = {},
-	options: SpawnDialogOptions = {},
-): Promise<unknown> {
+export function spawnDialog<
+    C extends Component,
+		P extends ComponentProps<C>,
+		E extends ClosePayload<P>,
+>(dialog: DialogComponent<C>, props: Partial<P> = {}, options: SpawnDialogOptions = {}): Promise<NormalizedPayload<E>> {
 	let { container } = options
 
 	// For backwards compatibility try to use container from props
@@ -40,15 +61,17 @@ export function spawnDialog(
 	const element = resolvedContainer.appendChild(document.createElement('div'))
 
 	return new Promise((resolve, reject) => {
-		const app = createApp(dialog, {
+		const app = createApp(dialog as Component, {
 			...props,
 			// If dialog has no `container` prop passing a falsy value does nothing
 			// Otherwise it is expected that `null` disables teleport and mounts dialog in place like NcDialog/NcModal
 			container: null,
-			onClose(...rest: unknown[]) {
+			onClose(...rest: E) {
+				const payload = (rest.length > 1 ? rest : rest[0]) as NormalizedPayload<E>
+
 				app.unmount()
 				element.remove()
-				resolve(rest.length > 1 ? rest : rest[0])
+				resolve(payload)
 			},
 			'onVue:unmounted'() {
 				app.unmount()

--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -8,9 +8,7 @@ import type { Component } from 'vue'
 import { createApp } from 'vue'
 
 type ComponentProps<T extends Component> = T extends new (...args: any) => { $props: infer P }
-	? P extends Record<string, any>
-		? P
-		: never
+	? P
 	: never
 
 type DialogComponent<T extends Component> = 'onClose' extends keyof ComponentProps<T>

--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -4,7 +4,8 @@
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { createApp, type Component } from 'vue'
+import type { Component } from 'vue'
+import { createApp } from 'vue'
 
 type ComponentProps<T extends Component> = T extends new (...args: any) => { $props: infer P }
 	? P extends Record<string, any>

--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -43,9 +43,9 @@ type SpawnDialogOptions = {
  * @return Promise resolved with the `close` event payload
  */
 export function spawnDialog<
-    C extends Component,
-		P extends ComponentProps<C>,
-		E extends ClosePayload<P>,
+	C extends Component,
+	P extends ComponentProps<C>,
+	E extends ClosePayload<P>,
 >(dialog: DialogComponent<C>, props: Partial<P> = {}, options: SpawnDialogOptions = {}): Promise<NormalizedPayload<E>> {
 	let { container } = options
 

--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -44,9 +44,8 @@ type SpawnDialogOptions = {
  */
 export function spawnDialog<
 	C extends Component,
-	P extends ComponentProps<C>,
-	E extends ClosePayload<P>,
->(dialog: DialogComponent<C>, props: Partial<NoInfer<P>> = {}, options: SpawnDialogOptions = {}): Promise<NormalizedPayload<E>> {
+	E extends ClosePayload<ComponentProps<C>>,
+>(dialog: DialogComponent<C>, props: Partial<ComponentProps<C>> = {}, options: SpawnDialogOptions = {}): Promise<NormalizedPayload<E>> {
 	let { container } = options
 
 	// For backwards compatibility try to use container from props

--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -46,7 +46,7 @@ export function spawnDialog<
 	C extends Component,
 	P extends ComponentProps<C>,
 	E extends ClosePayload<P>,
->(dialog: DialogComponent<C>, props: Partial<P> = {}, options: SpawnDialogOptions = {}): Promise<NormalizedPayload<E>> {
+>(dialog: DialogComponent<C>, props: Partial<NoInfer<P>> = {}, options: SpawnDialogOptions = {}): Promise<NormalizedPayload<E>> {
 	let { container } = options
 
 	// For backwards compatibility try to use container from props


### PR DESCRIPTION
### ☑️ Resolves

- A next iteration of https://github.com/nextcloud-libraries/nextcloud-vue/pull/6770 that improves `spawnDialog` types:
- Now only components with a declared `@close` event can be passed to `spawnDialog`, otherwise an error is thrown on a type level suggesting what went wrong
- Autocompletion for props
- Return type is automatically inferred based on a `@close` event's payload

The implementation passes all the test cases from https://github.com/nextcloud-libraries/nextcloud-vue/pull/6770#issuecomment-2804453176

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
