### PR TITLE
refactor(NcChip): properly document and type slots and emits

### DIFF
--- a/src/components/NcChip/NcChip.vue
+++ b/src/components/NcChip/NcChip.vue
@@ -77,7 +77,6 @@ export default {
 			'nc-chip--no-icon': !hasIcon(),
 		}">
 		<span v-if="hasIcon()" class="nc-chip__icon">
-			<!-- @slot The icon slot can be used to set the chip icon. Make sure that the icon is not exceeding a height of `24px`. For round icons a exact size of `24px` is recommended. -->
 			<slot name="icon">
 				<!-- The default icon wrapper uses a size of 18px to ensure the icon is not clipped by the round chip style -->
 				<NcIconSvgWrapper v-if="iconPath || iconSvg"
@@ -88,7 +87,6 @@ export default {
 			</slot>
 		</span>
 		<span class="nc-chip__text">
-			<!-- @slot The default slot can be used to set the text that is shown -->
 			<slot>{{ text }}</slot>
 		</span>
 		<NcActions v-if="canClose || hasActions()"
@@ -97,23 +95,23 @@ export default {
 			variant="tertiary-no-background">
 			<NcActionButton v-if="canClose"
 				close-after-click
-				@click="onClose">
+				@click="emit('close')">
 				<template #icon>
 					<NcIconSvgWrapper :path="mdiClose" :size="20" />
 				</template>
 				{{ ariaLabelClose }}
 			</NcActionButton>
-			<!-- @slot The actions slot can be used to add custom actions to the chips actions -->
 			<slot name="actions" />
 		</NcActions>
 	</div>
 </template>
 
 <script setup lang="ts">
-import { mdiClose } from '@mdi/js'
-import { computed, useSlots } from 'vue'
-import { t } from '../../l10n.js'
+import type { Slot } from 'vue'
 
+import { mdiClose } from '@mdi/js'
+import { computed } from 'vue'
+import { t } from '../../l10n.js'
 import NcActions from '../NcActions/NcActions.vue'
 import NcActionButton from '../NcActionButton/NcActionButton.vue'
 import NcIconSvgWrapper from '../NcIconSvgWrapper/NcIconSvgWrapper.vue'
@@ -162,22 +160,35 @@ const props = withDefaults(defineProps<{
 	variant: 'secondary',
 })
 
-const emit = defineEmits(['close'])
-const slots = useSlots()
+const emit = defineEmits<{
+	/**
+	 * Emitted when the close button is clicked
+	 */
+	close: []
+}>()
+
+const slots = defineSlots<{
+	/**
+	 * The actions slot can be used to add custom actions (`NcAction*`) to the chips actions.
+	 */
+	actions: Slot
+
+	/**
+	 * The default slot can be used to set the text that is shown.
+	 */
+	default: Slot
+
+	/**
+	 * The icon slot can be used to set the chip icon.
+	 * Make sure that the icon is not exceeding a height of `--chip-size`.
+	 * For round icons a exact size of `var(--chip-size)` is recommended.
+	 */
+	icon: Slot
+}>()
 
 const canClose = computed(() => !props.noClose)
 const hasActions = () => Boolean(slots.actions?.())
 const hasIcon = () => Boolean(props.iconPath || props.iconSvg || !!slots.icon?.())
-
-/**
- * Handle closing the chip (pressing the X-button)
- */
-function onClose() {
-	/**
-	 * Emitted when the close button is clicked
-	 */
-	emit('close')
-}
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
### ☑️ Resolves

* split from #6133  
* related to #841 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
