### PR TITLE
fix(NcPopover): lock upstream library style overrides

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -416,7 +416,8 @@ $arrow-position: $arrow-width - 1px;
 .resize-observer {
 	position: absolute;
 	top: 0;
-	inset-inline-start: 0;
+	/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
+	left: 0;
 	z-index: -1;
 	width: 100%;
 	height: 100%;
@@ -431,7 +432,8 @@ $arrow-position: $arrow-width - 1px;
 		display: block;
 		position: absolute;
 		top: 0;
-		inset-inline-start: 0;
+		/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
+		left: 0;
 		height: 100%;
 		width: 100%;
 		overflow: hidden;
@@ -449,7 +451,8 @@ $arrow-position: $arrow-width - 1px;
 	&.v-popper__popper {
 		z-index: 100000;
 		top: 0;
-		inset-inline-start: 0;
+		/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
+		left: 0;
 		display: block !important;
 
 		.v-popper__wrapper {
@@ -485,26 +488,36 @@ $arrow-position: $arrow-width - 1px;
 
 		&[data-popper-placement^='top'] .v-popper__arrow-container {
 			bottom: -$arrow-position;
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
 			border-bottom-width: 0;
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
 			border-top-color: var(--color-main-background);
 		}
 
 		&[data-popper-placement^='bottom'] .v-popper__arrow-container {
 			top: -$arrow-position;
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
 			border-top-width: 0;
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
 			border-bottom-color: var(--color-main-background);
 		}
 
 		&[data-popper-placement^='right'] .v-popper__arrow-container {
-			inset-inline-start: -$arrow-position;
-			border-inline-start-width: 0;
-			border-inline-end-color: var(--color-main-background);
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
+			left: -$arrow-position;
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
+			border-left-width: 0;
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
+			border-right-color: var(--color-main-background);
 		}
 
 		&[data-popper-placement^='left'] .v-popper__arrow-container {
-			inset-inline-end: -$arrow-position;
-			border-inline-end-width: 0;
-			border-inline-start-color: var(--color-main-background);
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
+			right: -$arrow-position;
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
+			border-right-width: 0;
+			/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
+			border-left-color: var(--color-main-background);
 		}
 
 		&[aria-hidden='true'] {

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -1085,7 +1085,7 @@ export default {
 	overflow: auto;
 	// Hide container root element while initializing
 	position: absolute;
-	/* stylelint-disable csstools/use-logical */ /* upstream logic */
+	/* stylelint-disable-next-line csstools/use-logical */ /* upstream logic */
 	left: -100vw;
 	// Space it out a bit from the text
 	margin: var(--default-grid-baseline) 0;


### PR DESCRIPTION
### ☑️ Resolves

- Fix regression from #6733
- lock upstream library style overrides (should be always left/right)
- disable csstools/use-logical to skip check

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="587" alt="2025-04-17_10h08_26" src="https://github.com/user-attachments/assets/fa3ff96b-dd19-447b-9c7d-5f9bc181500e" /> | <img width="587" alt="2025-04-17_10h08_10" src="https://github.com/user-attachments/assets/b262c897-499e-4ebf-a01e-37b8158eae26" />

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
