### PR TITLE
refactor(NcRichText): use `debounce` instead of custom delay function

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcRawLinkInput.vue
@@ -33,17 +33,16 @@
 </template>
 
 <script>
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+import debounce from 'debounce'
+import LinkVariantIcon from 'vue-material-design-icons/LinkVariant.vue'
 import NcReferenceWidget from '../NcReferenceWidget.vue'
-import { isUrl, delay } from './utils.js'
 import NcEmptyContent from '../../NcEmptyContent/index.ts'
 import NcLoadingIcon from '../../NcLoadingIcon/index.ts'
 import NcTextField from '../../NcTextField/index.ts'
+import { isUrl } from './utils.ts'
 import { t } from '../../../l10n.js'
-
-import axios from '@nextcloud/axios'
-import { generateOcsUrl } from '@nextcloud/router'
-
-import LinkVariantIcon from 'vue-material-design-icons/LinkVariant.vue'
 
 export default {
 	name: 'NcRawLinkInput',
@@ -79,6 +78,9 @@ export default {
 		isLinkValid() {
 			return isUrl(this.inputValue)
 		},
+		debouncedUpdateReference() {
+			return debounce(this.updateReference, 500)
+		},
 	},
 	methods: {
 		focus() {
@@ -100,9 +102,7 @@ export default {
 				this.abortController.abort()
 			}
 			if (this.isLinkValid) {
-				delay(() => {
-					this.updateReference()
-				}, 500)()
+				this.debouncedUpdateReference()
 			}
 		},
 		updateReference() {

--- a/src/components/NcRichText/NcReferencePicker/NcSearch.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcSearch.vue
@@ -68,18 +68,16 @@
 </template>
 
 <script>
-import NcSearchResult from './NcSearchResult.vue'
-import { isUrl, delay } from './utils.js'
-import NcEmptyContent from '../../NcEmptyContent/index.ts'
-import NcSelect from '../../NcSelect/index.js'
-
-import { t } from '../../../l10n.js'
-
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-
+import debounce from 'debounce'
 import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
 import LinkVariantIcon from 'vue-material-design-icons/LinkVariant.vue'
+import NcSearchResult from './NcSearchResult.vue'
+import NcEmptyContent from '../../NcEmptyContent/index.ts'
+import NcSelect from '../../NcSelect/index.js'
+import { isUrl } from './utils.ts'
+import { t } from '../../../l10n.js'
 
 const LIMIT = 5
 
@@ -183,6 +181,9 @@ export default {
 			})
 			return results
 		},
+		debouncedUpdateSearch() {
+			return debounce(this.updateSearch, 500)
+		},
 	},
 	mounted() {
 		this.resetResults()
@@ -213,9 +214,7 @@ export default {
 		},
 		onSearchInput(query) {
 			this.searchQuery = query
-			delay(() => {
-				this.updateSearch()
-			}, 500)()
+			this.debouncedUpdateSearch()
 		},
 		onSelectResultSelected(item) {
 			if (item !== null) {

--- a/src/components/NcRichText/NcReferencePicker/utils.ts
+++ b/src/components/NcRichText/NcReferencePicker/utils.ts
@@ -1,22 +1,7 @@
-/**
+/*!
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-let timerId: number | undefined
-
-/**
- * @param callback - The callback to call after the delay
- * @param ms - The delay in milliseconds
- */
-export function delay<P extends Array<unknown>, R>(callback: (...args: P) => R, ms: number): (...args: P) => void {
-	return (...args) => {
-		window.clearTimeout(timerId)
-		timerId = window.setTimeout(() => {
-			callback(...args)
-		}, ms)
-	}
-}
 
 /**
  * Check wether a given string is a valid URL.


### PR DESCRIPTION
### ☑️ Resolves

- Resolves https://github.com/nextcloud-libraries/nextcloud-vue/pull/7173#discussion_r2213229073

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
