### PR TITLE
fix(NcAvatar): contacts menu is broken

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -160,14 +160,7 @@ export default {
 			'avatardiv--with-menu-loading': contactsMenuLoading
 		}"
 		:style="avatarStyle"
-		class="avatardiv popovermenu-wrapper"
-		:tabindex="hasMenu ? '0' : undefined"
-		:aria-label="avatarAriaLabel"
-		:role="hasMenu ? 'button' : undefined"
-		v-on="hasMenu ? {
-			click: toggleMenu,
-			keydown: toggleMenu,
-		} : {}">
+		class="avatardiv popovermenu-wrapper">
 		<!-- @slot Icon slot -->
 		<slot name="icon">
 			<!-- Avatar icon or image -->

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -654,9 +654,7 @@ export default {
 	beforeUnmount() {
 		unsubscribe('settings:avatar:updated', this.loadAvatarUrl)
 		unsubscribe('settings:display-name:updated', this.loadAvatarUrl)
-		if (!this.hideStatus && this.user && !this.isNoUser) {
-			unsubscribe('user_status:status.updated', this.handleUserStatusUpdated)
-		}
+		unsubscribe('user_status:status.updated', this.handleUserStatusUpdated)
 	},
 
 	methods: {

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -494,7 +494,7 @@ export default {
 		 * True if initials should be shown as the user icon fallback
 		 */
 		showInitials() {
-			return !this.noPlaceholder && this.userDoesNotExist && !(this.iconClass || this.$slots.icon?.())
+			return !this.noPlaceholder && this.userDoesNotExist && !(this.iconClass || this.$slots.icon)
 		},
 
 		avatarStyle() {

--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -242,6 +242,7 @@ import { vOnClickOutside as ClickOutside } from '@vueuse/components'
 
 import IconDotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import NcActions from '../NcActions/index.js'
+import NcActionButton from '../NcActionButton/index.js'
 import NcActionLink from '../NcActionLink/index.js'
 import NcActionRouter from '../NcActionRouter/index.js'
 import NcActionText from '../NcActionText/index.js'
@@ -256,6 +257,7 @@ import { getEnabledContactsMenuActions } from '../../functions/contactsMenu/inde
 import { usernameToColor } from '../../functions/usernameToColor/index.ts'
 import { userStatus } from '../../mixins/index.js'
 import { getAvatarUrl } from '../../utils/getAvatarUrl.ts'
+import logger from '../../utils/logger.ts'
 import { getUserStatusText } from '../../utils/UserStatus.ts'
 import { t } from '../../l10n.ts'
 


### PR DESCRIPTION
### ☑️ Resolves

- Add missing imports
  - Regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/6749/
  - <img width="473" height="166" alt="image" src="https://github.com/user-attachments/assets/1251eb9a-c74d-4dd6-9eca-8041f688828a" />
- Contacts menu is not opening
  - Incorrect merge conflict resolving in https://github.com/nextcloud-libraries/nextcloud-vue/pull/5158/
  - Before | After
    -- | --
    ![before](https://github.com/user-attachments/assets/9ebc345c-d987-4cb4-8a18-f272e3819a43) | ![after](https://github.com/user-attachments/assets/c8a0b60c-9d8d-4123-86ee-0e80249fbf67)
- Remove redundant check on unsubscribing
  - Missing backport from https://github.com/nextcloud-libraries/nextcloud-vue/pull/6780
- Do not execute a render function in a computed to check for an icon
  - For Vue 3 migration

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
