### PR TITLE
fix(NcMentionBubble): position selectable text aligned with the component

### DIFF
--- a/src/components/NcRichContenteditable/NcMentionBubble.vue
+++ b/src/components/NcRichContenteditable/NcMentionBubble.vue
@@ -105,6 +105,7 @@ $bubble-avatar-size: $bubble-height - 2 * $bubble-padding;
 	}
 
 	&__wrapper {
+		position: relative;
 		max-width: $bubble-max-width;
 		// Align with text
 		height: $bubble-height - $bubble-padding;
@@ -118,10 +119,10 @@ $bubble-avatar-size: $bubble-height - 2 * $bubble-padding;
 		overflow: hidden;
 		align-items: center;
 		max-width: 100%;
-		height: $bubble-height ;
+		height: $bubble-height;
 		-webkit-user-select: none;
 		user-select: none;
-		padding-inline: $bubble-padding  $bubble-padding * 3;
+		padding-inline: $bubble-padding $bubble-padding * 3;
 		border-radius: math.div($bubble-height, 2);
 		background-color: var(--color-background-dark);
 	}


### PR DESCRIPTION
### ☑️ Resolves

- Fix subelements positioning
  - Even if it's off the viewport, should be in line with wrapper
- To reproduce:
  - have scrollable chat and new message form in Talk
  - use autocomplete with `@` to mention someone
  - hit `Enter`
  - see third scrollbar

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A
<img width="585" alt="2025-04-24_10h25_01" src="https://github.com/user-attachments/assets/562e8a37-9155-47aa-9f10-dd6964d49feb" /> | <img width="581" alt="2025-04-24_10h27_29" src="https://github.com/user-attachments/assets/9ebf3314-188a-4765-b4a6-88fbb095cfd5" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
