### PR TITLE
fix(NcModal): use `--border-radius-container`

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -1016,7 +1016,7 @@ export default {
 		display: flex;
 		padding: 0;
 		transition: transform 300ms ease;
-		border-radius: var(--border-radius-large);
+		border-radius: var(--border-radius-container, var(--border-radius-rounded));
 		background-color: var(--color-main-background);
 		color: var(--color-main-text);
 		box-shadow: 0 0 40px rgba(0, 0, 0, .2);


### PR DESCRIPTION
### ☑️ Resolves

- resolves https://github.com/nextcloud-libraries/nextcloud-vue/issues/7175

> Currently, the border radius is quite low and eg. the close button doesn't nest nicely within it.
> If I see it correctly, with 4px of padding around it, the outer radius should be 12px (8+4).

### :framed_picture: Screenshots

before | after
---|---
<img width="1075" height="652" alt="Screenshot 2025-07-17 at 22-01-15 Nextcloud Vue Style Guide" src="https://github.com/user-attachments/assets/73f3f562-27f6-4ad9-b39e-f99896debb84" />|<img width="1075" height="652" alt="Screenshot 2025-07-17 at 22-00-56 Nextcloud Vue Style Guide" src="https://github.com/user-attachments/assets/aa4d2fd0-d1f7-4ae9-b60e-23af4aeea5c9" />


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
