### PR TITLE
refactor(NcChip): use `defineSlots` for proper slot definition

### DIFF
--- a/src/components/NcChip/NcChip.vue
+++ b/src/components/NcChip/NcChip.vue
@@ -77,7 +77,6 @@ export default {
 			'nc-chip--no-icon': !hasIcon(),
 		}">
 		<span v-if="hasIcon()" class="nc-chip__icon">
-			<!-- @slot The icon slot can be used to set the chip icon. Make sure that the icon is not exceeding a height of `24px`. For round icons a exact size of `24px` is recommended. -->
 			<slot name="icon">
 				<!-- The default icon wrapper uses a size of 18px to ensure the icon is not clipped by the round chip style -->
 				<NcIconSvgWrapper v-if="iconPath || iconSvg"
@@ -88,7 +87,6 @@ export default {
 			</slot>
 		</span>
 		<span class="nc-chip__text">
-			<!-- @slot The default slot can be used to set the text that is shown -->
 			<slot>{{ text }}</slot>
 		</span>
 		<NcActions v-if="canClose || hasActions()"
@@ -103,15 +101,16 @@ export default {
 				</template>
 				{{ ariaLabelClose }}
 			</NcActionButton>
-			<!-- @slot The actions slot can be used to add custom actions to the chips actions -->
 			<slot name="actions" />
 		</NcActions>
 	</div>
 </template>
 
 <script setup lang="ts">
+import type { Slot } from 'vue'
+
 import { mdiClose } from '@mdi/js'
-import { computed, useSlots } from 'vue'
+import { computed } from 'vue'
 import { t } from '../../l10n.js'
 
 import NcActions from '../NcActions/NcActions.vue'
@@ -162,8 +161,30 @@ const props = withDefaults(defineProps<{
 	variant: 'secondary',
 })
 
-const emit = defineEmits(['close'])
-const slots = useSlots()
+const emit = defineEmits<{
+	/**
+	 * Emitted when the close button is clicked
+	 */
+	close: []
+}>()
+
+const slots = defineSlots<{
+	/**
+	 * The actions slot can be used to add custom actions to the chips actions.
+	 */
+	actions?: Slot
+	/**
+	 * The default slot can be used to set the text that is shown.
+	 */
+	default?: Slot
+	/**
+	 * The icon slot can be used to set the chip icon.
+	 *
+	 * Make sure that the icon is not exceeding a height of `24px`.
+	 * For round icons a exact size of `24px` is recommended.
+	 */
+	icon?: Slot
+}>()
 
 const canClose = computed(() => !props.noClose)
 const hasActions = () => Boolean(slots.actions?.())
@@ -173,9 +194,6 @@ const hasIcon = () => Boolean(props.iconPath || props.iconSvg || !!slots.icon?.(
  * Handle closing the chip (pressing the X-button)
  */
 function onClose() {
-	/**
-	 * Emitted when the close button is clicked
-	 */
 	emit('close')
 }
 </script>


### PR DESCRIPTION
### ☑️ Resolves

This resolves 2 errors reported by Typescript when building the package (missing "private" type exports during the declaration creation).

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
