### PR TITLE
fix(NcBreadCrumb): correctly pass container for `NcActions`

### DIFF
--- a/src/components/NcBreadcrumb/NcBreadcrumb.vue
+++ b/src/components/NcBreadcrumb/NcBreadcrumb.vue
@@ -16,7 +16,7 @@ Renders a button element when given no redirection props, otherwise, renders <a/
 	<li ref="crumb"
 		class="vue-crumb"
 		:class="[{'vue-crumb--hovered': hovering}, $props.class]"
-		:[crumbId]="''"
+		:data-crumb-id="crumbId"
 		draggable="false"
 		@dragstart.prevent="() => {/** Prevent the breadcrumb from being draggable. */}"
 		@drop.prevent="dropped"
@@ -39,12 +39,12 @@ Renders a button element when given no redirection props, otherwise, renders <a/
 		</NcButton>
 		<NcActions v-if="$slots.default"
 			ref="actions"
+			:container="actionsContainer"
 			:force-menu="forceMenu"
+			force-name
 			:open="open"
 			:menu-name="name"
-			:title="title"
-			:force-name="true"
-			:container="`.vue-crumb[${crumbId}]`"
+			:title
 			variant="tertiary"
 			@update:open="onOpenChange">
 			<template #icon>
@@ -163,12 +163,10 @@ export default {
 	],
 
 	setup() {
+		const crumbId = createElementId()
 		return {
-			/**
-			 * The unique id of the breadcrumb. Necessary to append the
-			 * Actions menu to the correct crumb.
-			 */
-			 crumbId: createElementId(),
+			actionsContainer: `.vue-crumb[data-crumb-id="${crumbId}"]`,
+			crumbId,
 		}
 	},
 


### PR DESCRIPTION

### ☑️ Resolves
I am not sure how this was supposed to work, as it set a random attribute on the `li` tag - that was sometimes not even a valid HTML attribute name.
We can instead just use the ref to the li element directly.


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
