### PR TITLE
fix(NcUserStatusIcon): adjust icon colors

### DIFF
--- a/src/assets/status-icons/user-status-away.svg
+++ b/src/assets/status-icons/user-status-away.svg
@@ -4,6 +4,6 @@
 -->
 <svg viewBox="0 -960 960 960" width="24px" height="24px" xmlns="http://www.w3.org/2000/svg">
 	<path
-		fill="var(--color-favorite)"
+		fill="var(--color-icon-away, var(--color-warning, #C88800))"
 		d="m612-292 56-56-148-148v-184h-80v216l172 172ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z"/>
 </svg>

--- a/src/assets/status-icons/user-status-busy.svg
+++ b/src/assets/status-icons/user-status-busy.svg
@@ -4,6 +4,6 @@
 -->
 <svg viewBox="0 -960 960 960" width="24px" height="24px" xmlns="http://www.w3.org/2000/svg">
 	<path
-		fill="var(--color-border-error, var(--color-error))"
+		fill="var(--color-icon-busy, var(--color-error, #DB0606))"
 		d="M480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z"/>
 </svg>

--- a/src/assets/status-icons/user-status-dnd.svg
+++ b/src/assets/status-icons/user-status-dnd.svg
@@ -4,6 +4,6 @@
 -->
 <svg viewBox="0 -960 960 960" width="24px" height="24px" xmlns="http://www.w3.org/2000/svg">
 	<path
-		fill="var(--color-border-error, var(--color-error))"
+		fill="var(--color-icon-busy, var(--color-error, #DB0606))"
 		d="M280-440h400v-80H280v80ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z"/>
 </svg>

--- a/src/assets/status-icons/user-status-invisible.svg
+++ b/src/assets/status-icons/user-status-invisible.svg
@@ -4,6 +4,6 @@
 -->
 <svg viewBox="0 -960 960 960" width="24px" height="24px" xmlns="http://www.w3.org/2000/svg">
 	<path
-		fill="var(--color-text-maxcontrast)"
+		fill="var(--color-icon-offline, var(--color-text-maxcontrast, #6B6B6B))"
 		d="M480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/>
 </svg>

--- a/src/assets/status-icons/user-status-online.svg
+++ b/src/assets/status-icons/user-status-online.svg
@@ -4,6 +4,6 @@
 -->
 <svg viewBox="0 -960 960 960" width="24px" height="24px" xmlns="http://www.w3.org/2000/svg">
 	<path
-		fill="var(--color-border-success, var(--color-success))"
+		fill="var(--color-icon-online, var(--color-success, #2D7B41))"
 		d="m424-296 282-282-56-56-226 226-114-114-56 56 170 170Zm56 216q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z"/>
 </svg>

--- a/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
+++ b/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
@@ -12,29 +12,56 @@ This component displays a user status icon.
 
 ```vue
 <template>
-	<div class="grid">
-		<NcUserStatusIcon status="online" />
-		<span>Online</span>
-		<NcUserStatusIcon status="away" />
-		<span>Away</span>
-		<NcUserStatusIcon status="busy" />
-		<span>Busy</span>
-		<NcUserStatusIcon status="dnd" />
-		<span>Do not disturb</span>
-		<NcUserStatusIcon status="invisible" />
-		<span>Invisible</span>
-		<NcUserStatusIcon status="offline" />
-		<span>Offline</span>
+	<div class="flex">
+		<div class="grid">
+			<NcUserStatusIcon status="online" />
+			<span>Online</span>
+			<NcUserStatusIcon status="away" />
+			<span>Away</span>
+			<NcUserStatusIcon status="busy" />
+			<span>Busy</span>
+			<NcUserStatusIcon status="dnd" />
+			<span>Do not disturb</span>
+			<NcUserStatusIcon status="invisible" />
+			<span>Invisible</span>
+			<NcUserStatusIcon status="offline" />
+			<span>Offline</span>
+		</div>
+
+		<NcThemeProvider dark>
+			<div class="grid">
+				<NcUserStatusIcon status="online" />
+				<span>Online</span>
+				<NcUserStatusIcon status="away" />
+				<span>Away</span>
+				<NcUserStatusIcon status="busy" />
+				<span>Busy</span>
+				<NcUserStatusIcon status="dnd" />
+				<span>Do not disturb</span>
+				<NcUserStatusIcon status="invisible" />
+				<span>Invisible</span>
+				<NcUserStatusIcon status="offline" />
+				<span>Offline</span>
+			</div>
+		</NcThemeProvider>
 	</div>
 </template>
 
 <style>
+.flex {
+	display: flex;
+	gap: 4px;
+}
+
 .grid {
 	display: grid;
 	grid-template-columns: 20px 1fr;
 	gap: 8px;
 	align-items: center;
+	padding: 4px;
 	width: fit-content;
+	background-color: var(--color-main-background);
+	color: var(--color-main-text);
 }
 </style>
 ```
@@ -128,7 +155,6 @@ const activeSvg = computed(() => status.value && matchSvg[status.value])
 	--color-icon-busy: #DB0606;
 	--color-icon-away: #C88800;
 	--color-icon-offline: #6B6B6B;
-
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
+++ b/src/components/NcUserStatusIcon/NcUserStatusIcon.vue
@@ -123,6 +123,12 @@ const activeSvg = computed(() => status.value && matchSvg[status.value])
 
 <style lang="scss" scoped>
 .user-status-icon {
+	// Custom colors for the svg icons, to not rely on server variables
+	--color-icon-online: #2D7B41;
+	--color-icon-busy: #DB0606;
+	--color-icon-away: #C88800;
+	--color-icon-offline: #6B6B6B;
+
 	display: flex;
 	justify-content: center;
 	align-items: center;


### PR DESCRIPTION
### ☑️ Resolves

- Fix user status icon colors to be independent from server-defined pallete
```css
	--color-icon-online: #2D7B41;
	--color-icon-busy: #DB0606;
	--color-icon-away: #C88800;
	--color-icon-offline: #6B6B6B;
```
_Colors are hardcoded to SVG as a fallback, to see them in IDE and on Guthub_

### 🖼️ Screenshots

<img width="507" height="424" alt="image" src="https://github.com/user-attachments/assets/73e91237-c29b-4ea6-bb20-0beaa928641d" />


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
