### PR TITLE
fix(NcAppContent): adapt to new emitted event object with splitpanes ^4.0.0

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -405,7 +405,7 @@ export default {
 		},
 
 		handlePaneResize(event) {
-			const listPaneSize = parseInt(event[0].size, 10)
+			const listPaneSize = parseInt(event.panes[0].size, 10)
 			browserStorage.setItem(this.paneConfigID, JSON.stringify(listPaneSize))
 			this.listPaneSize = listPaneSize
 			/**


### PR DESCRIPTION
### ☑️ Resolves

- Fix #6931

From [Splitpanes Release Notes](https://antoniandre.github.io/splitpanes/#release-notes)

Version 4.0.0
> Refactored all the emitted events to always return a single object containing as much information as possible. E.g. event, index, pane, prevPane, nextPane, panes. 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
