### PR TITLE
[stable8] fix(NcRichText): always render code blocks in LTR direction

### DIFF
--- a/src/components/NcRichText/richtext.scss
+++ b/src/components/NcRichText/richtext.scss
@@ -80,6 +80,11 @@
 		margin-block-end: 0;
 	}
 
+	// Always render code blocks in LTR direction
+	pre {
+		direction: ltr;
+	}
+
 	table {
 		border-collapse: collapse;
 		border: 2px solid var(--color-border-maxcontrast);


### PR DESCRIPTION
Backport of #7056 

Styles have been moved from .scss file to the component