### PR TITLE
[stable8] fix(NcPopover): regression with `this.getPopoverTriggerContainerElement is not a function`

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -324,7 +324,7 @@ export default {
 		 */
 		removeFloatingVueAriaDescribedBy() {
 			// When the popover is shown, floating-vue mutates the root elements of the trigger adding data-popper-shown and incorrect aria-describedby attributes.
-			const triggerContainer = this.getPopoverTriggerContainerElement()
+			const triggerContainer = this.getPopoverTriggerElement()
 			const triggerElements = triggerContainer.querySelectorAll('[data-popper-shown]')
 			for (const el of triggerElements) {
 				el.removeAttribute('aria-describedby')


### PR DESCRIPTION
Function was renamed in
https://github.com/nextcloud-libraries/nextcloud-vue/pull/5155/commits/2ce15eb24b6b3304873399f2ee692acd4182474c#diff-0fd4de7746b137eb9b3ba7251f8c3bd9c9a066a802240c7a6bc993655ae0562fR335
