### PR TITLE
fix(l10n): adjust for `@nextcloud/l10n` v3.4.0

### DIFF
--- a/build/l10n-plugin.mts
+++ b/build/l10n-plugin.mts
@@ -100,8 +100,9 @@ export default (dir: string) => {
 				const exports = Object.entries(nameMap).map(([usage, id]) => `export const ${id} = ${JSON.stringify(translations[usage])}`).join(';\n')
 				return `import { getLanguage } from '@nextcloud/l10n'
 import { getGettextBuilder } from '@nextcloud/l10n/gettext'
-const builder = getGettextBuilder().setLanguage(getLanguage())
-let gettext = builder.build()
+const gettext = getGettextBuilder()
+	.detectLanguage()
+	.build()
 
 export const n = (...args) => gettext.ngettext(...args)
 export const t = (...args) => gettext.gettext(...args)
@@ -127,14 +128,11 @@ export function register(...chunks) {
 					])
 				)
 
-				gettext = builder.addTranslation(getLanguage(), {
+				gettext.addTranslations({
 					translations: {
-						'': {
-							...(gettext.bundle.translations?.[''] ?? {}),
-							...decompressed,
-						},
+						'': decompressed,
 					},
-				}).build()
+				})
 			}
 			chunk.registered = true
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/initial-state": "^2.2.0",
-        "@nextcloud/l10n": "^3.3.0",
+        "@nextcloud/l10n": "^3.4.0",
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
@@ -3460,9 +3460,9 @@
       }
     },
     "node_modules/@nextcloud/l10n": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.3.0.tgz",
-      "integrity": "sha512-gPvAf5gzqxjnk8l6kr8LQTMN3lv5CLN8tTWwMfavmTbPsKj2/ZUjZhwIm3PcZ3xvJzBi7Ttgrf9xz5cT6CGsWg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-3.4.0.tgz",
+      "integrity": "sha512-K4UBSl0Ou6sXXLxyjuhktRf2FyTCjyvHxJyBLmS2z3YEYcRkpf8ib3XneRwEQIEpzBPQjul2/ZdFlt7umd8Gaw==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/router": "^3.0.1",
@@ -3472,8 +3472,7 @@
         "escape-html": "^1.0.3"
       },
       "engines": {
-        "node": "^22.0.0",
-        "npm": "^10.5.1"
+        "node": "^20 || ^22 || ^24"
       }
     },
     "node_modules/@nextcloud/logger": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@nextcloud/capabilities": "^1.2.0",
     "@nextcloud/event-bus": "^3.3.2",
     "@nextcloud/initial-state": "^2.2.0",
-    "@nextcloud/l10n": "^3.3.0",
+    "@nextcloud/l10n": "^3.4.0",
     "@nextcloud/logger": "^3.0.2",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/sharing": "^0.2.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -66,6 +66,8 @@ export default defineConfig({
 				(await import('vite-plugin-node-polyfills')).nodePolyfills(),
 				// We need to strip off the docs sections for the vue plugin
 				(await import('./build/docs-plugin.ts')).default,
+				// Also add the l10n plugin so we can test translations
+				(await import('./build/l10n-plugin.mts')).default('l10n'),
 			],
 			define: {
 				appName: '"exampleApp"',

--- a/tests/component/components/NcRichContenteditable.spec.ts
+++ b/tests/component/components/NcRichContenteditable.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '@playwright/experimental-ct-vue'
+import NcRichContenteditable from '../../../src/components/NcRichContenteditable/NcRichContenteditable.vue'
+
+test('Placeholder is set', async ({ mount, page }) => {
+	await mount(NcRichContenteditable, {
+		props: {
+			modelValue: '',
+		},
+	})
+
+	await expect(page.getByRole('textbox')).toBeVisible()
+	await expect(page.getByRole('textbox')).toHaveAttribute('aria-placeholder', 'Write a message …')
+})
+
+test('Placeholder is correctly translated', async ({ mount, page }) => {
+	await page.addScriptTag({ content: 'document.documentElement.lang = "de";' })
+
+	await mount(NcRichContenteditable, {
+		props: {
+			modelValue: '',
+		},
+	})
+
+	await expect(page.getByRole('textbox')).toBeVisible()
+	await expect(page.getByRole('textbox')).toHaveAttribute('aria-placeholder', 'Nachricht schreiben …')
+})

--- a/tests/unit/components/NcDateTime/NcDateTime.spec.js
+++ b/tests/unit/components/NcDateTime/NcDateTime.spec.js
@@ -7,6 +7,7 @@ import { mount } from '@vue/test-utils'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import NcDateTime from '../../../../src/components/NcDateTime/NcDateTime.vue'
 import { nextTick } from 'vue'
+import { setLanguage } from '@nextcloud/l10n'
 
 const getCanonicalLocale = vi.hoisted(() => vi.fn(() => 'en-US'))
 
@@ -87,11 +88,11 @@ describe('NcDateTime.vue', () => {
 	describe('Work with different languages', () => {
 		beforeAll(() => {
 			// mock the language
-			document.documentElement.lang = 'de'
+			setLanguage('de')
 		})
 		afterAll(() => {
 			// revert mock
-			document.documentElement.lang = 'en'
+			setLanguage('en')
 		})
 
 		it('Works with relative timestamps', () => {

--- a/tests/unit/utils/l10n.spec.ts
+++ b/tests/unit/utils/l10n.spec.ts
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+import { setLanguage } from '@nextcloud/l10n'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 describe('Custom L10n plugin is working', () => {
@@ -13,7 +15,7 @@ describe('Custom L10n plugin is working', () => {
 	})
 
 	test('Other translation', async () => {
-		document.documentElement.lang = 'de'
+		setLanguage('de')
 		const { defaultPalette } = await import('../../../src/utils/colors.ts')
 
 		expect(defaultPalette[1].name).toBe('Rosiges Braun')


### PR DESCRIPTION
### ☑️ Resolves

- Requires https://github.com/nextcloud-libraries/nextcloud-l10n/pull/953

This fixes some components not being translated correctly.
Also the gettext wrapper is only created once (performance).

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
