### PR TITLE
fix(NcAssistantIcon): adjust gradient for dark theme

### DIFF
--- a/src/components/NcAssistantIcon/NcAssistantIcon.vue
+++ b/src/components/NcAssistantIcon/NcAssistantIcon.vue
@@ -6,8 +6,70 @@
 <docs>
 ```vue
 <template>
-	<NcAssistantIcon />
+	<NcThemeProvider class="wrapper" :dark="userTheme === 'dark'">
+			<fieldset class="controls">
+				<legend>
+					Color theme
+				</legend>
+				<NcCheckboxRadioSwitch
+					v-model="providerTheme"
+					type="radio"
+					value="dark">
+					Dark
+				</NcCheckboxRadioSwitch>
+				<NcCheckboxRadioSwitch
+					v-model="providerTheme"
+					value="light"
+					type="radio">
+					Light
+				</NcCheckboxRadioSwitch>
+			</div>
+		</fieldset>
+		<NcThemeProvider
+			:dark="providerTheme === 'dark'"
+			:light="providerTheme === 'light'">
+			<div class="theme-preview">
+				<NcAssistantIcon />
+			</div>
+		</NcThemeProvider>
+	</NcThemeProvider>
 </template>
+<script>
+export default {
+	data() {
+		return {
+			providerTheme: 'light',
+		}
+	}
+}
+</script>
+<style scoped>
+.wrapper {
+	background-color: var(--color-main-background);
+	color: var(--color-main-text);
+}
+
+.controls {
+	display: flex;
+	justify-content: center;
+	gap: 2lh;
+}
+
+legend {
+	width: 100%;
+	text-align: center;
+}
+
+.theme-preview {
+	background-color: var(--color-main-background);
+	color: var(--color-main-text);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-top: 0.5lh;
+	min-height: 2lh;
+}
+</style>
 ```
 
 ### Usage as inline icon
@@ -23,6 +85,8 @@
 <script setup lang="ts">
 import { mdiCreation } from '@mdi/js'
 import { computed } from 'vue'
+import { useIsDarkTheme } from '../../composables/useIsDarkTheme/index.ts'
+import { createElementId } from '../../utils/createElementId.ts'
 
 const props = withDefaults(defineProps<{
 	/**
@@ -41,6 +105,8 @@ const props = withDefaults(defineProps<{
 	size: 20,
 })
 
+const isDarkTheme = useIsDarkTheme()
+const gradientId = createElementId()
 const sizePx = computed(() => `${props.size}px`)
 </script>
 
@@ -51,13 +117,18 @@ const sizePx = computed(() => `${props.size}px`)
 		role="img">
 		<svg :class="$style.assistantIcon__svg" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 			<defs>
-				<linearGradient id="AssistantGradient" gradientTransform="rotateX(285)">
+				<linearGradient v-if="isDarkTheme" :id="gradientId" gradientTransform="rotateX(285)">
+					<stop offset="15%" stop-color="#CDACE7" />
+					<stop offset="40%" stop-color="#008FDB" />
+					<stop offset="82%" stop-color="#A180E0" />
+				</linearGradient>
+				<linearGradient v-else :id="gradientId" gradientTransform="rotateX(285)">
 					<stop offset="15%" stop-color="#9669D3" />
 					<stop offset="40%" stop-color="#00679E" />
 					<stop offset="80%" stop-color="#492083" />
 				</linearGradient>
 			</defs>
-			<path :d="mdiCreation" fill="url('#AssistantGradient')" />
+			<path :d="mdiCreation" :fill="`url('#${gradientId}')`" />
 		</svg>
 	</span>
 </template>


### PR DESCRIPTION
### ☑️ Resolves

- Companion to https://github.com/nextcloud/server/pull/54789
- For https://github.com/nextcloud/server/issues/54782

### 🖼️ Screenshots

B | A
-- | --
<img width="35" height="32" alt="image" src="https://github.com/user-attachments/assets/6243bb5b-d5f0-486b-b21e-0ca80919f635" /> | <img width="32" height="32" alt="image" src="https://github.com/user-attachments/assets/7fa3d8f1-a648-41e1-bb9f-3d5cc4d29fa9" />


See styleguide preview.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
