### PR TITLE
fix(NcNoteCard): too large icon padding

### DIFF
--- a/src/components/NcNoteCard/NcNoteCard.vue
+++ b/src/components/NcNoteCard/NcNoteCard.vue
@@ -125,7 +125,8 @@ const iconPath = computed(() => {
 		<slot name="icon">
 			<NcIconSvgWrapper :path="iconPath"
 				class="notecard__icon"
-				:class="{ 'notecard__icon--heading': heading }" />
+				:class="{ 'notecard__icon--heading': heading }"
+				inline />
 		</slot>
 		<div>
 			<p v-if="heading" class="notecard__heading">


### PR DESCRIPTION
### ☑️ Resolves

- Fix #7117

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/a99e4168-6f5d-4222-837e-f281f1a92e98) | ![grafik](https://github.com/user-attachments/assets/ba5b730d-1ccd-4789-b8d8-e790c53dd526)


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
