### PR TITLE
fix(NcAppNavigationSettings): button left full width

### DIFF
--- a/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
+++ b/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
@@ -57,6 +57,8 @@ onClickOutside(container, () => { open.value = false }, { ignore })
 		<div :class="$style.header">
 			<NcButton :aria-controls="contentId"
 				:aria-expanded="open ? 'true' : 'false'"
+				alignment="start"
+				wide
 				@click="open = !open">
 				<template #icon>
 					<IconCog :size="20" />


### PR DESCRIPTION
### ☑️ Resolves

- Fix #6998

Unfortunately, the settings button and the navigation entries are not nicely aligned yet. But since I didn't know which one should be adjusted, I left it as it was.

Regression from #6429.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2025-06-03 at 19-44-42 Aufgaben - Nextcloud](https://github.com/user-attachments/assets/82bbb616-2735-4cd0-a647-25986ea01d7a) | ![Screenshot 2025-06-03 at 19-49-25 Aufgaben - Nextcloud](https://github.com/user-attachments/assets/18cddaa2-8a22-4324-9bd1-5086c0704ecf) 


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
