### PR TITLE
ci: use correct base branch when doing styling update on stable*

### DIFF
--- a/.github/workflows/server-styling-update.yml
+++ b/.github/workflows/server-styling-update.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+          ref: ${{ matrix.branch }}
 
       - name: Download css
         run: |


### PR DESCRIPTION
### ☑️ Resolves

Noticed this on https://github.com/nextcloud-libraries/nextcloud-vue/pull/7254
It was forgotten to also checkout the correct branch. This will then also set the correct base branch for the PR.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
