### PR TITLE
chore(NcAppNavigationItem): fix linting warnings

### DIFF
--- a/src/components/NcAppNavigationItem/NcAppNavigationIconCollapsible.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationIconCollapsible.vue
@@ -46,7 +46,7 @@ export default {
 		 */
 		open: {
 			type: Boolean,
-			default: true,
+			required: true,
 		},
 
 		/**

--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -418,7 +418,8 @@ Just set the `pinned` prop.
 						<slot name="actions" />
 					</NcActions>
 				</div>
-				<NcAppNavigationIconCollapsible v-if="allowCollapse && !!$slots.default"
+				<NcAppNavigationIconCollapsible
+					v-if="allowCollapse && !!$slots.default"
 					:active="(isActive && to) || active"
 					:open="opened"
 					@click.prevent.stop="toggleCollapse" />


### PR DESCRIPTION
### ☑️ Resolves

- Make required prop `open` of `NcAppNavigationIconCollapsible` required instead of `default: true`.
- Use correct newline in template

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
