### PR TITLE
feat: add `useFormatRelativeTime` composable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/initial-state": "^2.2.0",
-        "@nextcloud/l10n": "^3.2.0",
+        "@nextcloud/l10n": "^3.3.0",
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
@@ -18680,53 +18680,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
-      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.52.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
-      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pofile": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@nextcloud/capabilities": "^1.2.0",
     "@nextcloud/event-bus": "^3.3.2",
     "@nextcloud/initial-state": "^2.2.0",
-    "@nextcloud/l10n": "^3.2.0",
+    "@nextcloud/l10n": "^3.3.0",
     "@nextcloud/logger": "^3.0.2",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.2.4",

--- a/src/components/NcDateTime/NcDateTime.vue
+++ b/src/components/NcDateTime/NcDateTime.vue
@@ -92,13 +92,13 @@ h4 {
 <template>
 	<span class="nc-datetime"
 		:data-timestamp="timestamp"
-		:title="formattedFullTime"
+		:title
 		v-text="formattedTime" />
 </template>
 
 <script setup lang="ts">
-import { toRef } from 'vue'
-import { useFormatDateTime } from '../../composables/useFormatDateTime.ts'
+import { computed, toRef } from 'vue'
+import { useFormatRelativeTime, useFormatTime } from '../../composables/useFormatDateTime.ts'
 
 const props = withDefaults(defineProps<{
 	/**
@@ -130,8 +130,15 @@ const props = withDefaults(defineProps<{
 	relativeTime: 'long',
 })
 
-const {
-	formattedTime,
-	formattedFullTime,
-} = useFormatDateTime(toRef(() => props.timestamp), props)
+const timeOptions = computed(() => ({ format: props.format }))
+const relativeTimeOptions = computed(() => ({
+	ignoreSeconds: props.ignoreSeconds,
+	relativeTime: props.relativeTime || 'long',
+	update: props.relativeTime !== false,
+}))
+
+const title = useFormatTime(toRef(() => props.timestamp), timeOptions)
+const relativeTime = useFormatRelativeTime(toRef(() => props.timestamp), relativeTimeOptions)
+
+const formattedTime = computed(() => props.relativeTime ? relativeTime.value : title.value)
 </script>

--- a/src/composables/useFormatDateTime.ts
+++ b/src/composables/useFormatDateTime.ts
@@ -3,18 +3,42 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { MaybeRef } from 'vue'
-import { getCanonicalLocale, getLanguage } from '@nextcloud/l10n'
-import { computed, onUnmounted, ref, toValue, watchEffect } from 'vue'
+import type { FormatDateOptions } from '@nextcloud/l10n'
+import type { MaybeRefOrGetter, Ref } from 'vue'
+
+import { formatRelativeTime, getCanonicalLocale } from '@nextcloud/l10n'
+import { computed, onUnmounted, readonly, ref, toValue, watchEffect } from 'vue'
 import { t } from '../l10n.js'
 
-const FEW_SECONDS_AGO = {
-	long: t('a few seconds ago'),
-	short: t('seconds ago'), // FOR TRANSLATORS: Shorter version of 'a few seconds ago'
-	narrow: t('sec. ago'), // FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+interface FormatRelativeTimeOptions extends Partial<Omit<FormatDateOptions, 'ignoreSeconds'>> {
+	ignoreSeconds?: boolean
+
+	/**
+	 * If set to false the relative time will not be updated anymore.
+	 * @default true - Meaning the relative time will be updated if needed
+	 */
+	update?: boolean
 }
 
-interface FormatDateOptions {
+interface FormatTimeOptions {
+	/**
+	 * Locale to use for formatting.
+	 * @default current locale
+	 */
+	locale?: string
+
+	/**
+	 * The format used for displaying.
+	 *
+	 * @default { timeStyle: 'medium', dateStyle: 'short' }
+	 */
+	format?: Intl.DateTimeFormatOptions
+}
+
+/**
+ * @deprecated
+ */
+interface LegacyFormatDateTimeOptions {
 	/**
 	 * The format used for displaying, or if relative time is used the format used for the title
 	 */
@@ -22,106 +46,130 @@ interface FormatDateOptions {
 	/**
 	 * Ignore seconds when displaying the relative time and just show `a few seconds ago`
 	 */
-	ignoreSeconds?: boolean
+	ignoreSeconds?: true
 	/**
 	 * Wether to display the timestamp as time from now
 	 */
 	relativeTime?: false | 'long' | 'short' | 'narrow'
 }
 
+const FEW_SECONDS_AGO = {
+	long: t('a few seconds ago'),
+	short: t('seconds ago'), // FOR TRANSLATORS: Shorter version of 'a few seconds ago'
+	narrow: t('sec. ago'), // FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'
+}
+
+/**
+ * Format a timestamp or date object as relative time.
+ *
+ * This is a composable wrapper around `formatRelativeTime` from `@nextcloud/l10n`.
+ *
+ * @param timestamp - The timestamp to format
+ * @param opts - Formatting options
+ */
+export function useFormatRelativeTime(
+	timestamp: MaybeRefOrGetter<Date | number> = Date.now(),
+	opts: MaybeRefOrGetter<FormatRelativeTimeOptions> = {},
+): Readonly<Ref<string>> {
+	let timeoutId
+
+	/**
+	 * ECMA Date object of the timestamp
+	 */
+	const date = computed(() => new Date(toValue(timestamp)))
+
+	/**
+	 * Reactive options for `formatRelativeTime` method
+	 */
+	const options = computed<FormatDateOptions>(() => {
+		const { language, relativeTime, ignoreSeconds } = toValue(opts)
+		return {
+			...language && { language },
+			...relativeTime && { relativeTime },
+			ignoreSeconds: ignoreSeconds
+				? FEW_SECONDS_AGO[relativeTime || 'long']
+				: false,
+		}
+	})
+
+	/**
+	 * The formatted relative time
+	 */
+	const relativeTime = ref('')
+	watchEffect(() => updateRelativeTime())
+
+	/**
+	 * Update the relative time string.
+	 * This is the callback for the interval.
+	 */
+	function updateRelativeTime() {
+		relativeTime.value = formatRelativeTime(date.value, options.value)
+
+		if (toValue(opts).update !== false) {
+			timeoutId = window.setTimeout(updateRelativeTime, options.value.ignoreSeconds ? 30000 : 1000)
+		}
+	}
+
+	// when the component is unmounted we also clear the timeout
+	onUnmounted(() => timeoutId && window.clearTimeout(timeoutId))
+
+	return readonly(relativeTime)
+}
+
+/**
+ * Format a given timestamp or date object as a human readable string.
+ *
+ * @param timestamp - Timestamp or date object to format
+ * @param opts - Formatting options
+ */
+export function useFormatTime(
+	timestamp: MaybeRefOrGetter<number | Date>,
+	opts: MaybeRefOrGetter<FormatTimeOptions>,
+): Readonly<Ref<string>> {
+	const options = computed<Required<FormatTimeOptions>>(() => ({
+		locale: getCanonicalLocale(),
+		format: { dateStyle: 'short', timeStyle: 'medium' },
+		...toValue(opts),
+	}))
+
+	const formatter = computed(() => new Intl.DateTimeFormat(options.value.locale, options.value.format))
+
+	return computed(() => formatter.value.format(toValue(timestamp)))
+}
+
 /**
  * Composable for formatting time stamps using current users locale and language
  *
- * @param {import('vue').MaybeRef<Date | number>} timestamp Current timestamp
+ * @param {import('vue').MaybeRefOrGetter<Date | number>} timestamp Current timestamp
  * @param {object} opts Optional options
  * @param {Intl.DateTimeFormatOptions} opts.format The format used for displaying, or if relative time is used the format used for the title (optional)
  * @param {boolean} opts.ignoreSeconds Ignore seconds when displaying the relative time and just show `a few seconds ago`
  * @param {false | 'long' | 'short' | 'narrow'} opts.relativeTime Wether to display the timestamp as time from now (optional)
+ *
+ * @deprecated use `useFormatRelativeTime` or `useFormatTime` instead.
  */
 export function useFormatDateTime(
-	timestamp: MaybeRef<Date|number> = Date.now(),
-	opts: MaybeRef<FormatDateOptions> = {},
+	timestamp: MaybeRefOrGetter<Date|number> = Date.now(),
+	opts: MaybeRefOrGetter<LegacyFormatDateTimeOptions> = {},
 ) {
-	// Current time as Date.now is not reactive
-	const currentTime = ref(Date.now())
-	// The interval ID for the window
-	let intervalId: number|undefined
-
-	const options = ref({
-		format: {
-			timeStyle: 'medium',
-			dateStyle: 'short',
-		} as Intl.DateTimeFormatOptions,
-		relativeTime: 'long' as const,
-		ignoreSeconds: false,
-		...toValue(opts),
-	})
-	const wrappedOptions = computed<Required<FormatDateOptions>>(() => ({ ...toValue(opts), ...options.value }))
-
-	/** ECMA Date object of the timestamp */
-	const date = computed(() => new Date(toValue(timestamp)))
-
-	const formattedFullTime = computed<string>(() => {
-		const formatter = new Intl.DateTimeFormat(getCanonicalLocale(), wrappedOptions.value.format)
-		return formatter.format(date.value)
-	})
-
-	/** Time string formatted for main text */
-	const formattedTime = computed<string>(() => {
-		if (wrappedOptions.value.relativeTime !== false) {
-			const formatter = new Intl.RelativeTimeFormat(getLanguage(), { numeric: 'auto', style: wrappedOptions.value.relativeTime })
-
-			const diff = date.value.getTime() - currentTime.value
-			const seconds = diff / 1000
-			if (Math.abs(seconds) <= 90) {
-				if (wrappedOptions.value.ignoreSeconds) {
-					return FEW_SECONDS_AGO[wrappedOptions.value.relativeTime]
-				} else {
-					return formatter.format(Math.round(seconds), 'second')
-				}
-			}
-			const minutes = seconds / 60
-			if (Math.abs(minutes) <= 90) {
-				return formatter.format(Math.round(minutes), 'minute')
-			}
-			const hours = minutes / 60
-			if (Math.abs(hours) <= 24) {
-				return formatter.format(Math.round(hours), 'hour')
-			}
-			const days = hours / 24
-			if (Math.abs(days) <= 6) {
-				return formatter.format(Math.round(days), 'day')
-			}
-			const weeks = days / 7
-			if (Math.abs(weeks) <= 4) {
-				return formatter.format(Math.round(weeks), 'week')
-			}
-			const months = days / 30
-			if (Math.abs(months) <= 12) {
-				return formatter.format(Math.round(months), 'month')
-			}
-			return formatter.format(Math.round(days / 365), 'year')
+	const formattedFullTime = useFormatTime(timestamp, opts)
+	const relativeTime = useFormatRelativeTime(timestamp, computed(() => {
+		const options = toValue(opts)
+		return {
+			...options,
+			relativeTime: typeof options.relativeTime === 'string'
+				? options.relativeTime
+				: 'long',
 		}
-		return formattedFullTime.value
-	})
+	}))
 
-	// Set or clear interval if relative time is dis/enabled
-	watchEffect(() => {
-		window.clearInterval(intervalId)
-		intervalId = undefined
-		if (wrappedOptions.value.relativeTime) {
-			intervalId = window.setInterval(() => { currentTime.value = Date.now() }, 1000)
-		}
-	})
-
-	// ensure interval is cleared
-	onUnmounted(() => {
-		window.clearInterval(intervalId)
-	})
+	const formattedTime = computed(() => toValue(opts).relativeTime !== false
+		? relativeTime.value
+		: formattedFullTime.value,
+	)
 
 	return {
 		formattedTime,
 		formattedFullTime,
-		options,
 	}
 }

--- a/tests/unit/components/NcDateTime/NcDateTime.spec.js
+++ b/tests/unit/components/NcDateTime/NcDateTime.spec.js
@@ -4,9 +4,16 @@
  */
 
 import { mount } from '@vue/test-utils'
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import NcDateTime from '../../../../src/components/NcDateTime/NcDateTime.vue'
 import { nextTick } from 'vue'
+
+const getCanonicalLocale = vi.hoisted(() => vi.fn(() => 'en-US'))
+
+vi.mock('@nextcloud/l10n', async (original) => ({
+	...(await original()),
+	getCanonicalLocale,
+}))
 
 describe('NcDateTime.vue', () => {
 	'use strict'
@@ -56,13 +63,8 @@ describe('NcDateTime.vue', () => {
 	})
 
 	describe('Work with different locales', () => {
-		beforeAll(() => {
-			// mock the locale
-			document.documentElement.dataset.locale = 'de_DE'
-		})
-		afterAll(() => {
-			// revert mock
-			document.documentElement.dataset.locale = 'en'
+		beforeEach(() => {
+			getCanonicalLocale.mockImplementationOnce(() => 'de-DE')
 		})
 
 		/**
@@ -199,40 +201,6 @@ describe('NcDateTime.vue', () => {
 			})
 
 			expect(wrapper.element.textContent).toContain('3 weeks')
-		})
-
-		it('shows months from now', () => {
-			const time = Date.UTC(2023, 1, 23, 14, 30, 30)
-			const currentTime = Date.UTC(2023, 6, 13, 14, 30, 30)
-			vi.setSystemTime(currentTime)
-			const wrapper = mount(NcDateTime, {
-				props: {
-					timestamp: time,
-				},
-			})
-
-			expect(wrapper.element.textContent).toContain('5 months')
-		})
-
-		it('shows years from now', () => {
-			const time = Date.UTC(2023, 5, 23, 14, 30, 30)
-			const time2 = Date.UTC(2022, 5, 23, 14, 30, 30)
-			const currentTime = Date.UTC(2024, 6, 13, 14, 30, 30)
-			vi.setSystemTime(currentTime)
-
-			const wrapper = mount(NcDateTime, {
-				props: {
-					timestamp: time,
-				},
-			})
-			const wrapper2 = mount(NcDateTime, {
-				props: {
-					timestamp: time2,
-				},
-			})
-
-			expect(wrapper.element.textContent).toContain('last year')
-			expect(wrapper2.element.textContent).toContain('2 years')
 		})
 	})
 })

--- a/tests/unit/composables/useFormatDateTime.spec.js
+++ b/tests/unit/composables/useFormatDateTime.spec.js
@@ -3,15 +3,89 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { useFormatDateTime } from '../../../src/composables/useFormatDateTime.ts'
-import { isRef, nextTick, ref } from 'vue'
+import { useFormatDateTime, useFormatRelativeTime } from '../../../src/composables/useFormatDateTime.ts'
+import { computed, isRef, nextTick, ref } from 'vue'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+describe('useFormatRelativeTime composable', () => {
+	const time = Date.parse('2025-01-01T00:00:00Z')
+
+	beforeAll(() => vi.useFakeTimers())
+	beforeEach(() => vi.setSystemTime(time + 60000))
+
+	it('works with timestamp', () => {
+		const formatted = useFormatRelativeTime(time)
+		expect(formatted.value).toBe('1 minute ago')
+	})
+
+	it('works with computed timestamp', () => {
+		const formatted = useFormatRelativeTime(computed(() => time))
+		expect(formatted.value).toBe('1 minute ago')
+	})
+
+	it('works with a date object', () => {
+		const formatted = useFormatRelativeTime(time)
+		expect(formatted.value).toBe('1 minute ago')
+	})
+
+	it('works with computed date object', () => {
+		const formatted = useFormatRelativeTime(computed(() => time))
+		expect(formatted.value).toBe('1 minute ago')
+	})
+
+	it('updates the time', () => {
+		vi.setSystemTime(time + 6000)
+
+		const formatted = useFormatRelativeTime(time)
+		expect(formatted.value).toBe('6 seconds ago')
+		vi.advanceTimersByTime(6000)
+		expect(formatted.value).toBe('12 seconds ago')
+	})
+
+	it('can stop and restart the interval', async () => {
+		const options = ref({})
+		const formatted = useFormatRelativeTime(time, options)
+		expect(formatted.value).toBe('1 minute ago')
+
+		// wait one minute
+		await vi.advanceTimersByTimeAsync(60000)
+		expect(formatted.value).toBe('2 minutes ago')
+
+		// disable update and wait 2 minutes
+		options.value.update = false
+		await vi.advanceTimersByTimeAsync(120000)
+		expect(formatted.value).toBe('2 minutes ago')
+
+		// reenable update and wait until next timer
+		delete options.value.update
+		// request the next tick
+		nextTick()
+		// and wait for it (Vue's computed calculation)
+		await vi.advanceTimersToNextTimerAsync()
+		expect(formatted.value).toBe('4 minutes ago')
+	})
+
+	it.each`
+	format      | expected
+	${'long'}   | ${'a few seconds ago'}
+	${'short'}  | ${'seconds ago'}
+	${'narrow'} | ${'sec. ago'}
+	`('can ignore seconds', ({ format, expected }) => {
+		const time = Date.parse('2025-01-01T00:00:00Z')
+		vi.setSystemTime(time + 6000)
+
+		const options = { ignoreSeconds: true, relativeTime: format }
+		const formatted = useFormatRelativeTime(time, options)
+		expect(formatted.value).toBe(expected)
+	})
+})
 
 describe('useFormatDateTime composable', () => {
 	beforeAll(() => {
 		vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.useFakeTimers({ now: new Date('2025-01-01T00:00:00Z') })
 	})
+
 	afterAll(() => {
 		vi.restoreAllMocks()
 	})
@@ -20,7 +94,6 @@ describe('useFormatDateTime composable', () => {
 		const ctx = useFormatDateTime()
 		expect(isRef(ctx.formattedTime)).toBe(true)
 		expect(isRef(ctx.formattedFullTime)).toBe(true)
-		expect(isRef(ctx.options)).toBe(true)
 	})
 
 	it('Shows relative times', async () => {
@@ -44,27 +117,31 @@ describe('useFormatDateTime composable', () => {
 		expect(ctx.formattedTime.value).toContain('2 weeks')
 		time.value = Date.now() - 2 * 30 * 24 * 60 * 60 * 1000
 		await nextTick()
-		expect(ctx.formattedTime.value).toContain('2 month')
+		expect(ctx.formattedTime.value).toContain('November 2')
 		time.value = Date.now() - 2 * 365 * 24 * 60 * 60 * 1000
 		await nextTick()
-		expect(ctx.formattedTime.value).toContain('2 years')
+		expect(ctx.formattedTime.value).toContain('January 2023')
 	})
 
 	it('Shows different relative times', async () => {
-		const ctx = useFormatDateTime(Date.now() - 5000, { ignoreSeconds: true, relativeTime: 'long' })
+		const options = ref({ ignoreSeconds: true, relativeTime: 'long' })
+		const ctx = useFormatDateTime(Date.now() - 5000, options)
 		expect(ctx.formattedTime.value).toBe('a few seconds ago')
-		ctx.options.value.relativeTime = 'short'
+		options.value.relativeTime = 'short'
 		await nextTick()
 		expect(ctx.formattedTime.value).toBe('seconds ago')
-		ctx.options.value.relativeTime = 'narrow'
+		options.value.relativeTime = 'narrow'
 		await nextTick()
 		expect(ctx.formattedTime.value).toBe('sec. ago')
 	})
 
 	it('Should be reactive on options change', async () => {
-		const ctx = useFormatDateTime(Date.now() - 5000, { ignoreSeconds: false })
+		const options = ref({ ignoreSeconds: false })
+		const ctx = useFormatDateTime(Date.now() - 5000, options)
+
 		expect(ctx.formattedTime.value).toContain('sec')
-		ctx.options.value.ignoreSeconds = true
+
+		options.value.ignoreSeconds = true
 		await nextTick()
 		expect(ctx.formattedTime.value).toBe('a few seconds ago')
 	})


### PR DESCRIPTION
### ☑️ Resolves

* alternative to #6543 

This adds new composables as discussed in the PR mentioned above using the `@nextcloud/l10n` method.

### 🚧 Tasks

- Write documentation if accepted

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
