### PR TITLE
fix: auto-resolve focus trap stack, if was changed outside of controller

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -345,7 +345,6 @@ import Timer from '../../utils/Timer.js'
 import Close from 'vue-material-design-icons/Close.vue'
 import Pause from 'vue-material-design-icons/Pause.vue'
 import Play from 'vue-material-design-icons/Play.vue'
-import { useTrapStackControl } from '../../composables/useTrapStackControl.js'
 
 export default {
 	name: 'NcModal',
@@ -614,10 +613,6 @@ export default {
 				this.focusTrap.updateContainerElements([contentContainer, ...elements])
 			}
 		},
-	},
-
-	created() {
-		useTrapStackControl(() => this.showModal)
 	},
 
 	beforeMount() {

--- a/src/utils/focusTrap.ts
+++ b/src/utils/focusTrap.ts
@@ -45,10 +45,14 @@ export function createTrapStackController() {
 		},
 		/**
 		 * Unpause the paused focus trap stack
+		 * If the actual stack is different from the paused one, there were changes
+		 * outside of this controller, so we assume it's self-regulated and do not unpause.
 		 */
 		unpause() {
-			for (const trap of pausedStack) {
-				trap.unpause()
+			if (pausedStack.length === getTrapStack().length) {
+				for (const trap of pausedStack) {
+					trap.unpause()
+				}
 			}
 			pausedStack = []
 		},


### PR DESCRIPTION
### ☑️ Resolves

- Follow-up to #7084
  - NcModal is working fine with default trap stack, so there's no need for `useTrapStackControl`
- To be backported with #7085
  - Does not change behaviour for main / Vue 3
  - Fixes following scenario for Vue 2:
    - Talk app -> shrink to mobile -> NcAppNavigation creates trap 0 -> trap 0 is active
    - open NcActions next to search bar -> pause trap 0
    - select 'Create open conversation' -> starts to mount NcModal
    - NcModal mounted -> useFocusTrap() -> creates trap 1 -> trap 1 is active
    - NcActions with `close-after-click` is closed -> unpause pausedStack (it has only [trap 0] from first step) -> trap 0 unpauses
    - trap 0 activates - trap 1 is paused -> focus trap is now in NcAppNavigation instead of NcModal
  - If trap stack was modified outside of stackcontroller, it should be safe to assume, that user action lead to that, and it's currently correctly resolved

### 🖼️ Screenshots

🏚️ Before (Vue 2 at #7085)


https://github.com/user-attachments/assets/037b6a8d-f2f4-4cab-b48f-2d06882e965e


🏡 After (Vue 2)

https://github.com/user-attachments/assets/44e08243-a4d2-4ae9-a4cd-6b68bdc5d761


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
