### PR TITLE
chore: work around bug in `corepack` blocking dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,11 +67,11 @@
     "extends @nextcloud/browserslist-config"
   ],
   "overrides": {
-    "mdast-util-gfm": {
-      "mdast-util-gfm-autolink-literal": "2.0.0"
-    },
     "@playwright/experimental-ct-core": {
       "vite": "^6.3.4 || ^7.0.0"
+    },
+    "mdast-util-gfm": {
+      "mdast-util-gfm-autolink-literal": "2.0.0"
     }
   },
   "dependencies": {
@@ -167,11 +167,13 @@
     "node": "^20.11.0 || ^22 || ^24"
   },
   "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": "^10",
-      "onFail": "error"
-    },
+    "packageManager": [
+      {
+        "name": "npm",
+        "version": "^10",
+        "onFail": "error"
+      }
+    ],
     "runtime": {
       "name": "node",
       "version": "^22",


### PR DESCRIPTION
### ☑️ Resolves

dependabot uses `corepack` for all updates of node dependencies. The problem here is that `corepack` breaks if the
`devEngines.packageManager` does not define a **full semantic version** meaning it does not support semantic ranges.
We can work around this by just using the array syntax with only one entry.

For reference the *corepack* bug report: https://github.com/nodejs/corepack/issues/729

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
