### PR TITLE
refactor(NcButton): use proper prop type for `pressed` to allow `undefined`

### DIFF
--- a/src/components/NcButton/NcButton.vue
+++ b/src/components/NcButton/NcButton.vue
@@ -510,7 +510,7 @@ const props = withDefaults(defineProps<{
 	 *
 	 * Note: Pressed state is not supported for links.
 	 */
-	pressed?: boolean
+	pressed?: boolean | undefined
 
 	/**
 	 * Specify the button size.


### PR DESCRIPTION
### ☑️ Resolves

For Vue a prop defined as `prop?: boolean` means that `prop` is a boolean property with default `false`. But in this case we have a tri-state value: either pressed (a boolean) or undefined. So to allow such a prop to have the default value `undefined` instead of `false` we need to explicitly type it as `prop?: boolean | undefined`.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
