### PR TITLE
chore: remove `todo` from NcSelect

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -577,8 +577,6 @@ export default {
 
 		/**
 		 * Visible label for the input element
-		 *
-		 * @todo Set default for @nextcloud/vue 9
 		 */
 		inputLabel: {
 			type: String,


### PR DESCRIPTION
### ☑️ Resolves

Going through our TODOs I noticed this stale TODO.
It makes no sense to provide a default as the label to be used varies to much depending on the use case. Its better to let the developer decide.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
