### PR TITLE
chore(docs): fix css modules export names in styleguidist

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -38,6 +38,7 @@ const cssLoaderOptions = {
 		namedExport: false,
 		// Same as in Vite
 		localIdentName: '_[local]_[hash:base64:5]',
+		exportLocalsConvention: 'asIs',
 	},
 }
 


### PR DESCRIPTION
### ☑️ Resolves

- Continue of https://github.com/nextcloud-libraries/nextcloud-vue/pull/7331
- `namedExport` changed the default value of `exportLocalsConvention`, forcing all class names to be `camelCase`

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
