### PR TITLE
feat(NcChip): allow to define the actions container

### DIFF
--- a/src/components/NcChip/NcChip.vue
+++ b/src/components/NcChip/NcChip.vue
@@ -91,6 +91,7 @@ export default {
 		</span>
 		<NcActions v-if="canClose || hasActions()"
 			class="nc-chip__actions"
+			:container="actionsContainer"
 			:force-menu="!canClose"
 			variant="tertiary-no-background">
 			<NcActionButton v-if="canClose"
@@ -124,6 +125,11 @@ const props = withDefaults(defineProps<{
 	ariaLabelClose?: string
 
 	/**
+	 * Container for the actions
+	 */
+	actionsContainer?: string
+
+	/**
 	 * Main text of the chip.
 	 */
 	text?: string
@@ -154,6 +160,7 @@ const props = withDefaults(defineProps<{
 	variant: 'primary' | 'secondary' | 'tertiary'
 }>(), {
 	ariaLabelClose: t('Close'),
+	actionsContainer: 'body',
 	iconPath: undefined,
 	iconSvg: undefined,
 	text: '',


### PR DESCRIPTION
### ☑️ Resolves

- split from #6133 

If the component is used within a container this allow to also limit the actions popover to that container.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
