### PR TITLE
chore: adjust vite plugin for vue `<docs>`

### DIFF
--- a/build/docs-plugin.ts
+++ b/build/docs-plugin.ts
@@ -1,0 +1,23 @@
+/*!
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ */
+import type { Plugin } from 'vite'
+
+/**
+ * Plugin for stripping out <docs> sections from vue files
+ */
+const vueDocsPlugin: Plugin = {
+	name: 'vue-docs-plugin',
+	transform(code, id) {
+		if (!/vue&type=doc/.test(id)) {
+			return
+		}
+		return {
+			code: 'export default ""',
+			map: { mappings: '' },
+		}
+	},
+}
+
+export default vueDocsPlugin

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -65,7 +65,7 @@ export default defineConfig({
 				// We do have some dependencies that use node modules -> we need to polyfill
 				(await import('vite-plugin-node-polyfills')).nodePolyfills(),
 				// We need to strip off the docs sections for the vue plugin
-				(await import('./vite.config.ts')).vueDocsPlugin,
+				(await import('./build/docs-plugin.ts')).default,
 			],
 			define: {
 				appName: '"exampleApp"',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-import type { Plugin, UserConfigFn } from 'vite'
+import type { UserConfigFn } from 'vite'
 import { createLibConfig } from '@nextcloud/vite-config'
 import { globSync } from 'glob'
+import crypto from 'node:crypto'
 import { join, resolve } from 'node:path'
 import { defineConfig } from 'vite'
 
-import crypto from 'node:crypto'
+import vueDocsPlugin from './build/docs-plugin'
 import l10nPlugin from './build/l10n-plugin.mjs'
 
 const appVersion = JSON.stringify(process.env.npm_package_version || 'nextcloud-vue')
@@ -28,17 +29,6 @@ const entryPoints = {
 		}, {}),
 
 	index: resolve(import.meta.dirname, 'src/index.ts'),
-}
-
-// Plugin for stripping out <docs> sections from vue files
-export const vueDocsPlugin: Plugin = {
-	name: 'vue-docs-plugin',
-	transform(code, id) {
-		if (!/vue&type=doc/.test(id)) {
-			return
-		}
-		return 'export default ""'
-	},
 }
 
 // Customizations for the vite config

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ import crypto from 'node:crypto'
 import { join, resolve } from 'node:path'
 import { defineConfig } from 'vite'
 
-import vueDocsPlugin from './build/docs-plugin'
+import vueDocsPlugin from './build/docs-plugin.ts'
 import l10nPlugin from './build/l10n-plugin.mjs'
 
 const appVersion = JSON.stringify(process.env.npm_package_version || 'nextcloud-vue')


### PR DESCRIPTION
### ☑️ Resolves

Explicitly do not generate source maps to prevent warnings about missing souremaps. This especially happens when running Playwright tests.

Not a big problem as the docs are not used, but at least we get rid of those warnings in the logs.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
