### PR TITLE
fix(NcIconSvgWrapper): do not restrict icon minimal size

### DIFF
--- a/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
+++ b/src/components/NcIconSvgWrapper/NcIconSvgWrapper.vue
@@ -254,8 +254,8 @@ const cleanSvg = computed(() => {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	min-width: var(--default-clickable-area);
-	min-height: var(--default-clickable-area);
+	min-width: v-bind('iconSize');
+	min-height: v-bind('iconSize');
 	opacity: 1;
 
 	&#{&}--inline {


### PR DESCRIPTION
### ☑️ Resolves

- Upstream to https://github.com/nextcloud/spreed/pull/15662

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="115" height="74" alt="image" src="https://github.com/user-attachments/assets/8c0d6359-f556-4d27-9831-0de261065b3d" /> | <img width="107" height="65" alt="image" src="https://github.com/user-attachments/assets/ea555772-a36f-417f-a95b-87587bd41af3" />


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
