### PR TITLE
fix(NcAppContent): incorrect page title from a different `core.apps` format in Nextcloud 30

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -160,7 +160,7 @@ import 'splitpanes/dist/splitpanes.css'
 const browserStorage = getBuilder('nextcloud').persist().build()
 const { name: productName } = loadState('theming', 'data', { name: 'Nextcloud' })
 const activeApp = loadState('core', 'active-app', APP_NAME)
-const localizedAppName = loadState('core', 'apps', {})[activeApp]?.name ?? APP_NAME
+const localizedAppName = loadState('core', 'apps', []).find(app => app.id === activeApp)?.name ?? APP_NAME
 
 /**
  * App content container to be used for the main content of your app


### PR DESCRIPTION
Main issue: The `core -> apps` initial state is treated like an object in NcAppContent but [it is an array](https://github.com/nextcloud/server/blob/master/lib/private/TemplateLayout.php#L73).

So in the page title, instead of the current app's name, the `core -> active-app` initial state is used. In the case of the Files app, this value is not what we want, it's "Nextcloud" which leads to page titles like
`CURRENT_DIR - All files - Nextcloud - THEMING_INSTANCE_NAME`
instead of the expected
`CURRENT_DIR - All files - Files - THEMING_INSTANCE_NAME`

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
