### PR TITLE
fix(NcButton): use correct type for `to` prop from VueRouter

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -434,7 +434,7 @@ td.row-size {
 
 <script setup lang="ts">
 import type { Slot } from 'vue'
-import type { RouteLocation } from 'vue-router'
+import type { RouteLocationRaw } from 'vue-router'
 
 import { computed, inject, toRef } from 'vue'
 import { routerKey, useLink } from 'vue-router'
@@ -535,7 +535,7 @@ interface NcButtonProps {
 	 *
 	 * Note: This takes precedence over the href attribute.
 	 */
-	to?: string|RouteLocation
+	to?: RouteLocationRaw
 
 	/**
 	 * Specifies the button native type


### PR DESCRIPTION
### ☑️ Resolves

The correct type is the `RouteLocationRaw` which is a unresolved location - and will be resolved by the router when needed.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
