### PR TITLE
fix(NcButton): correctly apply reverse padding

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -812,7 +812,7 @@ function onClick(event: MouseEvent) {
 	&--reverse {
 		--button-padding: var(--button-padding-default) var(--default-grid-baseline);
 
-		&__wrapper {
+		#{&}__wrapper {
 			flex-direction: row-reverse;
 		}
 	}

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -809,12 +809,12 @@ function onClick(event: MouseEvent) {
 		justify-content: start;
 	}
 
+	&--reverse &__wrapper {
+		flex-direction: row-reverse;
+	}
+
 	&--reverse {
 		--button-padding: var(--button-padding-default) var(--default-grid-baseline);
-
-		#{&}__wrapper {
-			flex-direction: row-reverse;
-		}
 	}
 
 	&__icon {

--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -804,15 +804,17 @@ function onClick(event: MouseEvent) {
 	&--end &__wrapper {
 		justify-content: end;
 	}
+
 	&--start &__wrapper {
 		justify-content: start;
 	}
-	&--reverse &__wrapper {
-		flex-direction: row-reverse;
-	}
 
-	&--reverse#{&}--icon-and-text {
-		padding-inline: var(--button-padding) var(--default-grid-baseline);
+	&--reverse {
+		--button-padding: var(--button-padding-default) var(--default-grid-baseline);
+
+		&__wrapper {
+			flex-direction: row-reverse;
+		}
 	}
 
 	&__icon {


### PR DESCRIPTION
### ☑️ Resolves

- Fix #7005

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
