### PR TITLE
fix(NcRichContenteditable): bring back error style on overflow

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -1068,6 +1068,12 @@ export default {
 			border-radius: var(--border-radius);
 			background-color: var(--color-background-dark);
 		}
+
+		&--overflow,
+		&--overflow:hover {
+			// we need important to override server styles
+			border-color: var(--color-error) !important;
+		}
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

- some time ago the error state style was lost and only the class was set.
- bring back the error style on overflow.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
