### PR TITLE
fix(NcCheckboxContent): limit wrapper width

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -226,7 +226,8 @@ export default {
 	max-width: fit-content;
 
 	&__wrapper {
-		flex: 1 0;
+		flex: 1 0 0;
+		max-width: 100%;
 	}
 
 	&__text {


### PR DESCRIPTION
### ☑️ Resolves

- Fix regression from #7378
  - By styleguidist, doesn't seem to affect other demo examples
  - stable doesn't look affected as well

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="483" height="82" alt="image" src="https://github.com/user-attachments/assets/6680b6e6-b920-42a7-b462-a575d7110575" /> | <img width="501" height="82" alt="image" src="https://github.com/user-attachments/assets/e41d241c-d9f2-4ea8-8f7d-66b017506f9a" />


### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
