### PR TITLE
style(NcRichText): consider reference widgets in markdown styles

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -613,6 +613,7 @@ export default {
 		margin-top: 0 !important;
 	}
 	& > :last-child,
+	& > *:has(+ .rich-text--reference-widget),
 	div > :last-child,
 	blockquote > :last-child {
 		margin-block-end: 0 !important;


### PR DESCRIPTION
### ☑️ Resolves

- Follow-up to #7106
- last child of .rich-text--wrapper-markdown might be .rich-text--reference-widget, which breaks styles for expected :last-child

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="388" height="282" alt="image" src="https://github.com/user-attachments/assets/084a3bed-961d-4b86-b531-9824fd0a121f" /> | <img width="383" height="227" alt="image" src="https://github.com/user-attachments/assets/11ce958c-dd91-460e-a9db-1ee26da7e9f3" />

### 🚧 Tasks

- [x] Test in actual app 🙈 

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
