### PR TITLE
ci: use conventional commits in `/*-update` commands

### DIFF
--- a/.github/workflows/command-l10n-update.yml
+++ b/.github/workflows/command-l10n-update.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ needs.init.outputs.arg1 != 'fixup' && needs.init.outputs.arg1 != 'amend' }}
         run: |
           git add .
-          git commit --signoff -m 'Updating l10n asset'
+          git commit --signoff -m 'chore(l10n): extract new translations'
           git push origin ${{ needs.init.outputs.head_ref }}
 
       - name: Commit and push fixup

--- a/.github/workflows/command-playwright-update.yml
+++ b/.github/workflows/command-playwright-update.yml
@@ -69,7 +69,7 @@ jobs:
         if: ${{ needs.init.outputs.arg1 != 'fixup' && needs.init.outputs.arg1 != 'amend' }}
         run: |
           git add .
-          git commit --signoff -m 'Updating l10n asset'
+          git commit --signoff -m 'test: update playwright snapshots'
           git push origin ${{ needs.init.outputs.head_ref }}
 
       - name: Commit and push fixup


### PR DESCRIPTION
### ☑️ Resolves

- Adjust our CI commands to use conventional commits

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
