### PR TITLE
fix(NcActionInput): lazy load large children

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -240,11 +240,9 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 </template>
 
 <script>
-import NcColorPicker from '../NcColorPicker/index.ts'
-import NcDateTimePicker from '../NcDateTimePicker/index.js'
+import { defineAsyncComponent } from 'vue'
 import NcDateTimePickerNative from '../NcDateTimePickerNative/index.ts'
 import NcPasswordField from '../NcPasswordField/index.ts'
-import NcSelect from '../NcSelect/index.js'
 import NcTextField from '../NcTextField/index.ts'
 import ActionGlobalMixin from '../../mixins/actionGlobal.js'
 import { createElementId } from '../../utils/createElementId.ts'
@@ -254,12 +252,13 @@ export default {
 	name: 'NcActionInput',
 
 	components: {
-		NcColorPicker,
-		NcDateTimePicker,
 		NcDateTimePickerNative,
 		NcPasswordField,
-		NcSelect,
 		NcTextField,
+		// Lazy load components with more than 50kB bundle size impact
+		NcColorPicker: defineAsyncComponent(() => import('../NcColorPicker/index.ts')),
+		NcDateTimePicker: defineAsyncComponent(() => import('../NcDateTimePicker/index.js')),
+		NcSelect: defineAsyncComponent(() => import('../NcSelect/index.js')),
 	},
 
 	mixins: [ActionGlobalMixin],


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud-libraries/nextcloud-vue/issues/7062
- Ref: https://github.com/nextcloud-libraries/nextcloud-vue/pull/4128
- Lazy load every child of `NcActionInput` with more than 50kB individual impact
- `vue` and `@nextcloud/*` libraries are not counted in the impact

| Part                     | Size, kb   |
| ------------------------ | ---------- |
| Self-size                | 10.19      |
| `NcDateTimePickerNative` | 🟩 13.25   |
| `NcTextField`            | 🟩 17.10   |
| `NcPasswordField`        | 🟩 22.23   |
| `NcSelect`               | 🟨 65.24   |
| `NcColorPicker`          | 🟨 76.54   |
| `NcDateTimePicker`       | 🟥 474.83  |
| **TOTAL**                | **543.46** |

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
543.46 kb | 65 kb

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
