### PR TITLE
fix(l10n): correctly add languages to bundle

### DIFF
--- a/build/l10n-plugin.mts
+++ b/build/l10n-plugin.mts
@@ -21,7 +21,7 @@ export default (dir: string) => {
 	let nameMap: Record<string, string>
 	// all loaded translations, as filenames ->
 	const translations: Record<string, { l: string, t: Record<string, { v: string[], p?: string }> }[]> = {}
-	const l10nRegistrationCode = readFileSync(join(__dirname, 'l10n-registration-implementation.js'))
+	let l10nRegistrationCode: string
 
 	return {
 		name: 'nextcloud-l10n-plugin',
@@ -31,6 +31,9 @@ export default (dir: string) => {
 		 * Prepare l10n loading once the building start, this loads all translations and splits them into chunks by their usage in the components.
 		 */
 		async buildStart() {
+			this.info('[l10n] Loading registration code')
+			const l10nRegistrationPath = join(import.meta.dirname, 'l10n-registration-implementation.js')
+			l10nRegistrationCode = readFileSync(l10nRegistrationPath).toString()
 			this.info('[l10n] Loading translations')
 			// all translations for all languages and components
 			const allTranslations = await loadTranslations(dir)

--- a/build/l10n-plugin.mts
+++ b/build/l10n-plugin.mts
@@ -6,7 +6,8 @@
 import type { Plugin } from 'vite'
 
 import { loadTranslations } from './translations.mts'
-import { dirname, resolve } from 'path'
+import { readFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
 
 /**
  * This is a plugin to split all translations into chunks of users meaning components that use that translation
@@ -20,6 +21,7 @@ export default (dir: string) => {
 	let nameMap: Record<string, string>
 	// all loaded translations, as filenames ->
 	const translations: Record<string, { l: string, t: Record<string, { v: string[], p?: string }> }[]> = {}
+	const l10nRegistrationCode = readFileSync(join(__dirname, 'l10n-registration-implementation.js'))
 
 	return {
 		name: 'nextcloud-l10n-plugin',
@@ -99,47 +101,7 @@ export default (dir: string) => {
 			} else if (id === '\0l10n') {
 				// exports are all chunked translations
 				const exports = Object.entries(nameMap).map(([usage, id]) => `export const ${id} = ${JSON.stringify(translations[usage])}`).join(';\n')
-				return `import { getLanguage } from '@nextcloud/l10n'
-import { getGettextBuilder } from '@nextcloud/l10n/gettext'
-const gettext = getGettextBuilder()
-	.detectLanguage()
-	.build()
-
-export const n = (...args) => gettext.ngettext(...args)
-export const t = (...args) => gettext.gettext(...args)
-
-export function register(...chunks) {
-	for (const chunk of chunks) {
-		if (!chunk.registered) {
-			// for every language in the chunk: decompress and register
-			for (const { l: language, t: translations } of chunk) {
-				if (language !== getLanguage() || !translations) {
-					continue
-				}
-
-				const decompressed = Object.fromEntries(
-					Object.entries(translations)
-					.map(([id, value]) => [
-						id,
-						{
-							msgid: id,
-							msgid_plural: value.p,
-							msgstr: value.v,
-						}
-					])
-				)
-
-				gettext.addTranslations({
-					translations: {
-						'': decompressed,
-					},
-				})
-			}
-			chunk.registered = true
-		}
-	}
-}
-${exports}`
+				return `${l10nRegistrationCode}\n${exports}`
 			}
 		},
 	} as Plugin

--- a/build/l10n-registration-implementation.js
+++ b/build/l10n-registration-implementation.js
@@ -1,0 +1,52 @@
+/*!
+ * SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// This file is included by the l10n-plugin - its provided as source code here to allow linting
+
+import { getLanguage } from '@nextcloud/l10n'
+import { getGettextBuilder } from '@nextcloud/l10n/gettext'
+const gettext = getGettextBuilder()
+	.detectLanguage()
+	.build()
+
+export const n = (...args) => gettext.ngettext(...args)
+export const t = (...args) => gettext.gettext(...args)
+
+/**
+ * @param {{ l: string, t: Record<string, { v: string[], p?: string }> }[]} chunks 
+ */
+export function register(...chunks) {
+	for (const chunk of chunks) {
+		if (chunk.registered) {
+			continue
+		}
+
+		// for every language in the chunk: decompress and register if matching
+		for (const { l: language, t: translations } of chunk) {
+			if (language !== getLanguage() || !translations) {
+				continue
+			}
+
+			const decompressed = Object.fromEntries(
+				Object.entries(translations)
+				.map(([id, value]) => [
+					id,
+					{
+						msgid: id,
+						msgid_plural: value.p,
+						msgstr: value.v,
+					}
+				])
+			)
+
+			gettext.addTranslations({
+				translations: {
+					'': decompressed,
+				},
+			})
+		}
+		chunk.registered = true
+	}
+}

--- a/build/translations.mts
+++ b/build/translations.mts
@@ -7,23 +7,7 @@ import { join, basename } from 'path'
 import { readdir, readFile } from 'fs/promises'
 import { po as poParser } from 'gettext-parser'
 
-// https://github.com/alexanderwallin/node-gettext#usage
-// https://github.com/alexanderwallin/node-gettext#load-and-add-translations-from-mo-or-po-files
-const parseFile = async (fileName) => {
-	const locale = basename(fileName).slice(0, -'.pot'.length)
-	const po = await readFile(fileName)
-
-	// compress translations
-	const json = Object.fromEntries(Object.entries(poParser.parse(po).translations[''])
-		// Remove not translated string to save space
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		.filter(([_id, value]) => value.msgstr.length > 0 || value.msgstr[0] !== '')
-		// Compress translations to remove duplicated information and reduce asset size
-		.map(([id, value]) => [id, { ...(value.msgid_plural ? { p: value.msgid_plural } : {}), v: value.msgstr }]))
-	return [locale, json] as const
-}
-
-export const loadTranslations = async (baseDir: string) => {
+export async function loadTranslations(baseDir: string) {
 	const files = await readdir(baseDir)
 
 	const promises = files
@@ -31,6 +15,38 @@ export const loadTranslations = async (baseDir: string) => {
 		.map(file => join(baseDir, file))
 		.map(parseFile)
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	return Object.fromEntries((await Promise.all(promises)).filter(([_locale, value]) => Object.keys(value).length > 0))
+	const parsedTranslations = await Promise.all(promises)
+	// In `parseFile` reduced the returned translations to only available.
+	// In that process some languages can be stripped completely resulting in an empty translation set.
+	// Those languages need to be filtered now.
+	const nonEmptyTranslations = parsedTranslations.filter(([, value]) => Object.keys(value).length > 0)
+
+	return Object.fromEntries(nonEmptyTranslations)
+}
+
+/**
+ * @param fileName - The full filename to open and parse
+ *
+ * @see https://github.com/alexanderwallin/node-gettext#usage
+ * @see https://github.com/alexanderwallin/node-gettext#load-and-add-translations-from-mo-or-po-files
+ */
+async function parseFile(fileName: string) {
+	const fileBasename = basename(fileName).slice(0, -'.pot'.length)
+	const languageArray = fileBasename.split(/[_@]/)
+	if (languageArray[1]?.toLowerCase() === 'latin') {
+		languageArray[1] = 'Latn' // BCP47 uses 4 letter script tag
+	}
+	const languageName = languageArray.join('-')
+	const po = await readFile(fileName)
+
+	// compress translations
+	const json = Object.fromEntries(Object.entries(poParser.parse(po).translations[''])
+		// Remove the meta data entry
+		.filter(([key]) => key !== '')
+		// Remove not translated string to save space
+		.filter(([, value]) => value.msgstr.length > 1 || value.msgstr[0] !== '')
+		// Compress translations to remove duplicated information and reduce asset size
+		.map(([id, value]) => [id, { ...(value.msgid_plural ? { p: value.msgid_plural } : {}), v: value.msgstr }]))
+
+	return [languageName, json] as const
 }


### PR DESCRIPTION
### ☑️ Resolves

Our files have names like `de_DE` but the BCP47 name is `de-DE` or `sr@latin` vs `sr-Latn`.
We need to adjust them as otherwise the language is not loaded when a language with region or script suffix is selected by the user.

This also fixed an issue where empty translations were not removed (`length > 0` vs `length > 1`), thus this also reduces the amount of bundled translations by 50% (because they were just empty).

Additionally split the injected code into a js file to make it lintable.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
