### PR TITLE
fix(NcActions + NcEmojiPicker): no focus-trap when needed, extra focus-trap when not

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1773,7 +1773,7 @@ export default {
 					popoverBaseClass: 'action-item__popper',
 					popupRole: this.config.popupRole,
 					setReturnFocus: this.config.withFocusTrap ? this.$refs.triggerButton?.$el : undefined,
-					focusTrap: this.config.withFocusTrap,
+					noFocusTrap: !this.config.withFocusTrap,
 					'onUpdate:shown': this.toggleMenu,
 					onAfterShow: this.onOpened,
 					onAfterClose: this.onClosed,

--- a/src/components/NcEmojiPicker/NcEmojiPicker.vue
+++ b/src/components/NcEmojiPicker/NcEmojiPicker.vue
@@ -111,7 +111,7 @@ This component allows the user to pick an emoji.
 		v-model:shown="open"
 		:container="container"
 		popup-role="dialog"
-		:focus-trap="false /* Handled manually to remove emoji buttons from TAB sequence */"
+		:no-focus-trap="true /* Handled manually to remove emoji buttons from TAB sequence */"
 		@after-show="afterShow"
 		@after-hide="afterHide">
 		<template #trigger="slotProps">


### PR DESCRIPTION
### ☑️ Resolves

- Alternative to: https://github.com/nextcloud-libraries/nextcloud-vue/pull/7090
- Regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/6807/
  - Migration was missing

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
