### PR TITLE
refactor!: remove `useFormatDateTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,8 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
 - `Tooltip` directive was deprecated in v8 and is now removed.
   This was done in favor of native tooltips using the `title` attribute, which is better for accessibility.
   If you really need custom formatted tooltips, you can use `NcPopover` instead.
+- The `useFormatDateTime` composable - only exported from default entry point - is removed.
+  Instead you can now use `useFormatTime` for formatting a time to a local date string or `useFormatRelativeTime` to format it to a humanized string like *a day ago*.
 
 ### 🚀 Enhancements
 * Allow writing components using Typescript and provide type definitions for `NcButton` [\#4525](https://github.com/nextcloud-libraries/nextcloud-vue/pull/4525) \([susnux](https://github.com/susnux)\)

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -4,7 +4,6 @@
  */
 
 export {
-	useFormatDateTime,
 	useFormatRelativeTime,
 	useFormatTime,
 } from './useFormatDateTime/index.ts'

--- a/src/composables/useFormatDateTime/index.ts
+++ b/src/composables/useFormatDateTime/index.ts
@@ -35,24 +35,6 @@ interface FormatTimeOptions {
 	format?: Intl.DateTimeFormatOptions
 }
 
-/**
- * @deprecated
- */
-interface LegacyFormatDateTimeOptions {
-	/**
-	 * The format used for displaying, or if relative time is used the format used for the title
-	 */
-	format?: Intl.DateTimeFormatOptions
-	/**
-	 * Ignore seconds when displaying the relative time and just show `a few seconds ago`
-	 */
-	ignoreSeconds?: boolean
-	/**
-	 * Wether to display the timestamp as time from now
-	 */
-	relativeTime?: false | 'long' | 'short' | 'narrow'
-}
-
 const FEW_SECONDS_AGO = {
 	long: t('a few seconds ago'),
 	short: t('seconds ago'), // FOR TRANSLATORS: Shorter version of 'a few seconds ago'
@@ -139,41 +121,4 @@ export function useFormatTime(
 	const formatter = computed(() => new Intl.DateTimeFormat(options.value.locale, options.value.format))
 
 	return computed(() => formatter.value.format(toValue(timestamp)))
-}
-
-/**
- * Composable for formatting time stamps using current users locale and language
- *
- * @param {import('vue').MaybeRefOrGetter<Date | number>} timestamp Current timestamp
- * @param {object} opts Optional options
- * @param {Intl.DateTimeFormatOptions} opts.format The format used for displaying, or if relative time is used the format used for the title (optional)
- * @param {boolean} opts.ignoreSeconds Ignore seconds when displaying the relative time and just show `a few seconds ago`
- * @param {false | 'long' | 'short' | 'narrow'} opts.relativeTime Wether to display the timestamp as time from now (optional)
- *
- * @deprecated use `useFormatRelativeTime` or `useFormatTime` instead.
- */
-export function useFormatDateTime(
-	timestamp: MaybeRefOrGetter<Date|number> = Date.now(),
-	opts: MaybeRefOrGetter<LegacyFormatDateTimeOptions> = {},
-) {
-	const formattedFullTime = useFormatTime(timestamp, opts)
-	const relativeTime = useFormatRelativeTime(timestamp, computed(() => {
-		const options = toValue(opts)
-		return {
-			...options,
-			relativeTime: typeof options.relativeTime === 'string'
-				? options.relativeTime
-				: 'long',
-		}
-	}))
-
-	const formattedTime = computed(() => toValue(opts).relativeTime !== false
-		? relativeTime.value
-		: formattedFullTime.value,
-	)
-
-	return {
-		formattedTime,
-		formattedFullTime,
-	}
 }

--- a/tests/unit/composables/useFormatDateTime.spec.js
+++ b/tests/unit/composables/useFormatDateTime.spec.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { useFormatDateTime, useFormatRelativeTime } from '../../../src/composables/useFormatDateTime/index.ts'
-import { computed, isRef, nextTick, ref } from 'vue'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFormatRelativeTime } from '../../../src/composables/useFormatDateTime/index.ts'
+import { computed, nextTick, ref } from 'vue'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('useFormatRelativeTime composable', () => {
 	const time = Date.parse('2025-01-01T00:00:00Z')
@@ -77,72 +77,5 @@ describe('useFormatRelativeTime composable', () => {
 		const options = { ignoreSeconds: true, relativeTime: format }
 		const formatted = useFormatRelativeTime(time, options)
 		expect(formatted.value).toBe(expected)
-	})
-})
-
-describe('useFormatDateTime composable', () => {
-	beforeAll(() => {
-		vi.spyOn(console, 'error').mockImplementation(() => {})
-		vi.useFakeTimers({ now: new Date('2025-01-01T00:00:00Z') })
-	})
-
-	afterAll(() => {
-		vi.restoreAllMocks()
-	})
-
-	it('Should provide formatted time and options as ref', () => {
-		const ctx = useFormatDateTime()
-		expect(isRef(ctx.formattedTime)).toBe(true)
-		expect(isRef(ctx.formattedFullTime)).toBe(true)
-	})
-
-	it('Shows relative times', async () => {
-		const time = ref(Date.now())
-		const ctx = useFormatDateTime(time, { ignoreSeconds: false, relativeTime: 'long' })
-		expect(ctx.formattedTime.value).toContain('now')
-		time.value = Date.now() - 5000
-		await nextTick()
-		expect(ctx.formattedTime.value).toMatch(/\d sec/)
-		time.value = Date.now() - 120000
-		await nextTick()
-		expect(ctx.formattedTime.value).toContain('2 minutes')
-		time.value = Date.now() - 2 * 60 * 60 * 1000
-		await nextTick()
-		expect(ctx.formattedTime.value).toContain('2 hours')
-		time.value = Date.now() - 2 * 24 * 60 * 60 * 1000
-		await nextTick()
-		expect(ctx.formattedTime.value).toContain('2 days')
-		time.value = Date.now() - 2 * 7 * 24 * 60 * 60 * 1000
-		await nextTick()
-		expect(ctx.formattedTime.value).toContain('2 weeks')
-		time.value = Date.now() - 2 * 30 * 24 * 60 * 60 * 1000
-		await nextTick()
-		expect(ctx.formattedTime.value).toContain('November 2')
-		time.value = Date.now() - 2 * 365 * 24 * 60 * 60 * 1000
-		await nextTick()
-		expect(ctx.formattedTime.value).toContain('January 2023')
-	})
-
-	it('Shows different relative times', async () => {
-		const options = ref({ ignoreSeconds: true, relativeTime: 'long' })
-		const ctx = useFormatDateTime(Date.now() - 5000, options)
-		expect(ctx.formattedTime.value).toBe('a few seconds ago')
-		options.value.relativeTime = 'short'
-		await nextTick()
-		expect(ctx.formattedTime.value).toBe('seconds ago')
-		options.value.relativeTime = 'narrow'
-		await nextTick()
-		expect(ctx.formattedTime.value).toBe('sec. ago')
-	})
-
-	it('Should be reactive on options change', async () => {
-		const options = ref({ ignoreSeconds: false })
-		const ctx = useFormatDateTime(Date.now() - 5000, options)
-
-		expect(ctx.formattedTime.value).toContain('sec')
-
-		options.value.ignoreSeconds = true
-		await nextTick()
-		expect(ctx.formattedTime.value).toBe('a few seconds ago')
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

We now have `useFormatTime` and `useFormatRelativeTime` instead. This was never exported¹ thus its not breaking.

¹ because our exports pattern requires a subfolder e.g. `composables/NAME/index.ts` and not just the file itself like `composables/NAME.ts`.

**EDIT** It was not exported as entry point but it was exported in the default entry point, thus it is breaking and thus v9 only.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
