### PR TITLE
fix(NcCheckboxRadioSwitch): align icons with the first row of label

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -205,9 +205,15 @@ export default {
 		}
 	}
 
+	&-checkbox:not(&--button-variant) &__icon,
+	&-radio:not(&--button-variant) &__icon,
+	&-switch:not(&--button-variant) &__icon {
+		margin-block: calc((var(--default-clickable-area) - 2 * var(--default-grid-baseline) - var(--icon-height)) / 2) auto;
+	}
+
 	&__icon > * {
 		width: var(--icon-size);
-		height: var(--icon-size);
+		height: var(--icon-height);
 		color: var(--color-primary-element);
 	}
 

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -19,6 +19,9 @@ Note: All generic attributes on the component, except `class` and `style`, are p
 		<NcCheckboxRadioSwitch v-model="sharingEnabled">Enable sharing</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch v-model="sharingEnabled" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch :model-value="sharingEnabled" :loading="loading" @update:model-value="onToggle">Enable sharing (with request loading)</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled">
+			Enable sharing. This can contain a long multiline text, that will be wrapped in a second row. It is generally not advised to have such long text inside of an element
+		</NcCheckboxRadioSwitch>
 		<br>
 		sharingEnabled: {{ sharingEnabled }}
 	</div>
@@ -51,6 +54,9 @@ export default {
 	<div>
 		<NcCheckboxRadioSwitch v-model="sharingPermission" value="r" name="sharing_permission_radio" type="radio">Default permission read</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch v-model="sharingPermission" value="rw" name="sharing_permission_radio" type="radio">Default permission read+write</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingPermission" value="rws" name="sharing_permission_radio" type="radio">
+			Default permission read+write+share. This can contain a long multiline text, that will be wrapped in a second row. It is generally not advised to have such long text inside of an element
+		</NcCheckboxRadioSwitch>
 		<br>
 		sharingPermission: {{ sharingPermission }}
 	</div>
@@ -224,6 +230,9 @@ export default {
 	<div>
 		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">Enable sharing</NcCheckboxRadioSwitch>
 		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch" :disabled="true">Enable sharing (disabled)</NcCheckboxRadioSwitch>
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">
+			Enable sharing. This can contain a long multiline text, that will be wrapped in a second row. It is generally not advised to have such long text inside of an element
+		</NcCheckboxRadioSwitch>
 		<br>
 		sharingEnabled: {{ sharingEnabled }}
 	</div>


### PR DESCRIPTION

### ☑️ Resolves

- Fix https://github.com/nextcloud/spreed/issues/15288

>[!WARNING]
> this reduces 'switch' icon height to `16px`
> this reduces 'switch' component height to `34px`
>
> - [ ] Qualify as breaking change or bugfix?


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/486dd215-894c-413f-92c2-46c2616345c0) | ![image](https://github.com/user-attachments/assets/7f64088d-4165-401b-940d-7e9e6240e2cc)
![image](https://github.com/user-attachments/assets/cb7f0753-259e-44f7-8514-d6d9bedf85a5) | ![image](https://github.com/user-attachments/assets/fbc2a830-21bc-4fa4-aeaf-b17be7fa170f)
![image](https://github.com/user-attachments/assets/dfe9c9fd-3c55-40e1-b9b0-611d9f85cc3d) | ![image](https://github.com/user-attachments/assets/9105229b-002a-4c71-b7d9-54c7b3cdb020)

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
