### PR TITLE
chore: remove deprecated `aria-hidden` prop from `NcAction*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ Especially the following are now provided as composables:
 The `richEditing` mixin can be replaced by just using the `NcRichText` component.
 
 #### Other breaking changes
+- `NcActions` and `NcAction*`
+  - The `ariaHidden` property is removed, please do no longer provide it, otherwise the root element will inherit incorrect aria-hidden.
 - `NcAppSidebar`
   - The `closing` and `opening` events were removed.
     They are directly emitted when the sidebar was opened when using `v-if`

--- a/src/components/NcActionButton/NcActionButton.vue
+++ b/src/components/NcActionButton/NcActionButton.vue
@@ -397,16 +397,6 @@ export default {
 
 	props: {
 		/**
-		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
-		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
-		 * otherwise root element will inherit incorrect aria-hidden.
-		 */
-		ariaHidden: {
-			type: Boolean,
-			default: null,
-		},
-
-		/**
 		 * disabled state of the action button
 		 */
 		disabled: {

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -354,15 +354,6 @@ export default {
 			default: '',
 		},
 		/**
-		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
-		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
-		 * otherwise root element will inherit incorrect aria-hidden.
-		 */
-		ariaHidden: {
-			type: Boolean,
-			default: null,
-		},
-		/**
 		 * Attribute forwarded to the underlying NcPasswordField and NcTextField
 		 */
 		showTrailingButton: {

--- a/src/components/NcActionLink/NcActionLink.vue
+++ b/src/components/NcActionLink/NcActionLink.vue
@@ -164,15 +164,6 @@ export default {
 			type: String,
 			default: null,
 		},
-		/**
-		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
-		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
-		 * otherwise root element will inherit incorrect aria-hidden.
-		 */
-		ariaHidden: {
-			type: Boolean,
-			default: null,
-		},
 	},
 }
 </script>

--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1039,16 +1039,6 @@ export default {
 		},
 
 		/**
-		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
-		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
-		 * otherwise root element will inherit incorrect aria-hidden.
-		 */
-		ariaHidden: {
-			type: Boolean,
-			default: null,
-		},
-
-		/**
 		 * Wanted direction of the menu
 		 */
 		placement: {
@@ -1260,6 +1250,10 @@ export default {
 		useTrapStackControl(() => this.opened, {
 			disabled: () => this.config.withFocusTrap,
 		})
+
+		if ('ariaHidden' in this.$attrs) {
+			warn('[NcActions]: Do not set the ariaHidden attribute as the root element will inherit the incorrect aria-hidden.')
+		}
 	},
 
 	methods: {

--- a/src/mixins/actionText.js
+++ b/src/mixins/actionText.js
@@ -5,6 +5,7 @@
 
 import actionGlobal from './actionGlobal.js'
 import { NC_ACTIONS_CLOSE_MENU } from '../components/NcActions/useNcActions.ts'
+import { warn } from 'vue'
 
 export default {
 	mixins: [actionGlobal],
@@ -44,15 +45,6 @@ export default {
 			type: String,
 			default: null,
 		},
-		/**
-		 * @deprecated To be removed in @nextcloud/vue 9. Migration guide: remove ariaHidden prop from NcAction* components.
-		 * @todo Add a check in @nextcloud/vue 9 that this prop is not provided,
-		 * otherwise root element will inherit incorrect aria-hidden.
-		 */
-		ariaHidden: {
-			type: Boolean,
-			default: null,
-		},
 	},
 
 	inject: {
@@ -64,6 +56,12 @@ export default {
 	emits: [
 		'click',
 	],
+
+	created() {
+		if ('ariaHidden' in this.$attrs) {
+			warn('[NcAction*]: Do not set the ariaHidden attribute as the root element will inherit the incorrect aria-hidden.')
+		}
+	},
 
 	computed: {
 		/**


### PR DESCRIPTION
### ☑️ Resolves
> To be removed in @nextcloud/vue 9.


This was deprecated in v8 and we should remove with v9.
Also added the check as written in the TODO.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
