### PR TITLE
feat(NcColorPicker): add proper open-state handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,8 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
     and also just duplicated the state of the `open` prop [\#5606](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5606)
 - `NcButton` now does no longer has `role="button"` when used as a link (passing the `href` prop or a router link (`to`)).
    Instead, for accessibility and semantical correctness, has the `link` role.
+- `NcColorPicker`
+  - The deprecated `close` event was removed in favor of the `closed` event, this was done for consistent event names.
 - `NcCounterBubble`
   - The default slot was removed
   - The `count` prop is now required [\#5997](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5997)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,8 +142,6 @@ The `richEditing` mixin can be replaced by just using the `NcRichText` component
     and also just duplicated the state of the `open` prop [\#5606](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5606)
 - `NcButton` now does no longer has `role="button"` when used as a link (passing the `href` prop or a router link (`to`)).
    Instead, for accessibility and semantical correctness, has the `link` role.
-- `NcColorPicker`
-  - The `update:open` event is removed in favor of the already available `close` event.
 - `NcCounterBubble`
   - The default slot was removed
   - The `count` prop is now required [\#5997](https://github.com/nextcloud-libraries/nextcloud-vue/pull/5997)

--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -203,11 +203,6 @@ const emit = defineEmits<{
 	 * The color picker was fully closed and all transitions are finished.
 	 */
 	closed: []
-
-	/**
-	 * @deprecated - use the `closed` event instead.
-	 */
-	close:[]
 }>()
 
 /**
@@ -291,21 +286,13 @@ function hexToRGB(hex: string) {
 		? [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16)]
 		: [0, 0, 0]
 }
-
-/**
- * Callback when all transistions of the closing popover are finished
- */
-function onClosed() {
-	emit('close')
-	emit('closed')
-}
 </script>
 
 <template>
 	<NcPopover v-model:shown="open"
 		:container="container"
 		popup-role="dialog"
-		@apply-hide="onClosed">
+		@apply-hide="emit('closed')">
 		<template #trigger="slotProps">
 			<slot v-bind="slotProps" />
 		</template>

--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -71,7 +71,7 @@ export default {
 <template>
 	<div class="container1">
 		<NcButton @click="open = !open"> Click Me </NcButton>
-		<NcColorPicker v-model="color" v-model:shown="open" v-slot="{ attrs }">
+		<NcColorPicker v-model="color" v-model:open="open" v-slot="{ attrs }">
 			<div v-bind="attrs" :style="{'background-color': color}" class="color1" />
 		</NcColorPicker>
 	</div>
@@ -187,6 +187,11 @@ const props = withDefaults(defineProps<{
  */
 const currentColor = defineModel<string>({ required: true })
 
+/**
+ * The open state of the color picker.
+ */
+const open = defineModel<boolean>('open')
+
 const emit = defineEmits<{
 	/**
 	 * Emitted when the submit button was pressed.
@@ -297,8 +302,9 @@ function onClosed() {
 </script>
 
 <template>
-	<NcPopover popup-role="dialog"
+	<NcPopover v-model:shown="open"
 		:container="container"
+		popup-role="dialog"
 		@apply-hide="onClosed">
 		<template #trigger="slotProps">
 			<slot v-bind="slotProps" />

--- a/src/components/NcColorPicker/NcColorPicker.vue
+++ b/src/components/NcColorPicker/NcColorPicker.vue
@@ -195,9 +195,14 @@ const emit = defineEmits<{
 	submit: [string]
 
 	/**
-	 * The color picker was fully closed.
+	 * The color picker was fully closed and all transitions are finished.
 	 */
-	close: []
+	closed: []
+
+	/**
+	 * @deprecated - use the `closed` event instead.
+	 */
+	close:[]
 }>()
 
 /**
@@ -281,12 +286,20 @@ function hexToRGB(hex: string) {
 		? [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16)]
 		: [0, 0, 0]
 }
+
+/**
+ * Callback when all transistions of the closing popover are finished
+ */
+function onClosed() {
+	emit('close')
+	emit('closed')
+}
 </script>
 
 <template>
 	<NcPopover popup-role="dialog"
 		:container="container"
-		@apply-hide="emit('close')">
+		@apply-hide="onClosed">
 		<template #trigger="slotProps">
 			<slot v-bind="slotProps" />
 		</template>


### PR DESCRIPTION
### ☑️ Resolves

With #7080 we dropped the `update:open` event, but the usage of the component is different - as you can already see in the docs of it. We in-officially used the attributes passing to the underlying `NcPopover` for custom open state handling.

So instead of this we should revert that change and instead just implement it correctly by providing the 2-way binding for `open` (consistent props naming) - then we need to reverse the event removal and remove `close` (which is covered by `update:open` and for fully closed (transitions done) the proper (consistent) named event `closed`).

I would backport the `feat` commits to v8 for forward compatibility.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
