### PR TITLE
fix(NcInputField): remove browser injected clear button

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -345,6 +345,20 @@ function handleInput(event: Event) {
 			color: var(--color-text-maxcontrast);
 		}
 
+		// prevent Blink and WebKit to add an additional button when type is set to search
+		// we have our properly styled trailing button anyways.
+		&::-webkit-search-cancel-button {
+			// its a weird bug in Blink that this rule must not be grouped with the other selectors below.
+			// otherwise it is not recognized by Blink
+			display: none;
+		}
+		&::-webkit-search-decoration,
+		&::-webkit-search-results-button,
+		&::-webkit-search-results-decoration,
+		&::-ms-clear {
+			display: none;
+		}
+
 		&:active:not([disabled]),
 		&:hover:not([disabled]),
 		&:focus:not([disabled]) {


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/7133

Ensure that **all** browsers show **our** clear button instead of some non-themed clear button of the browser implementation. This only happened for search boxes.

### 🖼️ Screenshots

🏚️ Before (firefox) | 🏚️ Before (chrome) | 🏡 After (all!)
---|---|---
<img width="376" height="75" alt="Bildschirmfoto_20250716_160118" src="https://github.com/user-attachments/assets/26513c6a-5c8d-4364-966b-585439e607d8" /> | <img width="376" height="75" alt="Bildschirmfoto_20250716_160124" src="https://github.com/user-attachments/assets/4ffe13c0-994a-4fc9-8ce9-074ebe5c9a0a" /> | <img width="376" height="75" alt="Bildschirmfoto_20250716_160118" src="https://github.com/user-attachments/assets/26513c6a-5c8d-4364-966b-585439e607d8" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
