### PR TITLE
chore: prepare release of v9.0.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v9.0.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.0.0-alpha.8) (unreleased)
-[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.24.0...v9.0.0-alpha.8)
+## [v9.0.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.0.0-rc.0) (unreleased)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.24.0...v9.0.0-rc.0)
 
 ### 💥 Breaking Changes
 * The package now uses Vue 3 instead of Vue 2.7
@@ -155,6 +155,11 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
 
 ### 🚀 Enhancements
 * Allow writing components using Typescript and provide type definitions for `NcButton` [\#4525](https://github.com/nextcloud-libraries/nextcloud-vue/pull/4525) \([susnux](https://github.com/susnux)\)
+* feat(NcDateTimePicker): add time range picker and align naming [#6728](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6728) ([susnux](https://github.com/susnux))
+* feat(dialogs/spawnDialog): separate spawning options from dialog props and allow Element as a container [#6756](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6756) ([ShGKme](https://github.com/ShGKme))
+* feat(dialogs/spawnDialogs)!: do not toRaw the result  [#6760](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6760) ([ShGKme](https://github.com/ShGKme))
+* feat(dialogs/spawnDialog): return promise with the result [#6758](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6758) ([ShGKme](https://github.com/ShGKme))
+* feat(dialogs/spawnDialog)!: replace onClose callback with Promise [#6759](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6759) ([ShGKme](https://github.com/ShGKme))
 
 ### 🐛 Fixed bugs
 * fix(NcActions): trigger forgotten closed event and correctly handle open [#6706](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6706) ([ShGKme](https://github.com/ShGKme))
@@ -184,6 +189,10 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
 * fix(NcAvatar): attributes order [\#6377](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6377) \([raimund-schluessler](https://github.com/raimund-schluessler)\)
 * fix!: make 'box-sizing: border-box' a default behaviour for all containers [\#6390](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6390) \([Antreesy](https://github.com/Antreesy)\)
 * fix(NcSelect): `required` doesn't work [\#6458](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6458) \([ShGKme](https://github.com/ShGKme)\)
+* fix(dialogs/spawnDialog): enhance `spawnDialog` types [#6781](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6781) ([mattersj](https://github.com/mattersj))
+* fix(NcDateTimePicker): adjust padding to prevent horizontal scrolling [#6722](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6722) ([susnux](https://github.com/susnux))
+* fix(NcDateTimePicker): prevent emitting `[Date, null]` [#6726](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6726) ([susnux](https://github.com/susnux))
+* fix(dialogs/spawnDialog)!: support vue-devtool but lose appContext [#6752](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6752) ([ShGKme](https://github.com/ShGKme))
 
 ### Changed
 * refactor: replace boolean properties with `default: true` with `default: false` [#6653](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6653) ([susnux](https://github.com/susnux))
@@ -255,6 +264,13 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
 * refactor(useHotKey): migrate code to Typescript [\#6430](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6430) \([susnux](https://github.com/susnux)\)
 * chore: restructure `package.json` [\#6405](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6405) \([susnux](https://github.com/susnux)\)
 * chore: Refactor changelog to make breaking changes better readable [\#6428](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6428) \([susnux](https://github.com/susnux)\)
+* refactor: Migrate `NcButton` from render function to template [#6033](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6033) ([susnux](https://github.com/susnux))
+* refactor: adjust code to fix all SASS deprecations [#6734](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6734) ([susnux](https://github.com/susnux))
+* refactor: drop `string-length` dependency and replace with native solution [#6779](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6779) ([susnux](https://github.com/susnux))
+* chore: drop remaining cypress files [#6735](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6735) ([susnux](https://github.com/susnux))
+* chore: adjust package engines versions [#6725](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6725) ([susnux](https://github.com/susnux))
+* chore: update pull_request_template.md [#6736](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6736) ([ShGKme](https://github.com/ShGKme))
+* docs(NcDateTimePicker): add prop documentation for all props [#6727](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6727) ([susnux](https://github.com/susnux))
 
 ## [v8.26.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.26.0) (UNRELEASED)
 
@@ -268,9 +284,31 @@ Also this component now supports a logical placement (`start`, `end`) which work
 Moreover the `focusTrap` property is now deprecated and will be replaced with `noFocusTrap`,
 the reason behind this is to only have boolean properties with default value of `false` allowing shortcut props.
 
-## [v8.25.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.25.0) (UNRELEASED)
+## [v8.25.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.25.1) (2025-04-17)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.25.0...v8.25.1)
+
+### 🐛 Fixed bugs
+* fix(NcPopover): regression with incorrect size on RTL [#6797](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6797)
+
+## [v8.25.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.25.0) (2025-04-16)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.24.0...v8.25.0)
 
 ### 📝 Notes
+#### `NcDateTimePicker`
+In version 8 the `NcDateTimePicker` was a transparent wrapper around the [vue2 datepicker library](https://github.com/mengxiong10/vue2-datepicker).
+With version 9 and beyond we will no longer transparently wrap external libraries,
+thus only documented props, events, and slots of Nextcloud components are guaranteed to work.
+This will allow use to change the underlying library while keeping a stable API for the component users.
+
+For this we deprecated the `range` property in favor of three new types for the `NcDateTimePicker`.
+- `date-range`
+- `time-range`
+- `datetime-range`
+
+Also the `formatter` property is deprecated, instead you can now provide a function to the `format` property,
+which will receive a `Date` object and should return the formatted date as a string.
+
+#### `Tooltip` directive
 The `Tooltip` directive has been deprecated and will be removed in the future.
 In most cases you want to use the native browser tooltips instead by using the native HTML `title` attribute.
 In some rare cases where you really need a formatted tooltip `NcPopover` could be used.
@@ -280,8 +318,6 @@ In some rare cases where you really need a formatted tooltip `NcPopover` could b
 -    v-tooltip="title"
 +    :title="title"
 ```
-
-#### Boolean properties
 
 ## [v8.24.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.24.0) (2025-04-02)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.0.0-alpha.8",
+  "version": "9.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "9.0.0-alpha.8",
+      "version": "9.0.0-rc.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.0.0-alpha.8",
+  "version": "9.0.0-rc.0",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## First release candidate

This release will (hopefully) be the last release of the v9 series with breaking changes.

### Required PRs (breaking)

- [x] https://github.com/nextcloud-libraries/nextcloud-vue/pull/6787
- [x] https://github.com/nextcloud-libraries/nextcloud-vue/pull/6790
- [x] https://github.com/nextcloud-libraries/nextcloud-vue/pull/6732
- [x] https://github.com/nextcloud-libraries/nextcloud-vue/pull/6802

### Changelog of this release
#### 🚀 Enhancements
* feat(NcDateTimePicker): add time range picker and align naming by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6728
* feat(dialogs/spawnDialog): separate spawning options from dialog props and allow Element as a container by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6756
* feat(dialogs/spawnDialogs)!: do not toRaw the result  by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6760
* Adjust all styles for RTL support and add `directional` prop to NcIconSvgWrapper by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6733
* feat(dialogs/spawnDialog): return promise with the result by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6758
* feat(dialogs/spawnDialog)!: replace onClose callback with Promise by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6759
* [next] feat(NcAvatar): implement custom javascript hook action for the contacts menu by @backportbot in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6306

#### 🐛 Fixed bugs
* fix(NcDateTimePicker): adjust padding to prevent horizontal scrolling by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6722
* fix(dialogs/spawnDialog): dialog cannot be closed by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6729
* fix(NcDateTimePicker): prevent emitting `[Date, null]` by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6726
* fix(dialogs/spawnDialog)!: support vue-devtool but lose appContext by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6752
* fix(dialogs/spawnDialog): do not teleport dialog from root by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6757
* fix(dialogs/spawnDialog): enhance `spawnDialog` types by @mattersj in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6781
* fix(NcRichContenteditable): add correct tooltip by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6778

#### Other Changes
* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6721
* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6724
* docs(NcDateTimePicker): add prop documentation for all props by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6727
* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6739
* chore: drop remaining cypress files by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6735
* chore: adjust package engines versions by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6725
* chore: update pull_request_template.md by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6736
* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6762
* refactor: deprecate `Tooltip` directive for accessibility by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6761
* refactor!(NcModal): adjust to boolean props with default `false` by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6719
* refactor: drop `string-length` dependency and replace with native solution by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6779
* chore: type check project on CI by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6737
* refactor: adjust code to fix all SASS deprecations by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6734
* refactor: Migrate `NcButton` from render function to template by @susnux in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6033
* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6783
* Updates for project Nextcloud vue library by @transifex-integration in https://github.com/nextcloud-libraries/nextcloud-vue/pull/6784