### PR TITLE
fix(NcHeaderMenu): bring caret back

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -303,7 +303,7 @@ $externalMargin: 8px;
 		filter: drop-shadow(0 1px 5px var(--color-box-shadow));
 	}
 
-	&__carret {
+	&__caret {
 		position: absolute;
 		z-index: 2001; // Because __wrapper is 2000.
 		bottom: 0;


### PR DESCRIPTION
### 🖼️ Screenshots

Regression from refactoring.
 
🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/45174316-97cb-42a0-9924-45c762a1f0ff) | ![image](https://github.com/user-attachments/assets/386fc727-da3f-48af-9d82-2092cc592164)

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
