### PR TITLE
fix(NcActionText): remove br between action name and action long text

### DIFF
--- a/src/components/NcActionText/NcActionText.vue
+++ b/src/components/NcActionText/NcActionText.vue
@@ -22,7 +22,6 @@
 				<strong class="action-text__name">
 					{{ name }}
 				</strong>
-				<br>
 				<!-- white space is shown on longtext, so we can't
 				put {{ text }} on a new line for code readability -->
 				<span class="action-text__longtext" v-text="text" />


### PR DESCRIPTION
### ☑️ Resolves

The `br` adds too much space between `action-text__name` and `action-text__longtext`. Talk app and Mail app use NcActionText and so far we could find only these apps where it breaks.

On [NcActionButton](https://github.com/nextcloud-libraries/nextcloud-vue/pull/6932) Maksim solved it by adding a description prop, but in our case the entry is fully informational and standalone([cn](https://github.com/nextcloud/mail/pull/11347#issuecomment-3027766033)).

### 🖼️ Screenshots

🏚️ Before | 🏡 After
![Screenshot from 2025-07-02 13-50-44](https://github.com/user-attachments/assets/3757c6f7-93c7-4fef-b4d6-d557cc5e186f)|![Screenshot from 2025-07-02 16-37-12](https://github.com/user-attachments/assets/73594819-b5fd-425d-9fea-c6ac0989b103)


![Screenshot from 2025-07-02 12-35-21](https://github.com/user-attachments/assets/bcf8e914-c8a0-4296-b040-009ce8363d0f)
![Screenshot from 2025-07-02 12-35-41](https://github.com/user-attachments/assets/d059efc9-3020-4264-9e15-e3d83550d876)



### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
