### PR TITLE
feat(NcActionButton): introduce `description` prop

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -110,7 +110,7 @@
 			overflow: hidden;
 			white-space: nowrap;
 			max-width: 100%;
-			display: inline-block;
+			display: block;
 		}
 
 		&__menu-icon {

--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -113,6 +113,15 @@
 			display: block;
 		}
 
+		&__description {
+			display: block;
+			white-space: pre-wrap;
+			font-size: var(--font-size-small);
+			line-height: var(--default-line-height);
+			color: var(--color-text-maxcontrast);
+			cursor: pointer;
+		}
+
 		&__menu-icon {
 			margin-inline: auto calc($icon-margin * -1);
 		}

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -53,7 +53,9 @@ This component is made to be used inside of the [NcActions](#NcActions) componen
 	</script>
 ```
 
-If you're using a long text you can specify a name
+If you're using a long text, you can specify a `name` prop.
+
+For the same purpose, but in a more compact way, `description` prop can be used.
 
 ```vue
 	<template>
@@ -70,15 +72,23 @@ If you're using a long text you can specify a name
 				</template>
 				This button is associated with a very long text.\nAnd with new lines too.
 			</NcActionButton>
+			<NcActionButton description="Subline description for the button" @click="showMessage('Edit')">
+				<template #icon>
+					<Pencil :size="20" />
+				</template>
+				Edit
+			</NcActionButton>
 		</NcActions>
 	</template>
 	<script>
 	import Delete from 'vue-material-design-icons/Delete.vue'
+	import Pencil from 'vue-material-design-icons/Pencil.vue'
 	import Plus from 'vue-material-design-icons/Plus.vue'
 
 	export default {
 		components: {
 			Delete,
+			Pencil,
 			Plus,
 		},
 		methods: {
@@ -348,6 +358,9 @@ export default {
 					class="action-button__text">
 					{{ text }}
 				</span>
+				<span v-if="description"
+					class="action-button__description"
+					v-text="description" />
 			</span>
 
 			<!-- right(in LTR) or left(in RTL) arrow icon when there is a sub-menu -->
@@ -443,6 +456,14 @@ export default {
 		value: {
 			type: String,
 			default: null,
+		},
+
+		/**
+		 * Small underlying text content of the entry
+		 */
+		description: {
+			type: String,
+			default: '',
 		},
 	},
 

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -333,26 +333,22 @@ export default {
 			</slot>
 
 			<!-- long text with name -->
-			<span v-if="name"
-				class="action-button__longtext-wrapper">
-				<strong class="action-button__name">
+			<span class="action-button__longtext-wrapper">
+				<strong v-if="name"
+					class="action-button__name">
 					{{ name }}
 				</strong>
-				<br>
 				<!-- white space is shown on longtext, so we can't
 					put {{ text }} on a new line for code readability -->
-				<span class="action-button__longtext" v-text="text" />
+				<span v-if="isLongText"
+					class="action-button__longtext"
+					v-text="text" />
+				<!-- default text display -->
+				<span v-else
+					class="action-button__text">
+					{{ text }}
+				</span>
 			</span>
-
-			<!-- long text only -->
-			<!-- white space is shown on longtext, so we can't
-				put {{ text }} on a new line for code readability -->
-			<span v-else-if="isLongText"
-				class="action-button__longtext"
-				v-text="text" />
-
-			<!-- default text display -->
-			<span v-else class="action-button__text">{{ text }}</span>
 
 			<!-- right(in LTR) or left(in RTL) arrow icon when there is a sub-menu -->
 			<ChevronRightIcon v-if="isMenu && !isRtl" :size="20" class="action-button__menu-icon" />


### PR DESCRIPTION
### ☑️ Resolves

- There might be a need to use a button as 'action name' + 'description'
- Current solution: `name` prop + `default` slot is a bit bulky
- Alternative with this PR:  `default` slot + `subline` prop

### 🖼️ Screenshots

Documentation screenshot:
<img width="408" alt="image" src="https://github.com/user-attachments/assets/de86df2d-5fff-4bf0-af18-526a3e28467c" />

Same content comparison:
<img width="172" alt="image" src="https://github.com/user-attachments/assets/1b3c3705-b84a-4d69-bc98-d2b3ece4ea83" />

### 🚧 Tasks

- [ ] First commit: check if it's non-breaking

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
