### PR TITLE
fix(NcCheckboxRadioSwitch): Remove some leftover

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -313,7 +313,6 @@ export default {
 			:button-variant="buttonVariant"
 			:is-checked="isChecked"
 			:loading="loading"
-			:description="description"
 			:label-id="labelId"
 			:description-id="descriptionId"
 			:icon-size


### PR DESCRIPTION
### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ ~~Backport to `stable8` for maintained Vue 2 version or not applicable~~ (already fixed in the backport)
