### PR TITLE
chore: add missing docblock comments

### DIFF
--- a/build/l10n-registration-implementation.js
+++ b/build/l10n-registration-implementation.js
@@ -15,7 +15,10 @@ export const n = (...args) => gettext.ngettext(...args)
 export const t = (...args) => gettext.gettext(...args)
 
 /**
- * @param {{ l: string, t: Record<string, { v: string[], p?: string }> }[]} chunks
+ * This is called by the l10n plugin for the chunk(s) of translations used by a used component.
+ * So that only those chunks used by the imported components are loaded.
+ *
+ * @param {{ l: string, t: Record<string, { v: string[], p?: string }> }[]} chunks - The translation chunk to be registered
  */
 export function register(...chunks) {
 	for (const chunk of chunks) {

--- a/src/components/NcSelectTags/api.js
+++ b/src/components/NcSelectTags/api.js
@@ -8,8 +8,7 @@ import { generateRemoteUrl } from '@nextcloud/router'
 import logger from '../../utils/logger.ts'
 
 /**
- *
- * @param xml
+ * @param {Document} xml - The xml document
  */
 function xmlToJson(xml) {
 	let obj = {}
@@ -46,8 +45,8 @@ function xmlToJson(xml) {
 }
 
 /**
- *
- * @param xml
+ * @param {string} xml - The XML string to be parsed into a XML document
+ * @return {Document}
  */
 function parseXml(xml) {
 	let dom = null
@@ -60,8 +59,7 @@ function parseXml(xml) {
 }
 
 /**
- *
- * @param xml
+ * @param {string} xml - The XML result to be parsed
  */
 function xmlToTagList(xml) {
 	const json = xmlToJson(parseXml(xml))
@@ -85,7 +83,7 @@ function xmlToTagList(xml) {
 }
 
 /**
- *
+ * Get tags from backend
  */
 async function searchTags() {
 	if (window.NextcloudVueDocs) {


### PR DESCRIPTION
### ☑️ Resolves

Those were warnings for ESLint so added proper comments (the missing types - as this is JavaScript).

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
