### PR TITLE
fix(useIsDarkTheme): provide default value to silence runtime warnings

### DIFF
--- a/src/composables/useIsDarkTheme/constants.ts
+++ b/src/composables/useIsDarkTheme/constants.ts
@@ -10,4 +10,4 @@ import type { ComputedRef, InjectionKey } from 'vue'
  *
  * @private
  */
-export const INJECTION_KEY_THEME: InjectionKey<ComputedRef<'light' | 'dark' | ''>> = Symbol.for('nc:theme:enforced')
+export const INJECTION_KEY_THEME: InjectionKey<ComputedRef<'light' | 'dark' | ''> | undefined> = Symbol.for('nc:theme:enforced')

--- a/src/composables/useIsDarkTheme/index.ts
+++ b/src/composables/useIsDarkTheme/index.ts
@@ -54,7 +54,7 @@ const useInternalIsDarkTheme = createSharedComposable(() => useIsDarkThemeElemen
  */
 export function useIsDarkTheme(): DeepReadonly<Ref<boolean>> {
 	const isDarkTheme = useInternalIsDarkTheme()
-	const enforcedTheme = inject(INJECTION_KEY_THEME)
+	const enforcedTheme = inject(INJECTION_KEY_THEME, undefined)
 
 	return computed(() => {
 		if (enforcedTheme?.value) {


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/pull/6764#discussion_r2217310037

Otherwise if no `NcThemeProvider` is used a runtime warning is shown in the dev tools console.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
