### PR TITLE
fix(NcPopover): component crash when unmounted shown

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -565,7 +565,16 @@ export default {
 			this.addEscapeStopPropagation()
 		},
 		afterHide() {
-			this.getPopoverContentElement().addEventListener('transitionend', () => {
+			/**
+			 * On component unmounting Vue:
+			 * 1. Resets the template ref to null
+			 * 2. Triggers <Dropdown> `beforeUnmount` - it emits `apply-hide` event
+			 *   2.1. At that moment this.$refs.popover is null already, and we cannot use `this.getPopoverContentElement()`
+			 *   2.2. We can ignore emitting `after-hide` event (was also not the case on stable8)
+			 * 3. Actually removes <Dropdown> node
+			 * 4. Triggers <Dropdown> `unmounted`
+			 */
+			this.getPopoverContentElement()?.addEventListener('transitionend', () => {
 				/**
 				 * Triggered after the tooltip was visually hidden.
 				 *


### PR DESCRIPTION
### ☑️ Resolves

`getPopoverContentElement()` can be undefined, so it should not fail when trying to add a listener


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
