### PR TITLE
fix(NcChip): adjust default prop declaration

### DIFF
--- a/src/components/NcChip/NcChip.vue
+++ b/src/components/NcChip/NcChip.vue
@@ -157,7 +157,7 @@ const props = withDefaults(defineProps<{
 	 * @default 'secondary'
 	 * @since 8.23.0
 	 */
-	variant: 'primary' | 'secondary' | 'tertiary'
+	variant?: 'primary' | 'secondary' | 'tertiary'
 }>(), {
 	ariaLabelClose: t('Close'),
 	actionsContainer: 'body',

--- a/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
+++ b/src/components/NcDateTimePickerNative/NcDateTimePickerNative.vue
@@ -124,7 +124,7 @@ export default defineComponent({
 		 * Pass null to clear the input field.
 		 */
 		modelValue: {
-			type: Date,
+			type: [Date, null],
 			default: null,
 		},
 
@@ -159,7 +159,7 @@ export default defineComponent({
 		 * default type: null
 		 */
 		min: {
-			type: [Date, Boolean],
+			type: [Date, Boolean, null],
 			default: null,
 		},
 		/**
@@ -167,7 +167,7 @@ export default defineComponent({
 		 * default type: null
 		 */
 		max: {
-			type: [Date, Boolean],
+			type: [Date, Boolean, null],
 			default: null,
 		},
 		/**


### PR DESCRIPTION
### ☑️ Resolves

- Fix TS errors in typed components
  - NcChip: `variant` is optional
  - NcDateTimePicker: `modelValue`, `min` and `max` are nullable

So far noticed only these
### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
