### PR TITLE
fix(NcHeaderMenu): pause trap stack on opening

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -64,6 +64,7 @@ import { onClickOutside } from '@vueuse/core'
 import { createFocusTrap } from 'focus-trap'
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 import { useHotKey } from '../../composables/index.js'
+import { useTrapStackControl } from '../../composables/useTrapStackControl.ts'
 import { createElementId } from '../../utils/createElementId.ts'
 import { getTrapStack } from '../../utils/focusTrap.js'
 import NcButton from '../NcButton/index.ts'
@@ -153,6 +154,12 @@ onClickOutside(headerMenu, () => setMenuState(false), { ignore })
 
 // Pressing escape should close the menu
 useHotKey('Escape', () => setMenuState(false), { prevent: true })
+
+// When component has its own custom focus management
+// The global focus trap stack should be paused
+useTrapStackControl(isOpened, {
+	disabled: () => !isNav,
+})
 
 // Watch the open prop to adjust the internal opened state
 watch(() => open, (state: boolean) => setMenuState(state))


### PR DESCRIPTION
### ☑️ Resolves

- Fix #5385
- Fix https://github.com/nextcloud/spreed/issues/13062

With `is-nav` prop NcHeaderMenu doesn't start a focus-trap and therefore doesn't pause existing ones. That prevents any click in mobile state, as focus returned to AppNavigation

Alternatives for NcAppNavigation:
- release focus-trap on click outside
- toggle component to closed state on click outside

### 🖼️ Screenshots

🏡 After (cherry-picked to stable8 + applied to server repo)

https://github.com/user-attachments/assets/b2e8cd28-edbb-4ea2-ad40-104c55cf86db

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
