### PR TITLE
fix(NcButton): correctly apply reverse padding

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -804,15 +804,17 @@ function onClick(event: MouseEvent) {
 	&--end &__wrapper {
 		justify-content: end;
 	}
+
 	&--start &__wrapper {
 		justify-content: start;
 	}
+
 	&--reverse &__wrapper {
 		flex-direction: row-reverse;
 	}
 
-	&--reverse#{&}--icon-and-text {
-		padding-inline: var(--button-padding) var(--default-grid-baseline);
+	&--reverse {
+		--button-padding: var(--button-padding-default) var(--default-grid-baseline);
 	}
 
 	&__icon {


### PR DESCRIPTION
### ☑️ Resolves

This correctly applies the padding for reverse buttons.

- Fix #7005

Regression from #6033.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/41b1304d-7f71-4bd7-81ca-1c02782c88c6) | ![grafik](https://github.com/user-attachments/assets/08f9e972-c087-4cf5-9274-151e8b33c7d8)

Comparison to `stable8`:
![grafik](https://github.com/user-attachments/assets/d1078932-2c20-456f-9ca9-1dc2d1016b89)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
