### PR TITLE
[stable8] fix(NcSelectUsers): fix using of v-model in Vue 2

### DIFF
--- a/src/components/NcSelectUsers/NcSelectUsers.vue
+++ b/src/components/NcSelectUsers/NcSelectUsers.vue
@@ -361,6 +361,16 @@ function localFilterBy(option, label, search) {
 }
 </script>
 
+<script>
+/** For backward compatibility with Vue 2 */
+export default {
+	model: {
+		prop: 'modelValue',
+		event: 'update:modelValue',
+	},
+}
+</script>
+
 <template>
 	<NcSelect class="nc-select-users"
 		v-bind="$props"


### PR DESCRIPTION
### ☑️ Resolves

- Fix `v-model` usage in Vue 2 (for backward compatibility with main branch)
- Noticed while testing unreleased eslint config

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
[Try stable8--nextcloud-vue](https://stable8--nextcloud-vue-components.netlify.app/#/Components/NcSelect?id=ncselect-1) | [Try deploy-preview](https://deploy-preview-7032--nextcloud-vue-components.netlify.app/)


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
