### PR TITLE
[stable8] fix(NcDateTimePicker): lost styles in docs

### DIFF
--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -170,6 +170,8 @@ import NcPopover from '../NcPopover/index.js'
 import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
 import Web from 'vue-material-design-icons/Web.vue'
 
+import './index.scss'
+
 import {
 	getFirstDay,
 	getDayNames,

--- a/src/components/NcDateTimePicker/index.js
+++ b/src/components/NcDateTimePicker/index.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import './index.scss'
 import NcDateTimePicker from './NcDateTimePicker.vue'
 import ScopeComponent from '../../utils/ScopeComponent.js'
 


### PR DESCRIPTION
### ☑️ Resolves

- Regression from https://github.com/nextcloud-libraries/nextcloud-vue/pull/7195
- Styles are not loaded
- I haven't found an app where the issue is reproducable. Either webpack or vue-styleguidist issue.
  - So, might be only in docs

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="949" height="374" alt="image" src="https://github.com/user-attachments/assets/ebddfea2-2e6e-47ab-a059-a3f22930311f" /> | <img width="310" height="398" alt="image" src="https://github.com/user-attachments/assets/e21fe589-ef8d-4ada-9e7f-e57d142f4e31" />
### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
