### PR TITLE
feat(NcAppNavigationItem): add `active` as slot property to the "icon"-slot

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -46,6 +46,37 @@
 </ul>
 ```
 
+* Using different icons based on the active state (e.g. using vue-router and showing the filled variant for the current route):
+
+```vue
+<template>
+	<ul>
+		<NcAppNavigationItem name="Current page" :active="true">
+			<template #icon="{ active }">
+				<NcIconSvgWrapper :path="active ? mdiFolder : mdiFolderOutline" />
+			</template>
+		</NcAppNavigationItem>
+		<NcAppNavigationItem name="Other page">
+			<template #icon="{ active }">
+				<NcIconSvgWrapper :path="active ? mdiFolder : mdiFolderOutline" />
+			</template>
+		</NcAppNavigationItem>
+	</ul>
+</template>
+<script>
+import { mdiFolder, mdiFolderOutline } from '@mdi/js'
+
+export default {
+	setup() {
+		return {
+			mdiFolder,
+			mdiFolderOutline,
+		}
+	},
+}
+</script>
+```
+
 #### Element with actions
 Wrap the children in a template. If you have more than 2 actions, a popover menu and a menu
 button will be automatically created.
@@ -309,8 +340,8 @@ Just set the `pinned` prop.
 					<div :class="{ [icon]: icon }"
 						class="app-navigation-entry-icon">
 						<NcLoadingIcon v-if="loading" />
-						<!-- @slot Slot for the optional leading icon -->
-						<slot v-else name="icon" />
+						<!-- @slot Slot for the optional leading icon. This slots get the `active`-slot attribute passed which is based on the vue-routers active route or the `active` prop. -->
+						<slot v-else name="icon" :active="active || (to && isActive)" />
 					</div>
 					<span class="app-navigation-entry__name" :class="{ 'hidden-visually': editingActive }">
 						{{ name }}


### PR DESCRIPTION
### ☑️ Resolves

This allows to have different icons if the current item is active or not. (We will use this to show the filled variant for active icons).

### 🖼️ Screenshots

<img width="1672" height="204" alt="Screenshot 2025-08-11 at 16-06-21 Nextcloud Vue Style Guide" src="https://github.com/user-attachments/assets/256f91b9-b8d9-4dad-a001-5391735f94b6" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
