### PR TITLE
fix(NcEmptyContent): description styling for mobile

### DIFF
--- a/src/components/NcEmptyContent/NcEmptyContent.vue
+++ b/src/components/NcEmptyContent/NcEmptyContent.vue
@@ -232,6 +232,8 @@ defineSlots<{
 
 	&__description {
 		color: var(--color-text-maxcontrast);
+		text-align: center;
+		text-wrap-style: balance;
 	}
 
 	&__action {


### PR DESCRIPTION
Signed-off-by: Radek Pleskac <info@radekpleskac.com>

### ☑️ Resolves

- Fix https://github.com/nextcloud/server/issues/39398
- NcEmptyContent is a generic component used in multiple places, would like to verify more such places and also a couple diff languages, short and long ones, hence draft PR initially.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="360" alt="Screenshot 2025-05-20 at 11 27 13" src="https://github.com/user-attachments/assets/478e32e0-ccf5-4cd4-ac75-4e14fa06129a" /> | <img width="359" alt="Screenshot 2025-05-20 at 11 20 34" src="https://github.com/user-attachments/assets/cca90351-2cc4-4060-bbd4-a52e3def1950" />

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
