### PR TITLE
chore!(NcRichContenteditable): remove `title` prop in favor of `label`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
   - The `limitWidth` was removed (the content is now always limited width) [\#5605](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5605)
 - The `isFullscreen`, and `isMobile` mixins were removed. Use the according composables instead.
 - The `clickOutsideOptions` mixin is removed
-- The `box-sizing: border-box` is now default for following components and its content. This is done to match behaviour of `NcContent` (as they can be mounted directly to `body`):
+- The `box-sizing: border-box` is now default for following components and its content. This is done to match behavior of `NcContent` (as they can be mounted directly to `body`):
   - `NcModal`
   - `NcPopover`
 - `NcDateTimePicker`
@@ -146,6 +146,9 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
 - `NcPopover` is no longer a transparent wrapper over the `floating-vue` package.
   Instead only use the documented properties and events.
   If you find some use cases not covered by the documented interface, please open a feature request.
+- `NcRichContenteditable`
+  - `NcAutoCompleteResult`: The `title` prop was deprecated and is now removed in favor of the `label` prop
+  - `NcMentionBubble`: The `title` prop was deprecated and is now removed in favor of the `label` prop
 - `NcSelect`
   - `userSelect` property was removed, instead just use the `NcSelectUsers` component
   - `closeOnSelect` property was removed in favor of `keepOpen`.

--- a/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
+++ b/src/components/NcRichContenteditable/NcAutoCompleteResult.vue
@@ -20,8 +20,8 @@
 
 		<!-- Label and subline -->
 		<span class="autocomplete-result__content">
-			<span class="autocomplete-result__title" :title="labelWithFallback">
-				{{ labelWithFallback }}
+			<span class="autocomplete-result__title" :title="label">
+				{{ label }}
 			</span>
 			<span v-if="subline" class="autocomplete-result__subline">
 				{{ subline }}
@@ -43,14 +43,6 @@ export default {
 	},
 
 	props: {
-		/**
-		 * @deprecated Use `label` instead
-		 */
-		title: {
-			type: String,
-			required: false,
-			default: null,
-		},
 		label: {
 			type: String,
 			required: false,
@@ -90,10 +82,6 @@ export default {
 			return this.id && this.source === 'users'
 				? this.getAvatarUrl(this.id, 44)
 				: null
-		},
-		// For backwards compatibility
-		labelWithFallback() {
-			return this.label || this.title
 		},
 	},
 

--- a/src/components/NcRichContenteditable/NcMentionBubble.vue
+++ b/src/components/NcRichContenteditable/NcMentionBubble.vue
@@ -15,7 +15,7 @@
 					class="mention-bubble__icon" />
 
 				<!-- Title -->
-				<span role="heading" class="mention-bubble__title" :title="labelWithFallback" />
+				<span role="heading" class="mention-bubble__title" :title="label" />
 			</span>
 
 			<!-- Selectable text for copy/paste -->
@@ -34,14 +34,6 @@ export default {
 		id: {
 			type: String,
 			required: true,
-		},
-		/**
-		 * @deprecated Use `label` instead
-		 */
-		title: {
-			type: String,
-			required: false,
-			default: null,
 		},
 		label: {
 			type: String,
@@ -79,10 +71,6 @@ export default {
 			return !this.id.includes(' ') && !this.id.includes('/')
 				? `@${this.id}`
 				: `@"${this.id}"`
-		},
-		// Fallback to title for compatibility
-		labelWithFallback() {
-			return this.label || this.title
 		},
 	},
 


### PR DESCRIPTION
### ☑️ Resolves
Was deprecated in v8 and need to be removed in v9. Affects:
- `NcAutoCompleteResult`
- `NcMentionBubble`

title only was added by accident, the backend provides `label` so only semantically breaking, but should not affect users.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
