### PR TITLE
feat(NcPopover): add new `noFocusTrap` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,13 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
 * chore: restructure `package.json` [\#6405](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6405) \([susnux](https://github.com/susnux)\)
 * chore: Refactor changelog to make breaking changes better readable [\#6428](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6428) \([susnux](https://github.com/susnux)\)
 
+## [v8.26.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.26.0) (UNRELEASED)
+
+### 📝 Notes
+#### NcPopover
+The `focusTrap` property is now deprecated and will be replaced with `noFocusTrap`,
+the reason behind this is to only have boolean properties with default value of `false` allowing shortcut props.
+
 ## [v8.25.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v8.25.0) (UNRELEASED)
 
 ### 📝 Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ are now removed. Following components have been adjusted:
 |     `NcModal` |           `enableSwipe` |       `disableSwipe` |
 |     `NcModal` |              `canClose` |            `noClose` |
 |    `NcDialog` |              `canClose` |            `noClose` |
+|   `NcPopover` |             `focusTrap` |        `noFocusTrap` |
 
 Additionally the default value `closeOnClickOutside` for `NcModal` was aligned with `NcDialog` and now defaults to `false`.
 

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -206,16 +206,6 @@ export default {
 		},
 
 		/**
-		 * Enable popover focus trap
-		 *
-		 * @deprecated use noFocusTrap instead
-		 */
-		focusTrap: {
-			type: Boolean,
-			default: true,
-		},
-
-		/**
 		 * Disable the popover focus trap.
 		 */
 		noFocusTrap: {
@@ -316,7 +306,7 @@ export default {
 		async useFocusTrap() {
 			await this.$nextTick()
 
-			if (this.noFocusTrap || !this.focusTrap) {
+			if (this.noFocusTrap) {
 				return
 			}
 

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -204,13 +204,25 @@ export default {
 			type: String,
 			default: '',
 		},
+
 		/**
 		 * Enable popover focus trap
+		 *
+		 * @deprecated use noFocusTrap instead
 		 */
 		focusTrap: {
 			type: Boolean,
 			default: true,
 		},
+
+		/**
+		 * Disable the popover focus trap.
+		 */
+		noFocusTrap: {
+			type: Boolean,
+			default: false,
+		},
+
 		/**
 		 * Set element to return focus to after focus trap deactivation
 		 *
@@ -304,7 +316,7 @@ export default {
 		async useFocusTrap() {
 			await this.$nextTick()
 
-			if (!this.focusTrap) {
+			if (this.noFocusTrap || !this.focusTrap) {
 				return
 			}
 


### PR DESCRIPTION
* Split from #6802 

### ☑️ Resolves

* for #6384 

Replacing the `focusTrap` prop to have prop with default of `false` allowing to use HTML short cut attributes `<NcPopover no-focus-trap />`.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
