### PR TITLE
refactor!: make all events camelcase and drop deprecated events

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,7 @@
 			{
 				"ignore": ["\\?raw$"]
 			}
-		]
+		],
+		"vue/custom-event-name-casing": "error"
 	}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,15 @@ The `nativeType` property was removed in favor of `type`.
 <NcButton type="submit" variant="primary">Submit</NcButton>
 ```
 
+#### Event names
+To have a consistent naming for custom event the following events were deprecated
+and now are removed in favor of a new consistent event name:
+
+     Component |       Old event |       New event
+---------------|-----------------|----------------
+`NcAppContent` |   `resize:list` |   `resizeList`
+  `NcRichText` | `interact:todo` | `interactTodo`
+
 #### Mixins are removed
 Mixins only work in Options API and are in general not recommended by Vue anymore:
 

--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -270,7 +270,7 @@ export default {
 
 	emits: [
 		'update:showDetails',
-		'resize-list',
+		'resizeList',
 		'resize:list',
 	],
 
@@ -418,7 +418,7 @@ export default {
 			/**
 			 * Emitted when the list pane is resized by the user
 			 */
-			this.$emit('resize-list', { size: listPaneSize })
+			this.$emit('resizeList', { size: listPaneSize })
 			console.debug('AppContent pane config', listPaneSize)
 		},
 

--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -271,7 +271,6 @@ export default {
 	emits: [
 		'update:showDetails',
 		'resizeList',
-		'resize:list',
 	],
 
 	setup() {
@@ -409,12 +408,6 @@ export default {
 			const listPaneSize = parseInt(event.panes[0].size, 10)
 			browserStorage.setItem(this.paneConfigID, JSON.stringify(listPaneSize))
 			this.listPaneSize = listPaneSize
-			/**
-			 * Emitted when the list pane is resized by the user
-			 *
-			 * @deprecated listen on `resize-list` instead
-			 */
-			this.$emit('resize:list', { size: listPaneSize })
 			/**
 			 * Emitted when the list pane is resized by the user
 			 */

--- a/src/components/NcAppNavigationNewItem/NcAppNavigationNewItem.vue
+++ b/src/components/NcAppNavigationNewItem/NcAppNavigationNewItem.vue
@@ -128,7 +128,7 @@ export default {
 		},
 	},
 
-	emits: ['new-item'],
+	emits: ['newItem'],
 
 	data() {
 		return {
@@ -150,7 +150,7 @@ export default {
 			this.newItemActive = false
 		},
 		handleNewItemDone() {
-			this.$emit('new-item', this.newItemValue)
+			this.$emit('newItem', this.newItemValue)
 			this.newItemValue = ''
 			this.newItemActive = false
 		},

--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -920,14 +920,14 @@ export default {
 		'close',
 		'closed',
 		'opened',
-		// 'figure-click', not emitted on purpose to make "hasFigureClickListener" work
+		// 'figureClick', not emitted on purpose to make "hasFigureClickListener" work
 		'update:active',
 		'update:name',
 		'update:nameEditable',
 		'update:open',
 		'update:starred',
-		'submit-name',
-		'dismiss-editing',
+		'submitName',
+		'dismissEditing',
 	],
 
 	setup() {
@@ -1112,7 +1112,7 @@ export default {
 			 * @type {Event}
 			 */
 			// eslint-disable-next-line vue/require-explicit-emits
-			this.$emit('figure-click', e)
+			this.$emit('figureClick', e)
 		},
 
 		/**
@@ -1212,7 +1212,7 @@ export default {
 			 *
 			 * @type {Event}
 			 */
-			this.$emit('submit-name', event)
+			this.$emit('submitName', event)
 		},
 		onDismissEditing() {
 			// Disable editing
@@ -1222,7 +1222,7 @@ export default {
 			 *
 			 * @type {Event}
 			 */
-			this.$emit('dismiss-editing')
+			this.$emit('dismissEditing')
 		},
 		onUpdateActive(activeTab) {
 			/**

--- a/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
+++ b/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
@@ -62,7 +62,7 @@ export default {
 	},
 
 	emits: [
-		'bottom-reached',
+		'bottomReached',
 		'scroll',
 	],
 
@@ -99,7 +99,7 @@ export default {
 				 *
 				 * @property {Event} event Native scroll event
 				 */
-				this.$emit('bottom-reached', event)
+				this.$emit('bottomReached', event)
 			}
 			/**
 			 * @property {Event} event Native scroll event

--- a/src/components/NcCollectionList/NcCollectionListItem.vue
+++ b/src/components/NcCollectionList/NcCollectionListItem.vue
@@ -94,7 +94,10 @@ export default {
 		},
 	},
 
-	emits: ['remove-resource', 'rename-collection'],
+	emits: [
+		'removeResource',
+		'renameCollection',
+	],
 
 	data() {
 		return {
@@ -152,7 +155,7 @@ export default {
 		},
 
 		removeResource(collection, resource) {
-			this.$emit('remove-resource', {
+			this.$emit('removeResource', {
 				collectionId: collection.id,
 				resourceType: resource.type,
 				resourceId: resource.id,
@@ -165,7 +168,7 @@ export default {
 
 		renameCollection() {
 			if (this.newName) {
-				this.$emit('rename-collection', {
+				this.$emit('renameCollection', {
 					collectionId: this.collection.id,
 					name: this.newName,
 				})

--- a/src/components/NcContent/NcContent.vue
+++ b/src/components/NcContent/NcContent.vue
@@ -77,7 +77,7 @@ import contentSvg from './content-selected.svg?raw'
 import navigationSvg from './navigation-selected.svg?raw'
 /* eslint-enable import/no-unresolved */
 
-defineProps<{
+const props = defineProps<{
 	/**
 	 * The application name to use.
 	 * This is used to scope all content (content, sidebar, navigation) to the application.
@@ -94,6 +94,7 @@ defineSlots<{
 
 provide('NcContent:setHasAppNavigation', setAppNavigation)
 provide('NcContent:selector', '#content-vue')
+provide('appName', computed(() => props.appName))
 
 const isMobile = useIsMobile()
 

--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -313,7 +313,7 @@ export default {
 	},
 	emits: [
 		'select',
-		'select-data',
+		'selectData',
 		'unselect',
 	],
 
@@ -391,7 +391,7 @@ export default {
 			/**
 			 * Emits a object with more data about the picked emoji
 			 */
-			this.$emit('select-data', emojiObject)
+			this.$emit('selectData', emojiObject)
 
 			if (this.closeOnSelect) {
 				this.open = false

--- a/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
+++ b/src/components/NcRelatedResourcesPanel/NcRelatedResourcesPanel.vue
@@ -123,8 +123,8 @@ export default {
 	},
 
 	emits: [
-		'has-error',
-		'has-resources',
+		'hasError',
+		'hasResources',
 	],
 
 	data() {
@@ -201,7 +201,7 @@ export default {
 			 *
 			 * @type {boolean}
 			 */
-			this.$emit('has-error', Boolean(error))
+			this.$emit('hasError', Boolean(error))
 		},
 		resources(resources) {
 			/**
@@ -209,7 +209,7 @@ export default {
 			 *
 			 * @type {boolean}
 			 */
-			this.$emit('has-resources', resources.length > 0)
+			this.$emit('hasResources', resources.length > 0)
 		},
 	},
 

--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -412,10 +412,10 @@ export default {
 	},
 
 	emits: [
-		'submit',
 		'paste',
 		'update:modelValue',
-		'smart-picker-submit',
+		'smartPickerSubmit',
+		'submit',
 	],
 
 	setup() {
@@ -669,7 +669,7 @@ export default {
 						result,
 						insertText: true,
 					}
-					this.$emit('smart-picker-submit', eventData)
+					this.$emit('smartPickerSubmit', eventData)
 					if (eventData.insertText) {
 						const newElem = document.createTextNode(result)
 						tmpElem.replaceWith(newElem)

--- a/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcProviderList.vue
@@ -60,7 +60,7 @@ export default {
 		LinkVariantIcon,
 	},
 	emits: [
-		'select-provider',
+		'selectProvider',
 		'submit',
 	],
 	data() {
@@ -96,7 +96,7 @@ export default {
 				if (p.isLink) {
 					this.$emit('submit', p.title)
 				} else {
-					this.$emit('select-provider', p)
+					this.$emit('selectProvider', p)
 				}
 				this.selectedProvider = null
 			}

--- a/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePicker.vue
@@ -83,9 +83,9 @@ export default {
 	},
 	emits: [
 		'cancel',
-		'cancel-raw-link',
-		'cancel-search',
-		'provider-selected',
+		'cancelRawLink',
+		'cancelSearch',
+		'providerSelected',
 		'submit',
 	],
 	data() {
@@ -134,7 +134,7 @@ export default {
 		},
 		onProviderSelected(provider) {
 			this.selectedProvider = provider
-			this.$emit('provider-selected', provider)
+			this.$emit('providerSelected', provider)
 			this.$nextTick(() => {
 				this.$refs['url-input']?.focus()
 			})
@@ -143,11 +143,11 @@ export default {
 			this.deselectProvider()
 		},
 		cancelSearch() {
-			this.$emit('cancel-search', this.selectedProvider?.title)
+			this.$emit('cancelSearch', this.selectedProvider?.title)
 			this.deselectProvider()
 		},
 		cancelRawLinkInput() {
-			this.$emit('cancel-raw-link', this.selectedProvider?.title)
+			this.$emit('cancelRawLink', this.selectedProvider?.title)
 			this.deselectProvider()
 		},
 		cancelProviderSelection() {
@@ -162,7 +162,7 @@ export default {
 		},
 		deselectProvider() {
 			this.selectedProvider = null
-			this.$emit('provider-selected', null)
+			this.$emit('providerSelected', null)
 			setTimeout(() => {
 				this.$refs['provider-list']?.focus()
 			}, 300)

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -392,7 +392,7 @@ export default {
 		},
 	},
 	emits: [
-		'interact-todo',
+		'interactTodo',
 		'interact:todo',
 	],
 
@@ -533,13 +533,13 @@ export default {
 								/**
 								 * Emitted when a todo-list entry was interacted with
 								 *
-								 * @deprecated listen on the `interact-todo` instead
+								 * @deprecated listen on the `interactTodo` instead
 								 */
 								this.$emit('interact:todo', id)
 								/**
 								 * Emitted when a todo-list entry was interacted with
 								 */
-								this.$emit('interact-todo', id)
+								this.$emit('interactTodo', id)
 							},
 						}, { default: () => labelParts })
 

--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -393,7 +393,6 @@ export default {
 	},
 	emits: [
 		'interactTodo',
-		'interact:todo',
 	],
 
 	data() {
@@ -530,12 +529,6 @@ export default {
 							id,
 							disabled: !this.interactive,
 							'onUpdate:modelValue': () => {
-								/**
-								 * Emitted when a todo-list entry was interacted with
-								 *
-								 * @deprecated listen on the `interactTodo` instead
-								 */
-								this.$emit('interact:todo', id)
 								/**
 								 * Emitted when a todo-list entry was interacted with
 								 */

--- a/tests/unit/components/NcRichText/NcRichText.spec.js
+++ b/tests/unit/components/NcRichText/NcRichText.spec.js
@@ -208,7 +208,7 @@ describe('Foo', () => {
 		const checkbox = wrapper.findComponent({ name: 'NcCheckboxRadioSwitch' })
 		expect(checkbox.exists()).toBeTruthy()
 		await checkbox.vm.$emit('update:modelValue', true)
-		expect(wrapper.emitted()['interact:todo']).toBeTruthy()
+		expect(wrapper.emitted().interactTodo).toBeTruthy()
 	})
 
 	it('properly defines syntax in code blocks and highlights it', async () => {


### PR DESCRIPTION
- :warning: chained on https://github.com/nextcloud-libraries/nextcloud-vue/pull/7058

### ☑️ Resolves

Make all events camel case instead of kebab case. For Vue 3 this is the recommended way of naming.
With Vue 3 this is compatible as `@event-name` will be triggered for `emit('eventName')`.

The breaking part is only removal of the deprecated two events where a scope like `resize:list` was used.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
