### PR TITLE
feat(NcPopover): document all properties and remove transparent `floating-vue` wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,9 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
   - The `range` property was removed in favor of `type="datetime-range"` (datetime ranges), `type="date-range"` (date only ranges), and `type="time-range"` (time only ranges).
   - The `lang` property was replaced with the `locale` property.
   - The `formatter` property was removed.
+- `NcPopover` is no longer a transparent wrapper over the `floating-vue` package.
+  Instead only use the documented properties and events.
+  If you find some use cases not covered by the documented interface, please open a feature request.
 - `NcSelect`
   - `userSelect` property was removed, instead just use the `NcSelectUsers` component
   - `closeOnSelect` property was removed in favor of `keepOpen`.
@@ -257,7 +260,12 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
 
 ### 📝 Notes
 #### NcPopover
-The `focusTrap` property is now deprecated and will be replaced with `noFocusTrap`,
+`NcPopover` now has its own properties and no longer directly exposes the internal library used (`floating-vue`).
+It is still possible to use its properties, but this ability might be removed in the next version.
+Thus we encourage you to only use the documented properties.
+
+Also this component now supports a logical placement (`start`, `end`) which works with RTL design.
+Moreover the `focusTrap` property is now deprecated and will be replaced with `noFocusTrap`,
 the reason behind this is to only have boolean properties with default value of `false` allowing shortcut props.
 
 ## [v8.25.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.25.0) (UNRELEASED)

--- a/tests/unit/components/NcPopover/logical-placement.spec.ts
+++ b/tests/unit/components/NcPopover/logical-placement.spec.ts
@@ -1,0 +1,42 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { shallowMount } from '@vue/test-utils'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+import NcPopover from '../../../../src/components/NcPopover/NcPopover.vue'
+
+const rtlTs = vi.hoisted(() => ({ isRtl: false }))
+vi.mock('../../../../src/utils/rtl.ts', () => rtlTs)
+
+describe('NcPopover support logical placement', () => {
+	beforeAll(() => {
+		// disable debug as this tries to access internals of floting-vue
+		window.OC.debug = false
+	})
+
+	test.each`
+	placement      | isRtl    | expected
+	${'start'}     | ${false} | ${'left'}
+	${'start'}     | ${true}  | ${'right'}
+	${'bottom'}    | ${false} | ${'bottom'}
+	${'bottom'}    | ${true}  | ${'bottom'}
+	${'top-start'} | ${false} | ${'top-start'}
+	${'top-start'} | ${true}  | ${'top-start'}
+	`('Setting logical $placement results in $expected (RTL: $isRtl)', ({ placement, isRtl, expected }) => {
+		// set the RTL mock
+		rtlTs.isRtl = isRtl
+
+		const vm = shallowMount(NcPopover, {
+			props: {
+				placement,
+			},
+			slots: {
+				default: 'tooltip text',
+				trigger: '<button>trigger</button>',
+			},
+		})
+
+		expect(vm.getComponent({ name: 'Dropdown' }).props('placement')).toBe(expected)
+	})
+})


### PR DESCRIPTION
* Resolves #6384 

### ☑️ Resolves

1. Document all properties used by Nextcloud apps (I checked for all usage in the nextcloud GitHub organization)
2. Remove mention of the wrapped library
3. Add feature to use logical direction in the `placement` prop

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
