### PR TITLE
fix(NcAppNavigationSearch): add space before ellipsis

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -390,6 +390,9 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+msgid "Search …"
+msgstr ""
+
 msgid "Search emoji"
 msgstr ""
 
@@ -397,9 +400,6 @@ msgid "Search for timezone"
 msgstr ""
 
 msgid "Search results"
-msgstr ""
-
-msgid "Search…"
 msgstr ""
 
 #. FOR TRANSLATORS: If possible in your language an even shorter version of 'a few seconds ago'

--- a/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
+++ b/src/components/NcAppNavigationSearch/NcAppNavigationSearch.vue
@@ -172,7 +172,7 @@ defineProps({
 	 */
 	label: {
 		type: String,
-		default: t('Search…'),
+		default: t('Search …'),
 	},
 
 	/**

--- a/src/components/NcHeaderButton/NcHeaderButton.vue
+++ b/src/components/NcHeaderButton/NcHeaderButton.vue
@@ -21,7 +21,7 @@ similar to the NcHeaderMenu but to be used when only a trigger button is needed,
 		<NcDialog name="Search"
 			size="normal"
 			v-model:open="showDialog">
-			<NcTextField label="Search for files, comments, contacts…"
+			<NcTextField label="Search for files, comments, contacts …"
 				type="search"
 				v-model="query" />
 			<NcEmptyContent name="Search"

--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -15,7 +15,7 @@ This component is made to be used in the Nextcloud top header.
 				<Magnify />
 			</template>
 			<div>
-				<NcTextField label="Search for files, comments, contacts…"
+				<NcTextField label="Search for files, comments, contacts …"
 					style="padding-inline: 8px;"
 					type="search"
 					v-model="query" />


### PR DESCRIPTION
### ☑️ Resolves

- Added non-breaking space following:
  - https://docs.nextcloud.com/server/latest/developer_manual/basics/translations.html#dos-and-don-ts
  - https://github.com/nextcloud/server/wiki/Translation-knowledge-(valid-for-whole-nextcloud-project)/d45f1d248fdc6b1509337ebb0017653649a8f440#ellipsis

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
