### PR TITLE
fix(NcSelectUsers): add missing `search` event

### DIFF
--- a/src/components/NcSelectUsers/NcSelectUsers.vue
+++ b/src/components/NcSelectUsers/NcSelectUsers.vue
@@ -165,7 +165,7 @@ export default {
 </docs>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 import NcListItemIcon from '../NcListItemIcon/index.js'
 import NcSelect from '../NcSelect/index.js'
@@ -303,7 +303,17 @@ defineProps<{
  * The `v-model` directive may be used for two-way data binding.
  */
 defineModel<IUserData>('modelValue')
+
+const emit = defineEmits<{
+	/**
+	 * Emitted when the user enters some query.
+	 * This can be used to asynchronously fetch more options.
+	 */
+	search: [string]
+}>()
+
 const search = ref('')
+watch(search, () => emit('search', search.value))
 
 // Avatar size so the component has the same size as Nc*Field
 const clickableArea = Number.parseInt(window.getComputedStyle(document.body).getPropertyValue('--default-clickable-area'))
@@ -314,6 +324,7 @@ const avatarSize = clickableArea - 2 * gridBaseLine
  * Filter function to search users.
  *
  * @param option - The option to check
+ * @param option.subname - The second line to check (often the email address)
  * @param label - The label of the option
  * @param search - The current search string
  */

--- a/tests/unit/components/NcInputField/NcInputField.spec.ts
+++ b/tests/unit/components/NcInputField/NcInputField.spec.ts
@@ -6,7 +6,7 @@
 import { shallowMount } from '@vue/test-utils'
 import NcInputField from '../../../../src/components/NcInputField/index.js'
 
-import { describe, expect, it} from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 describe('NcInputField', () => {
 	it('should emit text when type is text', async () => {

--- a/tests/unit/components/NcSelectUsers/search-event.spec.ts
+++ b/tests/unit/components/NcSelectUsers/search-event.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { expect, it } from 'vitest'
+import NcSelectUsers from '../../../../src/components/NcSelectUsers/NcSelectUsers.vue'
+
+it('emits the search event', async () => {
+	const vm = mount(NcSelectUsers, {
+		props: {
+			ariaLabelCombobox: 'Search users',
+			options: [],
+		},
+	})
+
+	await vm.get('input[type="search"]').setValue('query')
+	expect(vm.emitted('search')).toEqual([['query']])
+})
+
+it('also emits the search event if cleared', async () => {
+	const vm = mount(NcSelectUsers, {
+		props: {
+			ariaLabelCombobox: 'Search users',
+			options: [],
+		},
+	})
+
+	await vm.get('input[type="search"]').setValue('query')
+	await vm.get('input[type="search"]').setValue('')
+	expect(vm.emitted('search')).toEqual([['query'], ['']])
+})


### PR DESCRIPTION
### ☑️ Resolves

The `search` event is commonly used to search for more users instead of preload all.
So we need to add this event as well.

Reported by @Chartman123 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
