### PR TITLE
fix(NcAvatar): do not load avatar from server, if iconClass was provided

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -706,7 +706,7 @@ export default {
 			this.isAvatarLoaded = false
 
 			/** Only run avatar image loading if either user or url property is defined */
-			if (!this.isUrlDefined && (!this.isUserDefined || this.isNoUser)) {
+			if (!this.isUrlDefined && (!this.isUserDefined || this.isNoUser || this.iconClass)) {
 				this.isAvatarLoaded = true
 				this.userDoesNotExist = true
 				return

--- a/tests/unit/components/NcAvatar/NcAvatar.spec.ts
+++ b/tests/unit/components/NcAvatar/NcAvatar.spec.ts
@@ -4,8 +4,8 @@
  */
 
 import { mount, shallowMount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
-import { nextTick } from 'vue'
+import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest'
+import { h, nextTick } from 'vue'
 import NcAvatar from '../../../../src/components/NcAvatar/NcAvatar.vue'
 
 describe('NcAvatar.vue', () => {
@@ -113,6 +113,109 @@ describe('NcAvatar.vue', () => {
 			})
 			await nextTick()
 			expect(wrapper.text()).toBe(initials)
+		})
+	})
+
+	describe('Icon and image rendering', () => {
+		// Mock the Image constructor
+		let originalImage
+
+		beforeAll(() => {
+			originalImage = global.Image
+			global.Image = vi.fn(() => ({
+				onload: null,
+				onerror: null,
+				_src: '',
+				get src() {
+					return this._src
+				},
+				set src(value) {
+					this._src = value
+					this.onload?.() // Trigger the onload event
+				},
+			}))
+		})
+
+		afterAll(() => {
+			global.Image = originalImage
+		})
+
+		it('should render image with avatar url pointing to a user', async () => {
+			const wrapper = mount(NcAvatar, {
+				props: {
+					displayName: 'Guest',
+					user: 'user1',
+				},
+			})
+			await nextTick()
+
+			expect(wrapper.find('img').exists()).toBeTruthy()
+			expect(wrapper.find('img').attributes('src')).toMatch(/avatar\/user1\/64$/)
+		})
+
+		it('should render image with avatar url pointing to a user', async () => {
+			const avatarUrl = 'https://cloud.ltd/index.php/avatar/user2/512'
+
+			const wrapper = mount(NcAvatar, {
+				props: {
+					displayName: 'Guest',
+					url: avatarUrl,
+				},
+			})
+			await nextTick()
+
+			expect(wrapper.find('img').exists()).toBeTruthy()
+			expect(wrapper.find('img').attributes('src')).toBe(avatarUrl)
+		})
+
+		it('should not render image with avatar url if icon slot is populated', async () => {
+			const wrapper = mount(NcAvatar, {
+				props: {
+					displayName: 'User',
+					user: 'userid',
+				},
+				slots: {
+					icon: h('span', { class: 'slot-scoped-icon' }, [])
+				}
+			})
+
+			expect(wrapper.find('img').exists()).toBeFalsy()
+			expect(wrapper.find('span.slot-scoped-icon').exists()).toBeTruthy()
+		})
+
+		it('should not render image with avatar url if iconClass is provided', async () => {
+			const wrapper = mount(NcAvatar, {
+				props: {
+					displayName: 'User',
+					user: 'userid',
+					iconClass: 'custom-icon-class',
+				},
+			})
+
+			expect(wrapper.find('img').exists()).toBeFalsy()
+			expect(wrapper.find('span.avatar-class-icon.custom-icon-class').exists()).toBeTruthy()
+		})
+
+		it('should not render image with avatar url if not a user', async () => {
+			const wrapper = mount(NcAvatar, {
+				props: {
+					displayName: 'Guest',
+					user: 'guest/abcdef',
+					isNoUser: true,
+				},
+			})
+
+			expect(wrapper.find('img').exists()).toBeFalsy()
+		})
+
+		it('should not render image with avatar url if user id is not provided', async () => {
+			const wrapper = mount(NcAvatar, {
+				props: {
+					displayName: 'Empty',
+				},
+			})
+
+			expect(wrapper.find('img').exists()).toBeFalsy()
 		})
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

- Fix loading of faulty avatars (for non-users) from NcUserBubble

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="777" alt="image" src="https://github.com/user-attachments/assets/9c4b4349-bd57-4f6c-88b1-e5bf48f02d85" /> | <img width="777" alt="image" src="https://github.com/user-attachments/assets/37d22b7e-646b-4cf0-b3aa-594e8ae522c7" />

### 🚧 Tasks

- [ ] do we need explicit `is-no-user` prop at NcUserBubble for such cases?

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
