### PR TITLE
fix(NcRichText): always render code blocks in LTR direction

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -654,6 +654,11 @@ export default {
 		margin-block-end: 0;
 	}
 
+	// Always render code blocks in LTR direction
+	pre {
+		direction: ltr;
+	}
+
 	table {
 		border-collapse: collapse;
 		border: 2px solid var(--color-border-maxcontrast);


### PR DESCRIPTION
### ☑️ Resolves

- Upstreaming https://github.com/nextcloud/spreed/pull/15363

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="520" alt="image" src="https://github.com/user-attachments/assets/4acd2530-35be-4810-bfca-b5d5b757edc1" /> | <img width="521" alt="image" src="https://github.com/user-attachments/assets/ba1867ef-0fbd-4c59-a8f9-9df9da487728" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
