### PR TITLE
fix(NcLoadingIcon): prevent height change from rotate transformation

### DIFF
--- a/src/components/NcLoadingIcon/NcLoadingIcon.vue
+++ b/src/components/NcLoadingIcon/NcLoadingIcon.vue
@@ -72,7 +72,11 @@ const colors = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-.loading-icon svg{
-	animation: rotate var(--animation-duration, 0.8s) linear infinite;
+.loading-icon {
+	overflow: hidden;
+
+	svg {
+		animation: rotate var(--animation-duration, 0.8s) linear infinite;
+	}
 }
 </style>


### PR DESCRIPTION
### ☑️ Resolves

- Fix flickering / height jumping when loading icon has position: static
 - Although wrapping span has a consistent width/height from props.size, rotating svg is constantly changing it dimensions:
	<img width="161" height="122" alt="2025-08-11_17h28_36" src="https://github.com/user-attachments/assets/ba7aea92-9311-4b5e-9d85-9678c43b254e" />
 - Reproducible by checking `element.getBoundingClientRect()` or hovering over DOM element in inspector
 - overflow: hidden should ignore parts that are standing out. Since spinner is round, shouldn't affect the appearance


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
