### PR TITLE
[stable8]: feat(NcCheckboxRadioSwitch): Add support for a description field

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -17,7 +17,8 @@
 		<span :class="{
 				'checkbox-content__icon': true,
 				'checkbox-content__icon--checked': isChecked,
-				[iconClass]: true
+				'checkbox-content__icon--hasDescription': hasDescription,
+				[iconClass]: true,
 			}"
 			:aria-hidden="true"
 			inert>
@@ -35,10 +36,16 @@
 			</slot>
 		</span>
 
-		<span v-if="$slots.default" :class="['checkbox-content__text', textClass]">
-			<!-- @slot The checkbox/radio label -->
-			<slot />
-		</span>
+		<div class="checkbox-content__wrapper">
+			<span v-if="$slots.default" class="checkbox-content__text" :class="[textClass]">
+				<!-- @slot The checkbox/radio label -->
+				<slot />
+			</span>
+			<em v-if="hasDescription" class="checkbox-content__description">
+				{{ description }}
+				<slot name="description" />
+			</em>
+		</div>
 	</span>
 </template>
 
@@ -140,11 +147,23 @@ export default {
 			type: Number,
 			default: 24,
 		},
+
+		/**
+		 * Description
+		 */
+		description: {
+			type: String,
+			default: null,
+		},
 	},
 
 	computed: {
 		isButtonType() {
 			return this.type === TYPE_BUTTON
+		},
+
+		hasDescription() {
+			return !this.isButtonType && (this.$slots.description || this.description)
 		},
 
 		/**
@@ -196,8 +215,11 @@ export default {
 	// but restrict to content so plain checkboxes / radio switches do not expand
 	max-width: fit-content;
 
-	&__text {
+	&__wrapper {
 		flex: 1 0;
+	}
+
+	&__text {
 
 		&:empty {
 			// hide text if empty to ensure checkbox outline is a circle instead of oval
@@ -211,10 +233,22 @@ export default {
 		margin-block: calc((var(--default-clickable-area) - 2 * var(--default-grid-baseline) - var(--icon-height)) / 2) auto;
 	}
 
+	&-checkbox:not(&--button-variant) &__icon--hasDescription,
+	&-radio:not(&--button-variant) &__icon--hasDescription,
+	&-switch:not(&--button-variant) &__icon--hasDescription {
+		display: flex;
+		align-items: center;
+		margin-block-end: 0;
+	}
+
 	&__icon > * {
 		width: var(--icon-size);
 		height: var(--icon-height);
 		color: var(--color-primary-element);
+	}
+
+	&__description {
+		display: block;
 	}
 
 	&--button-variant {

--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -23,6 +23,10 @@ Note: All attributes on the element are passed to the inner input element - exce
 		<NcCheckboxRadioSwitch v-model="sharingEnabled">
 			Enable sharing. This can contain a long multiline text, that will be wrapped in a second row. It is generally not advised to have such long text inside of an element
 		</NcCheckboxRadioSwitch>
+
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" description="The description">
+			Enable sharing with description
+		</NcCheckboxRadioSwitch>
 		<br>
 		sharingEnabled: {{ sharingEnabled }}
 	</div>
@@ -237,6 +241,18 @@ export default {
 		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">
 			Enable sharing. This can contain a long multiline text, that will be wrapped in a second row. It is generally not advised to have such long text inside of an element
 		</NcCheckboxRadioSwitch>
+
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch" description="Instead you can use a description as a prop which can also be a long multiline text, that will be wrapped in a second row.">
+			Enable sharing.
+		</NcCheckboxRadioSwitch>
+
+		<NcCheckboxRadioSwitch v-model="sharingEnabled" type="switch">
+			Enable sharing.
+			<template #description>
+				Or you can use a description as slot which can also be a <strong>long multiline text</strong>, that will be wrapped in a second row.
+			</template>
+		</NcCheckboxRadioSwitch>
+
 		<br>
 		sharingEnabled: {{ sharingEnabled }}
 	</div>
@@ -296,11 +312,16 @@ export default {
 			:button-variant="buttonVariant"
 			:is-checked="isChecked"
 			:loading="loading"
+			:description="description"
 			:size="size"
 			@click.native="onToggle">
 			<template #icon>
 				<!-- @slot The checkbox/radio icon, you can use it for adding an icon to the button variant -->
 				<slot name="icon" />
+			</template>
+			<template #description>
+				<!-- @slot The checkbox/radio description, you can use it for adding an complex description element to the button variant as opposed to the description slot -->
+				<slot name="description" />
 			</template>
 
 			<!-- @slot The checkbox/radio label -->
@@ -470,6 +491,16 @@ export default {
 		 * Defaults to `span`
 		 */
 		wrapperElement: {
+			type: String,
+			default: null,
+		},
+
+		/**
+		 * Description
+		 *
+		 * This is unsupported when using button has type.
+		 */
+		description: {
 			type: String,
 			default: null,
 		},


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="836" height="200" alt="image" src="https://github.com/user-attachments/assets/56cd5936-3abe-40f2-aede-4cb5c72bb23b" /> | <img width="836" height="385" alt="image" src="https://github.com/user-attachments/assets/0d42f55e-3cc9-400f-92f4-887172876754" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
