### PR TITLE
fix(NcListItem): let `active` prop take higher priority

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -438,7 +438,7 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 		v-slot="{ href: routerLinkHref, navigate, isActive }"
 		v-bind="{ ...to && { custom: true, to } }">
 		<li class="list-item__wrapper"
-			:class="{ 'list-item__wrapper--active' : isActive || active }"
+			:class="{ 'list-item__wrapper--active' : active ?? isActive }"
 			v-bind="$attrs">
 			<div ref="list-item"
 				class="list-item"
@@ -487,7 +487,7 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 								class="list-item-details__extra">
 								<NcCounterBubble v-if="counterNumber !== 0"
 									:count="counterNumber"
-									:active="isActive || active"
+									:active="active ?? isActive"
 									class="list-item-details__counter"
 									:type="counterType" />
 
@@ -510,7 +510,7 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 					class="list-item-content__actions"
 					@focusout="handleBlur">
 					<NcActions ref="actions"
-						:primary="isActive || active"
+						:primary="active ?? isActive"
 						:force-menu="forceMenu"
 						:aria-label="actionsAriaLabel"
 						@update:open="handleActionsUpdateOpen">
@@ -615,7 +615,7 @@ export default {
 		 */
 		active: {
 			type: Boolean,
-			default: false,
+			default: undefined,
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

- If we pass `:active="false` and current item has an active path, it will bypass the explicit prop. This is also needed as vue-router 4 active [changing behavior](https://router.vuejs.org/guide/migration/#Removal-of-the-exact-prop-in-router-link-) where there is a wider range of paths considered active -> we rely more on prop to better maintain the previous behavior. 


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
