### PR TITLE
fix(NcListItem): drop legacy check

### DIFF
--- a/src/components/NcListItem/NcListItem.vue
+++ b/src/components/NcListItem/NcListItem.vue
@@ -444,7 +444,6 @@ The `actions-icon` slot can be used to pass icon to the inner NcActions componen
 				class="list-item"
 				:class="{
 					'list-item--compact': compact,
-					'list-item--legacy': isLegacy,
 					'list-item--one-line': oneLine,
 				}"
 				@mouseover="handleMouseover"
@@ -684,15 +683,6 @@ export default {
 		'update:menuOpen',
 	],
 
-	setup() {
-		const [major] = window._oc_config?.version.split('.', 2) ?? []
-		const isLegacy = major && Number.parseInt(major) < 30
-
-		return {
-			isLegacy,
-		}
-	},
-
 	data() {
 		return {
 			hovered: false,
@@ -926,22 +916,10 @@ export default {
 		}
 	}
 
-	&--legacy {
-		--list-item-padding: calc(2 * var(--default-grid-baseline));
-
-		&.list-item--compact {
-			--list-item-padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
-		}
-	}
-
 	&--one-line {
 		--list-item-height: var(--default-clickable-area);
 		--list-item-border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
 		--list-item-padding: var(--default-grid-baseline);
-
-		&#{&}--legacy {
-			--list-item-padding: 2px calc((var(--list-item-height) - var(--list-item-border-radius)) / 2);
-		}
 
 		.list-item-content__main {
 			display: flex;

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -16,10 +16,6 @@ declare global {
 	interface Window {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		OCP: any
-		// internal global variables
-		_oc_config?: {
-			loglevel?: number
-		}
 		_nc_vue_element_id?: number
 		_nc_contacts_menu_hooks: { [id: string]: ContactsMenuAction },
 	}


### PR DESCRIPTION
### ☑️ Resolves

- Drop legacy check, sine we're not going to use Vue3 library with Nextcloud 29 and older
- since _oc_config is no longer used in project, dropping it from globals. There are better cross-platform alternatives to check that

### 🖼️ Screenshots

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
