### PR TITLE
fix(NcRichText): adjust markdown styles after migration

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -614,12 +614,14 @@ export default {
 .rich-text--wrapper-markdown {
 	tab-size: 4;
 
-	div > *:first-child,
-	blockquote > *:first-child {
+	& > :first-child,
+	div > :first-child,
+	blockquote > :first-child {
 		margin-top: 0 !important;
 	}
-	div > *:last-child,
-	blockquote > *:last-child {
+	& > :last-child,
+	div > :last-child,
+	blockquote > :last-child {
 		margin-block-end: 0 !important;
 	}
 


### PR DESCRIPTION
### ☑️ Resolves

- top children of .rich-text--wrapper-markdown is now a fragment instead of div in Vue 2

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/55003295-3822-4ae1-8fb4-2c8cbb0ae670) | ![image](https://github.com/user-attachments/assets/43d63ca3-e3e1-4729-b386-798eac6a0e36)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
