### PR TITLE
chore: release 8.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 # Changelog
 
+## [v8.25.1](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.25.1) (2025-04-17)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.25.0...v8.25.1)
+
+### 🐛 Fixed bugs
+* fix(NcPopover): regression with incorrect size on RTL [#6797](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6797)
+
 ## [v8.25.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.25.0) (2025-04-16)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.24.0...v8.25.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "8.25.0",
+      "version": "8.25.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "8.25.0",
+  "version": "8.25.1",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
## What's Changed
### 🐛 Fixed bugs
* fix(NcPopover): regression with incorrect size on RTL [#6797](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6797)


**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-vue/compare/v8.25.0...v8.25.1