### PR TITLE
fix(NcContent): flip skip action image in rtl mode

### DIFF
--- a/src/components/NcContent/NcContent.vue
+++ b/src/components/NcContent/NcContent.vue
@@ -219,6 +219,11 @@ function setAppNavigation(value: boolean): void {
 
 	&__image {
 		margin-top: 12px;
+
+		// Flip the image in RTL mode
+		&:dir(rtl) {
+			transform: rotateY(180deg);
+		}
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud/server/issues/48848

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="482" height="490" alt="2025-07-24_19-42_1" src="https://github.com/user-attachments/assets/e8aeef9b-dab4-4113-99de-bc084a3ec675" /> | <img width="478" height="492" alt="2025-07-24_19-42" src="https://github.com/user-attachments/assets/9a59cf6a-36dc-46b1-ba50-7e34fbb6d115" />


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
