### PR TITLE
fix(dialog/spawnDialog): incorrect return type for optional result

### DIFF
--- a/src/functions/dialog/index.ts
+++ b/src/functions/dialog/index.ts
@@ -15,11 +15,17 @@ type DialogComponent<T extends Component> = 'onClose' extends keyof ComponentPro
 	? T
 	: 'Please provide a Dialog Component that supports `@close` event'
 
+/**
+ * Event payload array normalized to a single value when payload has only one argument,
+ * including one optional argument
+ */
 type NormalizedPayload<T> = T extends []
 	? void
 	: T extends [infer F]
 		? F
-		: T
+		: T extends { length: 0 | 1, 0?: infer F }
+			? F | undefined
+			: T
 
 type ClosePayload<T> = T extends { onClose?: (...args: infer P) => any }
 	? P


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud-libraries/nextcloud-vue/issues/6902
- Looks dirty, but I didn't find a better solution

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
