### PR TITLE
fix(useHotKey): allow to pass key codes ('a' as 'KeyA')

### DIFF
--- a/docs/composables/useHotKey.md
+++ b/docs/composables/useHotKey.md
@@ -37,6 +37,7 @@ where:
 
 <template>
 	<div class="container">
+		<p class="description">{{ loggedKey }}</p>
 		<p class="description">Press <kbd>W</kbd> <kbd>S</kbd> <kbd>A</kbd> <kbd>D</kbd> keys to move the ball</p>
 		<div class="square">
 			<div class="circle" :style="{ left: `${circleX}px`, top: `${circleY}px` }"></div>
@@ -57,11 +58,35 @@ where:
 	import { ref } from 'vue'
 	import { useHotKey } from '../../src/composables/useHotKey/index.js'
 
+	const isMac = /mac|ipad|iphone|darwin/i.test(navigator.userAgent)
+
 	export default {
 		setup() {
+			const loggedKey = ref('Press any key')
 			const circleX = ref(20)
 			const circleY = ref(20)
 			const highlighted = ref(false)
+
+			const updateLoggedKey = (event) => {
+				if (['Ctrl', 'Meta', 'Alt', 'Shift'].includes(event.key)) {
+					return
+				}
+
+				loggedKey.value = `Key pressed: ${event.key} | `
+				if (event.ctrlKey) {
+					loggedKey.value += 'Ctrl + '
+				}
+				if (event.metaKey) {
+					loggedKey.value += isMac ? 'Cmd + ' : 'Meta + '
+				}
+				if (event.altKey) {
+					loggedKey.value += 'Alt + '
+				}
+				if (event.shiftKey) {
+					loggedKey.value += 'Shift + '
+				}
+				loggedKey.value += event.code
+			}
 
 			const moveUp = (event) => {
 				circleY.value = Math.max(0, circleY.value - 10)
@@ -79,13 +104,15 @@ where:
 				highlighted.value = !highlighted.value
 			}
 
-			useHotKey('w', moveUp)
-			useHotKey('s', moveDown)
-			useHotKey('a', moveLeft)
-			useHotKey('d', moveRight)
+			useHotKey(true, updateLoggedKey)
+			useHotKey(['w', 'KeyW'], moveUp)
+			useHotKey(['s', 'KeyS'], moveDown)
+			useHotKey(['a', 'KeyA'], moveLeft)
+			useHotKey(['d', 'KeyD'], moveRight)
 			const stop = useHotKey('m', toggleHighlighted, { push: true })
 
 			return {
+				loggedKey,
 				circleX,
 				circleY,
 				highlighted,

--- a/src/composables/useHotKey/index.ts
+++ b/src/composables/useHotKey/index.ts
@@ -135,6 +135,7 @@ export function useHotKey(
 			return event.key === key
 		}
 		return event.key.toLowerCase() === key.toLowerCase()
+			|| event.code === key
 	}
 
 	/**


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/spreed/issues/15393
- Allows to use hotkeys on non-latin keyboards
- Since validator accepts string arrays,  `['w', 'KeyW']` is backward-compatible with `'w'`, but can also be replaced with `'KeyW'`

### 🖼️ Screenshots

en | ru | de
-- | -- | --
![image](https://github.com/user-attachments/assets/25b79c6a-7f21-4bb5-a036-e5e9d10affc3) | ![image](https://github.com/user-attachments/assets/ea2fded7-2282-493e-b982-023280c00a71) | ![image](https://github.com/user-attachments/assets/bbb9cc81-4de7-409c-b909-c06d75246579)



### 🚧 Tasks

- [ ] AFAIK we do not use keys that occure mixed in different layouts (e.g. QWERTZ or AZERTY). Would it be an issue?

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
