### PR TITLE
fix(NcAppNavigationToggle): restore button design and remove wrong attribute

### DIFF
--- a/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
+++ b/src/components/NcAppNavigationToggle/NcAppNavigationToggle.vue
@@ -8,9 +8,9 @@
 		<NcButton class="app-navigation-toggle"
 			aria-controls="app-navigation-vue"
 			:aria-expanded="open ? 'true' : 'false'"
-			:aria-keyshortcuts="disableKeyboardShortcuts ? '' : 'n'"
 			:aria-label="label"
 			:title="label"
+			variant="tertiary"
 			@click="toggleNavigation">
 			<template #icon>
 				<MenuOpenIcon v-if="open" :size="20" />


### PR DESCRIPTION
* Resolves https://github.com/nextcloud-libraries/nextcloud-vue/issues/6930#issuecomment-2920520832

### ☑️ Resolves

The backport to `next` was incomplete as this was a conflict of the (still) missing backport of https://github.com/nextcloud-libraries/nextcloud-vue/pull/6322

Meaning we need to restore the correct behavior and remove the shortcuts stuff until #6322 is merged.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
