### PR TITLE
chore: move from `dev:watch` to `watch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "vite build --mode production ",
     "dev": "vite build --mode development",
-    "dev:watch": "vite build --mode development --watch",
+    "watch": "vite build --mode development --watch",
     "l10n:extract": "node build/extract-l10n.mjs",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",


### PR DESCRIPTION
So, we use `watch` everywhere, literally for over 7 years.
I see some repos that are slowly usig this new `dev:watch` syntax. Can we please stick to the one we used for years ? :see_no_evil: 

- https://github.com/nextcloud-libraries/nextcloud-vue/blob/f27d675871a16916e944cfbb5e1af196fd26524b/package.json#L17
- https://github.com/nextcloud/server/blob/2e7cbc5e1b5caed31cef9fc39c3dbc838478e03a/package.json#L13