### PR TITLE
refactor(NcAppContent): clarify props documentation and use capabilities over initial state

### DIFF
--- a/tests/unit/components/NcAppContent/NcAppContent.spec.ts
+++ b/tests/unit/components/NcAppContent/NcAppContent.spec.ts
@@ -53,6 +53,16 @@ describe('NcAppContent', () => {
 		expect(document.title).toBe('nextcloud-vue - Nextcloud')
 	})
 
+	it('does not duplicate the heading in the document title if already formatted', () => {
+		mount(NcAppContent, {
+			propsData: {
+				pageHeading: 'My heading - nextcloud-vue',
+			},
+		})
+
+		expect(document.title).toBe('My heading - nextcloud-vue - Nextcloud')
+	})
+
 	it('sets the document title if pageTitle is provided', () => {
 		mount(NcAppContent, {
 			propsData: {
@@ -60,17 +70,27 @@ describe('NcAppContent', () => {
 			},
 		})
 
-		expect(document.title).toBe('My title - nextcloud-vue - Nextcloud')
+		expect(document.title).toBe('My title - Nextcloud')
 	})
 
 	it('does not duplicate the title in the document title', () => {
 		mount(NcAppContent, {
 			propsData: {
-				pageTitle: 'nextcloud-vue',
+				pageTitle: 'Nextcloud',
 			},
 		})
 
-		expect(document.title).toBe('nextcloud-vue - Nextcloud')
+		expect(document.title).toBe('Nextcloud')
+	})
+
+	it('does not duplicate the title in the document title if already formatted', () => {
+		mount(NcAppContent, {
+			propsData: {
+				pageTitle: 'My title - Nextcloud',
+			},
+		})
+
+		expect(document.title).toBe('My title - Nextcloud')
 	})
 
 	it('sets the document title if pageTitle and pageHeading are provided', () => {
@@ -81,6 +101,6 @@ describe('NcAppContent', () => {
 			},
 		})
 
-		expect(document.title).toBe('My title - My heading - Nextcloud')
+		expect(document.title).toBe('My title - Nextcloud')
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

We do not use the product name but the instance name, so this clarifies it.
Also the docs of the size props was a bit confusing - adjusted it.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
