### PR TITLE
fix(NcListItem): correctly handle unmounting

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -776,7 +776,9 @@ export default {
 				return
 			}
 			// do not hide if focus is kept within
-			if (this.$refs['list-item'].contains(event.relatedTarget)) {
+			// On component unmounting Vue 3 resets the template ref to null,
+			// so we can ignore this check
+			if (this.$refs['list-item']?.contains(event.relatedTarget)) {
 				return
 			}
 			this.hideActions()


### PR DESCRIPTION
### ☑️ Resolves

- Similar to #7077 
- When component is unmonted, `$refs.name` is null and therefore can no longer be used

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="530" height="77" alt="image" src="https://github.com/user-attachments/assets/976dfd5d-d56a-49bc-a6f7-4e0edbc054c3" /> | A

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
