### PR TITLE
fix(NcHeaderMenu): apply `ariaLabel` prop and add proper default values

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -69,6 +69,8 @@ import { getTrapStack } from '../../utils/focusTrap.js'
 import NcButton from '../NcButton/index.ts'
 
 const {
+	ariaLabel = undefined,
+	description = undefined,
 	excludeClickOutsideSelectors = [],
 	open = false,
 	isNav = false,
@@ -252,9 +254,10 @@ function clearFocusTrap() {
 		<NcButton
 			:id="isNav ? triggerId : null"
 			ref="trigger-button-key"
-			class="header-menu__trigger"
 			:aria-controls="`header-menu-${id}`"
 			:aria-expanded="isOpened.toString()"
+			:aria-label
+			class="header-menu__trigger"
 			size="large"
 			variant="tertiary-no-background"
 			@click.prevent="toggleMenu">


### PR DESCRIPTION
### ☑️ Resolves

1. The `ariaLabel` was not applied to the button.
2. Some defaults were only added implicit causing Vue warnings - so added explicit `undefined` as default.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
