### PR TITLE
fix(NcIconSvgWrapper): center svg span wrapper

### DIFF
--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -287,9 +287,7 @@ export default {
 
 	// Icon svg wrapper
 	span {
-		display: flex;
-		justify-content: center;
-		align-items: center;
+		line-height: 0;
 	}
 
 	&:deep(svg) {

--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -285,6 +285,13 @@ export default {
 		vertical-align: text-bottom;
 	}
 
+	// Icon svg wrapper
+	span {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
 	&:deep(svg) {
 		fill: currentColor;
 		width: v-bind('iconSize');


### PR DESCRIPTION
Parent is flex, but not the intermediate span
See the folder icon:

### Before
![2025-05-02_08-48_1](https://github.com/user-attachments/assets/07451b9e-882b-425a-a5e7-734b4dbb5c5c)
### After
![2025-05-02_08-48](https://github.com/user-attachments/assets/48443319-b7fa-413e-934f-c360a006938d)
