### PR TITLE
refactor(Focus): migrate directive to Typescript

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -711,13 +711,6 @@ export default {
 </template>
 
 <script>
-import NcAppSidebarTabs from './NcAppSidebarTabs.vue'
-import NcActions from '../NcActions/index.js'
-import NcAppSidebarHeader from '../NcAppSidebarHeader/index.ts'
-import NcButton from '../NcButton/index.ts'
-import NcEmptyContent from '../NcEmptyContent/index.js'
-import NcLoadingIcon from '../NcLoadingIcon/index.js'
-import Focus from '../../directives/Focus/index.js'
 import { vOnClickOutside as ClickOutside } from '@vueuse/components'
 import { createFocusTrap } from 'focus-trap'
 import { provide, ref, warn } from 'vue'
@@ -732,6 +725,14 @@ import IconClose from 'vue-material-design-icons/Close.vue'
 import IconDockRight from 'vue-material-design-icons/DockRight.vue'
 import IconStar from 'vue-material-design-icons/Star.vue'
 import IconStarOutline from 'vue-material-design-icons/StarOutline.vue'
+
+import NcAppSidebarTabs from './NcAppSidebarTabs.vue'
+import NcActions from '../NcActions/index.js'
+import NcButton from '../NcButton/index.ts'
+import NcEmptyContent from '../NcEmptyContent/index.js'
+import NcLoadingIcon from '../NcLoadingIcon/index.js'
+import NcAppSidebarHeader from '../NcAppSidebarHeader/index.ts'
+import Focus from '../../directives/Focus/index.ts'
 
 export default {
 	name: 'NcAppSidebar',

--- a/src/directives/Focus/index.ts
+++ b/src/directives/Focus/index.ts
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export const directive = {
-	mounted(el) {
+import type { ObjectDirective } from 'vue'
+
+const directive: ObjectDirective<HTMLElement> = {
+	mounted(el: HTMLElement) {
 		el.focus()
 	},
 }

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -3,5 +3,5 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export { default as Focus } from './Focus/index.js'
+export { default as Focus } from './Focus/index.ts'
 export { default as Linkify } from './Linkify/index.ts'


### PR DESCRIPTION
### ☑️ Resolves

- for #841 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
