### PR TITLE
fix(NcReferencePickerModal): scope all styles

### DIFF
--- a/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
+++ b/src/components/NcRichText/NcReferencePicker/NcReferencePickerModal.vue
@@ -149,14 +149,12 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 // this is to avoid scroll on the container and leave it to the result block
-.reference-picker-modal .modal-container {
+.reference-picker-modal :deep(.modal-container) {
 	display: flex !important;
 }
-</style>
 
-<style lang="scss" scoped>
 .reference-picker-modal--content {
 	width: 100%;
 	display: flex;


### PR DESCRIPTION
### ☑️ Resolves

- Missed styles scoping
- No real issue at the moment — just to prevent issues in the future

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
