### PR TITLE
fix(NcRichText): filter links based on protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "remark-breaks": "^4.0.0",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.1",
+        "remark-unlink-protocols": "^1.0.0",
         "splitpanes": "^4.0.3",
         "striptags": "^3.2.0",
         "tabbable": "^6.2.0",
@@ -15579,6 +15580,20 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/mdast-squeeze-paragraphs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-6.0.0.tgz",
+      "integrity": "sha512-6NDbJPTg0M0Ye+TlYwX1KJ1LFbp515P2immRJyJQhc9Na9cetHzSoHNYIQcXpANEAP1sm9yd/CTZU2uHqR5A+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
@@ -19987,6 +20002,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-unlink-protocols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-unlink-protocols/-/remark-unlink-protocols-1.0.0.tgz",
+      "integrity": "sha512-5j/F28jhFmxeyz8nuJYYIWdR4nNpKWZ8A+tVwnK/0pq7Rjue33CINEYSckSq2PZvedhKUwbn08qyiuGoPLBung==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-squeeze-paragraphs": "^6.0.0",
+        "unist-util-visit": "^5.0.0"
       }
     },
     "node_modules/remark/node_modules/@types/mdast": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "remark-breaks": "^4.0.0",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.1",
+    "remark-unlink-protocols": "^1.0.0",
     "splitpanes": "^4.0.3",
     "striptags": "^3.2.0",
     "tabbable": "^6.2.0",

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -309,6 +309,7 @@ import { RouterLink } from 'vue-router'
 import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
 import breaks from 'remark-breaks'
+import remarkUnlinkProtocols from 'remark-unlink-protocols'
 import remark2rehype from 'remark-rehype'
 import rehype2react from 'rehype-react'
 import rehypeExternalLinks from 'rehype-external-links'
@@ -319,6 +320,11 @@ import { getRoute, remarkAutolink } from './autolink.ts'
 import { remarkPlaceholder, prepareTextNode } from './placeholder.js'
 import { remarkUnescape } from './remarkUnescape.js'
 import { createElementId } from '../../utils/createElementId.ts'
+
+/**
+ * Protocols allowed in links.
+ */
+const LINK_PROTOCOLS = ['http', 'https', 'mailto', 'tel']
 
 /**
  * Heavy libraries should be loaded on demand to reduce component size
@@ -441,6 +447,7 @@ export default {
 				.use(remarkUnescape)
 				.use(this.useExtendedMarkdown ? remarkGfm : undefined)
 				.use(breaks)
+				.use(remarkUnlinkProtocols, { except: LINK_PROTOCOLS })
 				.use(remark2rehype, {
 					handlers: {
 						component(toHast, node) {

--- a/tests/component/components/NcRichText/markown-rendering.spec.ts
+++ b/tests/component/components/NcRichText/markown-rendering.spec.ts
@@ -419,6 +419,36 @@ test.describe('inline code', () => {
 	})
 })
 
+test.describe('links', () => {
+	const testLink = (key: string, { text, href = text, name = text }) => {
+		test(key, async ({ mount }) => {
+			const component = await mount(NcRichText, {
+				props: {
+					text,
+					useExtendedMarkdown: true,
+				},
+			})
+			await expect(component.getByRole('link', { name }))
+				.toHaveAttribute('href', href)
+		})
+	}
+	testLink('autolink', { text: 'https://autolink.me' })
+	testLink('relative link', { text: '[hello](world)', href: 'world', name: 'hello' })
+	testLink('absolute link', { text: '[hello](https://nextcloud.com)', href: 'https://nextcloud.com', name: 'hello' })
+	testLink('tel link', { text: '[hello](tel:+49123456789)', href: 'tel:+49123456789', name: 'hello' })
+
+	test('no link to unknown protocols', async ({ mount }) => {
+		const component = await mount(NcRichText, {
+			props: {
+				text: '[link](other:proto)',
+				useExtendedMarkdown: true,
+			},
+		})
+		await expect(component).toContainText('link')
+		await expect(component.getByText('link')).not.toHaveRole('link')
+	})
+})
+
 test.describe('multiline code', () => {
 	test('multiline code (with triple backticks syntax)', async ({ mount }) => {
 		const component = await mount(NcRichText, {


### PR DESCRIPTION
### ☑️ Resolves

Only allow links to specific protocols.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/b8e19c8c-9ae9-4552-8e44-82eb38c7a5a5) | ![grafik](https://github.com/user-attachments/assets/96d92a94-7012-406f-b424-ca99ccf3b8a0)


### 🏁 Checklist

- [x] ⛑️ Tests are included
- [x] 📘 Component documentation is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
