### PR TITLE
fix(NcAppSidebar): remove slot styling for buttons in the description

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -1566,17 +1566,3 @@ $desc-height: $desc-name-height + $desc-subname-height;
 	margin-inline-end: calc(-1 * var(--app-sidebar-width));
 }
 </style>
-
-<style lang="scss">
-// ! slots specific designs, cannot be scoped
-// if any button inside the description slot, increase visual padding
-.app-sidebar-header__description {
-	button, .button,
-	input[type='button'],
-	input[type='submit'],
-	input[type='reset'] {
-		padding: 6px 22px;
-	}
-}
-
-</style>


### PR DESCRIPTION
### ☑️ Resolves

1. this probably was meant to center some icons within the button (22px sounds like it was the legacy 44px clickable area / 2).
2. but this breaks usage of any component within that slot.

Users of the component should rather self implement padding for their custom buttons if they need them

### 🖼️ Screenshots

The problem:
<img width="552" height="318" alt="Bildschirmfoto_20250718_155239" src="https://github.com/user-attachments/assets/fc87b668-09a3-4b69-9d09-999888dc84c0" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
