### PR TITLE
test: drop useless console output

### DIFF
--- a/tests/unit/functions/usernameToColor/usernameToColor.spec.ts
+++ b/tests/unit/functions/usernameToColor/usernameToColor.spec.ts
@@ -40,7 +40,6 @@ describe('usernameToColor', () => {
 		'Private Circle',
 	])('%s has the proper color', (name: string) => {
 		const color = usernameToColor(name)
-		console.error(color)
 		expect(rgbToHex(color)).toMatchSnapshot()
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

this just spams the test output.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
