### PR TITLE
fix: `Set operation on key "value" failed: target is readonly`

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -182,7 +182,7 @@ defineSlots<{
 let focusTrap: FocusTrap
 const setHasAppNavigation = inject<(v: boolean) => void>('NcContent:setHasAppNavigation', () => warn('NcAppNavigation is not mounted inside NcContent, this is probably an error.'), false)
 
-const appNavigationContainer = useTemplateRef('appNavigationContainer')
+const appNavigationContainer = useTemplateRef('app-navigation-container-key')
 const isMobile = useIsMobile()
 const open = ref(!isMobile.value)
 
@@ -275,7 +275,7 @@ function handleEsc(): void {
 </script>
 
 <template>
-	<div ref="appNavigationContainer"
+	<div ref="app-navigation-container-key"
 		class="app-navigation"
 		:class="{'app-navigation--closed':!open }">
 		<nav id="app-navigation-vue"

--- a/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
+++ b/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
@@ -139,7 +139,7 @@ export default {
 			</template>
 		</NcInputField>
 		<div v-if="hasActions()"
-			ref="actionsContainer"
+			ref="actions-container-key"
 			class="app-navigation-search__actions"
 			:class="{
 				'app-navigation-search__actions--hidden': !showActions,
@@ -189,7 +189,7 @@ const { focused: inputHasFocus } = useFocusWithin(inputElement)
 /** Timeout used to define when the search input is fully expanded */
 const transitionTimeout = Number.parseInt(window.getComputedStyle(window.document.body).getPropertyValue('--animation-quick')) || 100
 
-const actionsContainer = useTemplateRef('actionsContainer')
+const actionsContainer = useTemplateRef('actions-container-key')
 const hasActions = () => !!slots.actions?.({})
 const showActions = ref(true)
 const timeoutId = ref()

--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -318,8 +318,8 @@ const props = withDefaults(defineProps<{
  */
 const timezoneId = defineModel<string>('timezoneId', { default: 'UTC' })
 
-const target = useTemplateRef('target')
-const picker = useTemplateRef('picker')
+const target = useTemplateRef('target-key')
+const picker = useTemplateRef('picker-key')
 
 const emit = defineEmits<{
 	/**
@@ -576,7 +576,7 @@ function cancelSelection() {
 
 <template>
 	<div class="vue-date-time-picker__wrapper">
-		<VueDatePicker ref="picker"
+		<VueDatePicker ref="picker-key"
 			:aria-labels
 			:auto-apply="!confirm"
 			class="vue-date-time-picker"
@@ -642,7 +642,7 @@ function cancelSelection() {
 			</template>
 		</VueDatePicker>
 		<Teleport to="body" :disabled="!appendToBody">
-			<div ref="target" class="vue-date-time-picker__wrapper" />
+			<div ref="target-key" class="vue-date-time-picker__wrapper" />
 		</Teleport>
 	</div>
 </template>

--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -360,7 +360,7 @@ const slots = defineSlots<{
 /**
  * The dialog wrapper element
  */
-const wrapper = useTemplateRef('wrapper')
+const wrapper = useTemplateRef('wrapper-key')
 
 /**
  * We use the dialog width to decide if we collapse the navigation (flex direction row)
@@ -400,7 +400,7 @@ const navigationAriaLabelledbyAttr = computed(() => {
 	return props.navigationAriaLabelledby || navigationId
 })
 
-const dialogElement = useTemplateRef<HTMLDivElement|HTMLFormElement>('dialogElement')
+const dialogElement = useTemplateRef<HTMLDivElement|HTMLFormElement>('dialog-key')
 /**
  * The HTML element to use for the dialog wrapper - either form or plain div
  */
@@ -499,11 +499,11 @@ const modalProps = computed(() => ({
 		<!-- The dialog name / header -->
 		<h2 :id="navigationId" class="dialog__name" v-text="name" />
 		<component :is="dialogTagName"
-			ref="dialogElement"
+			ref="dialog-key"
 			class="dialog"
 			:class="dialogClasses"
 			v-on="dialogListeners">
-			<div ref="wrapper" :class="['dialog__wrapper', { 'dialog__wrapper--collapsed': isNavigationCollapsed }]">
+			<div ref="wrapper-key" :class="['dialog__wrapper', { 'dialog__wrapper--collapsed': isNavigationCollapsed }]">
 				<!-- When the navigation is collapsed (too small dialog) it is displayed above the main content, otherwise on the inline start -->
 				<nav v-if="hasNavigation"
 					class="dialog__navigation"

--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -139,11 +139,11 @@ const isOpened = ref(open)
 const wrapperTag = computed(() => isNav ? 'nav' : 'div')
 
 /** The menu content container element */
-const contentContainer = useTemplateRef('contentContainer')
+const contentContainer = useTemplateRef('content-container-key')
 /** The overall header menu wrapping element (<nav> or <div>) */
-const headerMenu = useTemplateRef<HTMLElement>('headerMenu')
+const headerMenu = useTemplateRef<HTMLElement>('header-menu-key')
 /** The menu trigger button */
-const triggerButton = useTemplateRef('triggerButton')
+const triggerButton = useTemplateRef('trigger-button-key')
 
 // Handle click outside of the menu -> should close the menu
 const ignore = computed(() => Array.isArray(excludeClickOutsideSelectors)
@@ -242,14 +242,14 @@ function clearFocusTrap() {
 <template>
 	<component :is="wrapperTag"
 		:id="id"
-		ref="headerMenu"
+		ref="header-menu-key"
 		:aria-labelledby="isNav ? triggerId : null"
 		:class="{ 'header-menu--opened': isOpened }"
 		class="header-menu"
 		@focusout="onFocusOut">
 		<!-- Trigger -->
 		<NcButton :id="isNav ? triggerId : null"
-			ref="triggerButton"
+			ref="trigger-button-key"
 			class="header-menu__trigger"
 			:aria-controls="`header-menu-${id}`"
 			:aria-expanded="isOpened.toString()"
@@ -274,7 +274,7 @@ function clearFocusTrap() {
 		<div v-show="isOpened"
 			:id="`header-menu-${id}`"
 			class="header-menu__wrapper">
-			<div ref="contentContainer" class="header-menu__content">
+			<div ref="content-container-key" class="header-menu__content">
 				<slot />
 			</div>
 		</div>

--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -158,7 +158,7 @@ defineSlots<{
 
 const attrs = useAttrs()
 
-const input = useTemplateRef('input')
+const input = useTemplateRef('input-key')
 
 const hasTrailingIcon = computed(() => props.showTrailingButton || props.success)
 
@@ -228,7 +228,7 @@ function handleInput(event: Event) {
 		<div class="input-field__main-wrapper">
 			<input v-bind="$attrs"
 				:id
-				ref="input"
+				ref="input-key"
 				:aria-describedby="ariaDescribedby"
 				aria-live="polite"
 				class="input-field__input"

--- a/src/components/NcPasswordField/NcPasswordField.vue
+++ b/src/components/NcPasswordField/NcPasswordField.vue
@@ -205,7 +205,7 @@ interface PasswordPolicy {
 const { password_policy: passwordPolicy } = getCapabilities() as { password_policy?: PasswordPolicy }
 
 // internal state
-const inputField = useTemplateRef('inputField')
+const inputField = useTemplateRef('input-field-key')
 
 const internalHelpMessage = ref('')
 const isValid = ref<boolean>()
@@ -287,7 +287,7 @@ function select() {
 
 <template>
 	<NcInputField v-bind="propsToForward"
-		ref="inputField"
+		ref="input-field-key"
 		v-model="modelValue"
 		:error="error || isValid === false"
 		:helper-text="helperText || internalHelpMessage"

--- a/src/components/NcTextField/NcTextField.vue
+++ b/src/components/NcTextField/NcTextField.vue
@@ -126,7 +126,7 @@ export default {
 
 <template>
 	<NcInputField v-bind="propsToForward"
-		ref="inputField"
+		ref="input-field-key"
 		v-model="modelValue">
 		<template v-if="!!$slots.icon" #icon>
 			<slot name="icon" />
@@ -188,7 +188,7 @@ defineSlots<{
 	icon?: Slot
 }>()
 
-const inputField = useTemplateRef('inputField')
+const inputField = useTemplateRef('input-field-key')
 
 const defaultTrailingButtonLabels = {
 	arrowEnd: t('Save changes'),


### PR DESCRIPTION
Vue warns in some edge cases when a ref in a component instance and template ref key string have the same name.

- Ref: https://github.com/vuejs/core/issues/12852

### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/7238

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
