### PR TITLE
style(NcAppSidebar): remove custom styles from close button

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -1318,14 +1318,6 @@ $top-buttons-spacing: $app-navigation-padding; // align with app navigation
 			inset-inline-end: $top-buttons-spacing;
 			width: var(--default-clickable-area);
 			height: var(--default-clickable-area);
-			opacity: $opacity_normal;
-			border-radius: calc(var(--default-clickable-area) / 2);
-			&:hover,
-			&:active,
-			&:focus {
-				opacity: $opacity_full;
-				background-color: $action-background-hover;
-			}
 		}
 
 		// Compact mode only affects a sidebar with a figure


### PR DESCRIPTION
### ☑️ Resolves

- Clean custom opacity, hover styles and radius from 'Close' button in NcAppSidebar

Variable | Radius
-- | --
var(--button-radius) | 8px
`+` | `+`
$top-buttons-spacing | 8px
`=` | `=`
var(--body-container-radius) | 16px

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A
![2025-05-23_10h46_03](https://github.com/user-attachments/assets/74355aed-d46e-4369-b48f-3c582b310266) | ![2025-05-23_10h47_37](https://github.com/user-attachments/assets/a54af03c-b33a-42a8-b40b-142d64786ac0)
![2025-05-23_10h46_15](https://github.com/user-attachments/assets/388d7802-509b-48b5-99b6-909f05dc3fb4) | ![2025-05-23_10h47_48](https://github.com/user-attachments/assets/b5b538f1-3b89-46fa-ade4-bf70e901972b)


### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
