### PR TITLE
fix(NcRichContentEditable): wait for input to focus so it can show tribute correctly

### DIFF
--- a/src/components/NcRichContenteditable/NcRichContenteditable.vue
+++ b/src/components/NcRichContenteditable/NcRichContenteditable.vue
@@ -950,9 +950,14 @@ export default {
 		 */
 		showTribute(trigger) {
 			this.focus()
-			const index = this.tribute.collection.findIndex(collection => collection.trigger === trigger)
-			this.tribute.showMenuForCollection(this.$refs.contenteditable, index)
-			this.updateValue(this.$refs.contenteditable.innerHTML)
+			// For an unknown reason in Vue 3 calling `tribute.showMenuForCollection` immediately after `contenteditable.focus()` 
+			// results in the wrong positioning.
+			// Waiting one animation frame for focusing fixes the issue.
+			requestAnimationFrame(() => {
+				const index = this.tribute.collection.findIndex(collection => collection.trigger === trigger)
+				this.tribute.showMenuForCollection(this.$refs.contenteditable, index)
+				this.updateValue(this.$refs.contenteditable.innerHTML)
+			})
 			document.addEventListener('click', this.hideTribute, true)
 		},
 


### PR DESCRIPTION
### ☑️ Resolves

### 🖼️ Screenshots

🏚️ Before

https://github.com/user-attachments/assets/84698410-8df3-43c2-b2f0-09faf8747eb2


🏡 After

https://github.com/user-attachments/assets/e7726744-5462-49a6-a128-c574833006ad




### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
