### PR TITLE
fix(NcDateTimePicker): correctly import library CSS

### DIFF
--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -319,6 +319,7 @@ const props = withDefaults(defineProps<{
 const timezoneId = defineModel<string>('timezoneId', { default: 'UTC' })
 
 const target = useTemplateRef('target')
+const picker = useTemplateRef('picker')
 
 const emit = defineEmits<{
 	/**
@@ -555,11 +556,28 @@ const ariaLabels = computed(() => ({
 	monthPicker: (overlay: boolean) => overlay ? t('Month picker overlay') : t('Month picker'),
 	yearPicker: (overlay: boolean) => overlay ? t('Year picker overlay') : t('Year picker'),
 }))
+
+/**
+ * Select the current value.
+ * This is used by the confirmation button if `confirmation` was set.
+ */
+function selectDate() {
+	picker.value!.selectDate()
+}
+
+/**
+ * Cancel the current selection by closing the overlay.
+ * This is used by the confirmation button if `confirmation` was set.
+ */
+function cancelSelection() {
+	picker.value!.closeMenu()
+}
 </script>
 
 <template>
 	<div class="vue-date-time-picker__wrapper">
-		<VueDatePicker :aria-labels
+		<VueDatePicker ref="picker"
+			:aria-labels
 			:auto-apply="!confirm"
 			class="vue-date-time-picker"
 			:cancel-text="t('Cancel')"
@@ -580,6 +598,14 @@ const ariaLabels = computed(() => ({
 			:week-start
 			v-bind="pickerType"
 			@update:model-value="onUpdateModelValue">
+			<template #action-buttons>
+				<NcButton size="small" variant="tertiary" @click="cancelSelection">
+					{{ t('Cancel') }}
+				</NcButton>
+				<NcButton size="small" variant="primary" @click="selectDate">
+					{{ t('Pick') }}
+				</NcButton>
+			</template>
 			<template #clear-icon="{ clear }">
 				<NcButton :aria-label="t('Clear value')"
 					variant="tertiary-no-background"

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -651,26 +651,26 @@ function cancelSelection() {
 
 .vue-date-time-picker__wrapper {
 	// This is under :root in @vuepic/vue-datepicker/dist/main.css, so importing it scoped won't work
-	--dp-common-transition: all 0.1s ease-in;
+	--dp-common-transition: all var(--animation-quick) ease-in;
 	--dp-menu-padding: 6px 8px;
-	--dp-animation-duration: 0.1s;
+	--dp-animation-duration: var(--animation-quick);
 	--dp-menu-appear-transition-timing: cubic-bezier(.4, 0, 1, 1);
 	--dp-transition-timing: ease-out;
 	--dp-action-row-transtion: all 0.2s ease-in;
-	--dp-font-family: -apple-system, blinkmacsystemfont, "Segoe UI", roboto, oxygen, ubuntu, cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-	// --dp-border-radius: 4px;
-	--dp-cell-border-radius: 4px;
+	--dp-font-family: var(--font-face);
+	--dp-border-radius: var(--border-radius-element);
+	--dp-cell-border-radius: var(--border-radius-small);
 	--dp-transition-length: 22px;
-	--dp-transition-timing-general: 0.1s;
-	--dp-button-height: 35px;
-	--dp-month-year-row-height: 35px;
-	--dp-month-year-row-button-size: 25px;
+	--dp-transition-timing-general: var(--animation-quick);
+	--dp-button-height: var(--default-clickable-area);
+	--dp-month-year-row-height: var(--default-clickable-area);
+	--dp-month-year-row-button-size: var(--clickable-area-small);
 	--dp-button-icon-height: 20px;
 	--dp-calendar-wrap-padding: 0 5px;
-	--dp-cell-size: 35px;
+	--dp-cell-size: var(--default-clickable-area);
 	--dp-cell-padding: 5px;
 	--dp-common-padding: 10px;
-	// --dp-input-icon-padding: 35px;
+	--dp-input-icon-padding: var(--default-clickable-area);
 	--dp-input-padding: 6px 30px 6px 12px;
 	--dp-menu-min-width: 260px;
 	--dp-action-buttons-padding: 1px 6px;
@@ -678,11 +678,11 @@ function cancelSelection() {
 	--dp-calendar-header-cell-padding: 0.5rem;
 	--dp-multi-calendars-spacing: 10px;
 	--dp-overlay-col-padding: 3px;
-	--dp-time-inc-dec-button-size: 32px;
+	--dp-time-inc-dec-button-size: var(--default-clickable-area);
 	--dp-font-size: 1rem;
-	--dp-preview-font-size: 0.8rem;
+	--dp-preview-font-size: var(--font-size-small);
 	--dp-time-font-size: 2rem;
-	--dp-action-button-height: 22px;
+	--dp-action-button-height: var(--clickable-area-small);
 	--dp-action-row-padding: 8px;
 	--dp-direction: ltr;
 
@@ -692,18 +692,13 @@ function cancelSelection() {
 		@include meta.load-css('@vuepic/vue-datepicker/dist/main.css');
 	}
 
-	/*
-	 * These are our customizations to the date picker.
-	 */
-	--dp-border-radius: var(--border-radius-element);
-	--dp-input-icon-padding: var(--default-clickable-area);
-
 	.vue-date-time-picker__timezone {
 		min-width: unset;
 		width: 100%;
 	}
 
 	:deep(.icon-vue) {
+		// we enforce full opacity to not create a11y issues with contrast
 		opacity: 1 !important;
 	}
 
@@ -735,46 +730,18 @@ function cancelSelection() {
 	:deep(input) {
 		padding-inline-start: var(--dp-input-icon-padding) !important;
 	}
-	:deep(.dp__input) {
-		margin: 3px;
-		margin-inline-start: 0;
-		padding: 0 12px;
-		font-size: var(--default-font-size);
-		background-color: var(--color-main-background);
-		color: var(--color-main-text);
-		border: 2px solid var(--color-border-maxcontrast);
-		outline: none;
-		border-radius: var(--border-radius-large);
-		text-overflow: ellipsis;
-		cursor: pointer;
-	}
-	:deep(.dp__btn),
-	:deep(.dp--time-overlay-btn),
-	:deep(.dp__action_button) {
+	:deep(.dp__btn) {
 		margin: 0;
-		font-weight: bold;
-		border-radius: var(--border-radius-element);
-		padding: calc((var(--default-clickable-area) - 1lh) / 2) calc(3 * var(--default-grid-baseline));
-		font-size: var(--default-font-size);
-		width: auto;
-		min-height: var(--default-clickable-area);
-		cursor: pointer;
-		box-sizing: border-box;
-		color: var(--color-primary-element-light-text);
-		background-color: var(--color-primary-element-light);
-		border: none;
-	}
-	:deep(.dp--time-overlay-btn),
-	:deep(.dp__action_button) {
-		margin: 3px;
-		margin-inline-start: 0;
-	}
-	:deep(.dp__inc_dec_button) {
-		padding: calc((var(--default-clickable-area) - 20px) / 2);
 	}
 	:deep(.dp__inner_nav) {
 		height: fit-content;
 		width: fit-content;
+	}
+
+	// make the bottom page toggle stand out better
+	:deep(.dp__btn.dp__button.dp__button_bottom) {
+		color: var(--color-primary-element-light);
+		background-color: var(--color-primary-element-light);
 	}
 
 	// Fix server styles causing buttons to be primary colored
@@ -783,7 +750,8 @@ function cancelSelection() {
 		background-color: var(--color-main-background);
 
 		&:hover {
-			background-color: var(--color-background-hover);
+			background: var(--dp-hover-color);
+			color: var(--dp-hover-icon-color);
 		}
 	}
 
@@ -806,9 +774,9 @@ function cancelSelection() {
 	:deep(.dp__theme_light) {
 		--dp-background-color: var(--color-main-background);
 		--dp-text-color: var(--color-main-text);
-		--dp-hover-color: var(--color-background-hover);
-		--dp-hover-text-color: var(--color-main-text);
-		--dp-hover-icon-color: var(--color-main-text);
+		--dp-hover-color: var(--color-primary-element-light-hover);
+		--dp-hover-text-color: var(--color-primary-element-light-text);
+		--dp-hover-icon-color: var(--color-primary-element-light-text);
 		--dp-primary-color: var(--color-primary-element);
 		--dp-primary-disabled-color: var(--color-primary-element-hover);
 		--dp-primary-text-color: var(--color-primary-element-text);

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -189,7 +189,7 @@ import {
 	getDayNamesMin,
 	getCanonicalLocale,
 } from '@nextcloud/l10n'
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { t } from '../../l10n.js'
 
 import VueDatePicker from '@vuepic/vue-datepicker'
@@ -317,6 +317,8 @@ const props = withDefaults(defineProps<{
  * @default 'UTC'
  */
 const timezoneId = defineModel<string>('timezoneId', { default: 'UTC' })
+
+const target = useTemplateRef('target')
 
 const emit = defineEmits<{
 	/**
@@ -556,7 +558,7 @@ const ariaLabels = computed(() => ({
 </script>
 
 <template>
-	<div class="date-time-picker-scope">
+	<div class="vue-date-time-picker-wrapper">
 		<VueDatePicker :aria-labels
 			:auto-apply="!confirm"
 			class="vue-date-time-picker"
@@ -571,7 +573,7 @@ const ariaLabels = computed(() => ({
 			:now-button-label="t('Now')"
 			:select-text="t('Pick')"
 			six-weeks="fair"
-			:teleport="appendToBody || undefined"
+			:teleport="appendToBody ? (target || undefined) : false"
 			text-input
 			:week-num-name
 			:week-numbers="showWeekNumber ? { type: 'iso' } : undefined"
@@ -612,16 +614,16 @@ const ariaLabels = computed(() => ({
 					:input-label="t('Timezone')" />
 			</template>
 		</VueDatePicker>
+		<Teleport to="body" :disabled="!appendToBody">
+			<div ref="target" class="vue-date-time-picker-wrapper" />
+		</Teleport>
 	</div>
-	<Teleport to="body" :disabled="!appendToBody">
-		<div ref="target" class="date-time-picker-scope" />
-	</Teleport>
 </template>
 
 <style scoped lang="scss">
 @use "sass:meta";
 
-.date-time-picker-scope {
+.vue-date-time-picker-wrapper {
 	// This is under :root in @vuepic/vue-datepicker/dist/main.css, so importing it scoped won't work
 	--dp-common-transition: all 0.1s ease-in;
 	--dp-menu-padding: 6px 8px;
@@ -630,7 +632,7 @@ const ariaLabels = computed(() => ({
 	--dp-transition-timing: ease-out;
 	--dp-action-row-transtion: all 0.2s ease-in;
 	--dp-font-family: -apple-system, blinkmacsystemfont, "Segoe UI", roboto, oxygen, ubuntu, cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-	--dp-border-radius: 4px;
+	// --dp-border-radius: 4px;
 	--dp-cell-border-radius: 4px;
 	--dp-transition-length: 22px;
 	--dp-transition-timing-general: 0.1s;
@@ -642,7 +644,7 @@ const ariaLabels = computed(() => ({
 	--dp-cell-size: 35px;
 	--dp-cell-padding: 5px;
 	--dp-common-padding: 10px;
-	--dp-input-icon-padding: 35px;
+	// --dp-input-icon-padding: 35px;
 	--dp-input-padding: 6px 30px 6px 12px;
 	--dp-menu-min-width: 260px;
 	--dp-action-buttons-padding: 1px 6px;
@@ -658,15 +660,15 @@ const ariaLabels = computed(() => ({
 	--dp-action-row-padding: 8px;
 	--dp-direction: ltr;
 
-	// we need to import the vuepic styles but at least scoped to our class and scope
+	// We need to import the vuepic styles, but at least scoped to our class and scope
 	// plain @import does not work as this will scope all styles imported.
 	:deep() {
-		// Importing like this does not work for webpack, it seems?
 		@include meta.load-css('@vuepic/vue-datepicker/dist/main.css');
 	}
-}
 
-.vue-date-time-picker {
+	/*
+	 * These are our customizations to the date picker.
+	 */
 	--dp-border-radius: var(--border-radius-element);
 	--dp-input-icon-padding: var(--default-clickable-area);
 
@@ -739,8 +741,8 @@ const ariaLabels = computed(() => ({
 		padding: 0 calc(4 * var(--default-grid-baseline));
 	}
 
-	&.dp__theme_dark,
-	&.dp__theme_light,
+	.vue-date-time-picker.dp__theme_dark,
+	.vue-date-time-picker.dp__theme_light,
 	:deep(.dp__theme_dark),
 	:deep(.dp__theme_light) {
 		--dp-background-color: var(--color-main-background);

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -556,65 +556,115 @@ const ariaLabels = computed(() => ({
 </script>
 
 <template>
-	<VueDatePicker :aria-labels
-		:auto-apply="!confirm"
-		class="vue-date-time-picker"
-		:cancel-text="t('Cancel')"
-		:clearable
-		:day-names
-		:placeholder="placeholder ?? placeholderFallback"
-		:format="realFormat"
-		:locale
-		:minutes-increment="minuteStep"
-		:model-value="value"
-		:now-button-label="t('Now')"
-		:select-text="t('Pick')"
-		six-weeks="fair"
-		:teleport="appendToBody || undefined"
-		text-input
-		:week-num-name
-		:week-numbers="showWeekNumber ? { type: 'iso' } : undefined"
-		:week-start
-		v-bind="pickerType"
-		@update:model-value="onUpdateModelValue">
-		<template #input-icon>
-			<NcIconSvgWrapper :path="mdiCalendarBlank" :size="20" />
-		</template>
-		<template #clear-icon="{ clear }">
-			<NcButton :aria-label="t('Clear value')"
-				variant="tertiary-no-background"
-				@click="clear">
-				<template #icon>
-					<NcIconSvgWrapper inline :path="mdiClose" :size="20" />
-				</template>
-			</NcButton>
-		</template>
-		<template #clock-icon>
-			<NcIconSvgWrapper inline :path="mdiClock" :size="20" />
-		</template>
-		<template #arrow-left>
-			<NcIconSvgWrapper inline :path="mdiChevronLeft" :size="20" />
-		</template>
-		<template #arrow-right>
-			<NcIconSvgWrapper inline :path="mdiChevronRight" :size="20" />
-		</template>
-		<template #arrow-down>
-			<NcIconSvgWrapper inline :path="mdiChevronDown" :size="20" />
-		</template>
-		<template #arrow-up>
-			<NcIconSvgWrapper inline :path="mdiChevronUp" :size="20" />
-		</template>
-		<template v-if="showTimezoneSelect" #action-extra>
-			<NcTimezonePicker v-model="timezoneId"
-				class="vue-date-time-picker__timezone"
-				:append-to-body="false"
-				:input-label="t('Timezone')" />
-		</template>
-	</VueDatePicker>
+	<div class="date-time-picker-scope">
+		<VueDatePicker :aria-labels
+			:auto-apply="!confirm"
+			class="vue-date-time-picker"
+			:cancel-text="t('Cancel')"
+			:clearable
+			:day-names
+			:placeholder="placeholder ?? placeholderFallback"
+			:format="realFormat"
+			:locale
+			:minutes-increment="minuteStep"
+			:model-value="value"
+			:now-button-label="t('Now')"
+			:select-text="t('Pick')"
+			six-weeks="fair"
+			:teleport="appendToBody || undefined"
+			text-input
+			:week-num-name
+			:week-numbers="showWeekNumber ? { type: 'iso' } : undefined"
+			:week-start
+			v-bind="pickerType"
+			@update:model-value="onUpdateModelValue">
+			<template #clear-icon="{ clear }">
+				<NcButton :aria-label="t('Clear value')"
+					variant="tertiary-no-background"
+					@click="clear">
+					<template #icon>
+						<NcIconSvgWrapper inline :path="mdiClose" :size="20" />
+					</template>
+				</NcButton>
+			</template>
+			<template #input-icon>
+				<NcIconSvgWrapper :path="mdiCalendarBlank" :size="20" />
+			</template>
+			<template #clock-icon>
+				<NcIconSvgWrapper inline :path="mdiClock" :size="20" />
+			</template>
+			<template #arrow-left>
+				<NcIconSvgWrapper inline :path="mdiChevronLeft" :size="20" />
+			</template>
+			<template #arrow-right>
+				<NcIconSvgWrapper inline :path="mdiChevronRight" :size="20" />
+			</template>
+			<template #arrow-down>
+				<NcIconSvgWrapper inline :path="mdiChevronDown" :size="20" />
+			</template>
+			<template #arrow-up>
+				<NcIconSvgWrapper inline :path="mdiChevronUp" :size="20" />
+			</template>
+			<template v-if="showTimezoneSelect" #action-extra>
+				<NcTimezonePicker v-model="timezoneId"
+					class="vue-date-time-picker__timezone"
+					:append-to-body="false"
+					:input-label="t('Timezone')" />
+			</template>
+		</VueDatePicker>
+	</div>
+	<Teleport to="body" :disabled="!appendToBody">
+		<div ref="target" class="date-time-picker-scope" />
+	</Teleport>
 </template>
 
 <style scoped lang="scss">
-@import '@vuepic/vue-datepicker/dist/main.css';
+@use "sass:meta";
+
+.date-time-picker-scope {
+	// This is under :root in @vuepic/vue-datepicker/dist/main.css, so importing it scoped won't work
+	--dp-common-transition: all 0.1s ease-in;
+	--dp-menu-padding: 6px 8px;
+	--dp-animation-duration: 0.1s;
+	--dp-menu-appear-transition-timing: cubic-bezier(.4, 0, 1, 1);
+	--dp-transition-timing: ease-out;
+	--dp-action-row-transtion: all 0.2s ease-in;
+	--dp-font-family: -apple-system, blinkmacsystemfont, "Segoe UI", roboto, oxygen, ubuntu, cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+	--dp-border-radius: 4px;
+	--dp-cell-border-radius: 4px;
+	--dp-transition-length: 22px;
+	--dp-transition-timing-general: 0.1s;
+	--dp-button-height: 35px;
+	--dp-month-year-row-height: 35px;
+	--dp-month-year-row-button-size: 25px;
+	--dp-button-icon-height: 20px;
+	--dp-calendar-wrap-padding: 0 5px;
+	--dp-cell-size: 35px;
+	--dp-cell-padding: 5px;
+	--dp-common-padding: 10px;
+	--dp-input-icon-padding: 35px;
+	--dp-input-padding: 6px 30px 6px 12px;
+	--dp-menu-min-width: 260px;
+	--dp-action-buttons-padding: 1px 6px;
+	--dp-row-margin: 5px 0;
+	--dp-calendar-header-cell-padding: 0.5rem;
+	--dp-multi-calendars-spacing: 10px;
+	--dp-overlay-col-padding: 3px;
+	--dp-time-inc-dec-button-size: 32px;
+	--dp-font-size: 1rem;
+	--dp-preview-font-size: 0.8rem;
+	--dp-time-font-size: 2rem;
+	--dp-action-button-height: 22px;
+	--dp-action-row-padding: 8px;
+	--dp-direction: ltr;
+
+	// we need to import the vuepic styles but at least scoped to our class and scope
+	// plain @import does not work as this will scope all styles imported.
+	:deep() {
+		// Importing like this does not work for webpack, it seems?
+		@include meta.load-css('@vuepic/vue-datepicker/dist/main.css');
+	}
+}
 
 .vue-date-time-picker {
 	--dp-border-radius: var(--border-radius-element);

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -558,7 +558,7 @@ const ariaLabels = computed(() => ({
 </script>
 
 <template>
-	<div class="vue-date-time-picker-wrapper">
+	<div class="vue-date-time-picker__wrapper">
 		<VueDatePicker :aria-labels
 			:auto-apply="!confirm"
 			class="vue-date-time-picker"
@@ -615,7 +615,7 @@ const ariaLabels = computed(() => ({
 			</template>
 		</VueDatePicker>
 		<Teleport to="body" :disabled="!appendToBody">
-			<div ref="target" class="vue-date-time-picker-wrapper" />
+			<div ref="target" class="vue-date-time-picker__wrapper" />
 		</Teleport>
 	</div>
 </template>
@@ -623,7 +623,7 @@ const ariaLabels = computed(() => ({
 <style scoped lang="scss">
 @use "sass:meta";
 
-.vue-date-time-picker-wrapper {
+.vue-date-time-picker__wrapper {
 	// This is under :root in @vuepic/vue-datepicker/dist/main.css, so importing it scoped won't work
 	--dp-common-transition: all 0.1s ease-in;
 	--dp-menu-padding: 6px 8px;
@@ -709,9 +709,42 @@ const ariaLabels = computed(() => ({
 	:deep(input) {
 		padding-inline-start: var(--dp-input-icon-padding) !important;
 	}
-	:deep(.dp__btn) {
-		padding: calc((var(--default-clickable-area) - 20px) / 2);
+	:deep(.dp__input) {
+		margin: 3px;
+		margin-inline-start: 0;
+		padding: 0 12px;
+		font-size: var(--default-font-size);
+		background-color: var(--color-main-background);
+		color: var(--color-main-text);
+		border: 2px solid var(--color-border-maxcontrast);
+		outline: none;
+		border-radius: var(--border-radius-large);
+		text-overflow: ellipsis;
+		cursor: pointer;
+	}
+	:deep(.dp__btn),
+	:deep(.dp--time-overlay-btn),
+	:deep(.dp__action_button) {
 		margin: 0;
+		font-weight: bold;
+		border-radius: var(--border-radius-element);
+		padding: calc((var(--default-clickable-area) - 1lh) / 2) calc(3 * var(--default-grid-baseline));
+		font-size: var(--default-font-size);
+		width: auto;
+		min-height: var(--default-clickable-area);
+		cursor: pointer;
+		box-sizing: border-box;
+		color: var(--color-primary-element-light-text);
+		background-color: var(--color-primary-element-light);
+		border: none;
+	}
+	:deep(.dp--time-overlay-btn),
+	:deep(.dp__action_button) {
+		margin: 3px;
+		margin-inline-start: 0;
+	}
+	:deep(.dp__inc_dec_button) {
+		padding: calc((var(--default-clickable-area) - 20px) / 2);
 	}
 	:deep(.dp__inner_nav) {
 		height: fit-content;

--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -258,8 +258,8 @@ const cleanSvg = computed(() => {
 	min-height: var(--default-clickable-area);
 	opacity: 1;
 
-	&--inline {
-		display: inline-flex;
+	&#{&}--inline {
+		display: inline-flex !important;
 		min-width: fit-content;
 		min-height: fit-content;
 		vertical-align: text-bottom;

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -28,6 +28,7 @@ const sassLoader = {
 			sourceMapContents: false,
 			includePaths: [
 				path.resolve(__dirname, './src/assets'),
+				path.resolve(__dirname, 'node_modules'),
 			],
 		},
 	},


### PR DESCRIPTION
### ☑️ Resolves

This adjusts the CSS import of the `NcDateTimePicker` vendor styles to not be scoped. I don't know if this is the proper way to handle this issue, so plead advise if not.

- Fixes https://github.com/nextcloud-libraries/nextcloud-vue/issues/7050#issuecomment-2978166946.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Image](https://github.com/user-attachments/assets/1a1a5c94-d0e6-4a0f-89c5-20b3c1e47ad2) | ![grafik](https://github.com/user-attachments/assets/fe0c3565-62c3-4658-af4d-2a0ed9d6c0e8)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
