### PR TITLE
fix(NcAppNavigationSettings): adjust style and padding

### DIFF
--- a/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
+++ b/src/components/NcAppNavigationSettings/NcAppNavigationSettings.vue
@@ -57,7 +57,9 @@ onClickOutside(container, () => { open.value = false }, { ignore })
 		<div :class="$style.header">
 			<NcButton :aria-controls="contentId"
 				:aria-expanded="open ? 'true' : 'false'"
+				:class="$style.button"
 				alignment="start"
+				variant="tertiary"
 				wide
 				@click="open = !open">
 				<template #icon>
@@ -88,6 +90,12 @@ onClickOutside(container, () => { open.value = false }, { ignore })
 .header {
 	margin-block: 0 var(--default-grid-baseline);
 	margin-inline: var(--default-grid-baseline);
+}
+
+/* Overwrite the padding to match NcAppNavigationItem */
+.button {
+	padding-left: 0 !important;
+	padding-inline-end: calc((var(--default-clickable-area) - 16px) / 2) !important;
 }
 
 .content {


### PR DESCRIPTION
### ☑️ Resolves

This adjusts the style of the `NcAppNavigationSettings` button to match `NcAppNavigationItem`.
Fix #7009.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2025-06-08 at 22-12-57 Aufgaben - Nextcloud](https://github.com/user-attachments/assets/dfa764a0-12ab-4f82-b70a-7cb6a54b0565) | ![Screenshot 2025-06-08 at 22-10-04 Aufgaben - Nextcloud](https://github.com/user-attachments/assets/4e85acac-93f0-42f4-8da8-e02d7d959616)
 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
