### PR TITLE
fix(NcRichText): `references` prop type

### DIFF
--- a/src/components/NcRichText/NcReferenceList.vue
+++ b/src/components/NcRichText/NcReferenceList.vue
@@ -32,7 +32,7 @@ export default {
 			default: '',
 		},
 		referenceData: {
-			type: Object,
+			type: Array,
 			default: null,
 		},
 		limit: {

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -362,7 +362,7 @@ export default {
 		},
 		/** Provide data upfront to avoid extra http request */
 		references: {
-			type: Object,
+			type: Array,
 			default: null,
 		},
 		/** Provide basic Markdown syntax */


### PR DESCRIPTION
The references prop is passed to `NcReferenceList` and is processed as a list, not an object. This prevents Vue warnings and fixes the docs.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
