### PR TITLE
fix(NcChip): do not rerender slots to check if they are available

### DIFF
--- a/src/components/NcChip/NcChip.vue
+++ b/src/components/NcChip/NcChip.vue
@@ -171,24 +171,24 @@ const slots = defineSlots<{
 	/**
 	 * The actions slot can be used to add custom actions (`NcAction*`) to the chips actions.
 	 */
-	actions: Slot
+	actions?: Slot
 
 	/**
 	 * The default slot can be used to set the text that is shown.
 	 */
-	default: Slot
+	default?: Slot
 
 	/**
 	 * The icon slot can be used to set the chip icon.
 	 * Make sure that the icon is not exceeding a height of `--chip-size`.
 	 * For round icons a exact size of `var(--chip-size)` is recommended.
 	 */
-	icon: Slot
+	icon?: Slot
 }>()
 
 const canClose = computed(() => !props.noClose)
-const hasActions = () => Boolean(slots.actions?.())
-const hasIcon = () => Boolean(props.iconPath || props.iconSvg || !!slots.icon?.())
+const hasActions = () => !!slots.actions
+const hasIcon = () => Boolean(props.iconPath || props.iconSvg || !!slots.icon)
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/pull/6812/files#r2082255104

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
