### PR TITLE
fix(NcRichText): correctly render empty children list

### DIFF
--- a/src/components/NcRichText/NcRichText.vue
+++ b/src/components/NcRichText/NcRichText.vue
@@ -553,6 +553,7 @@ export default {
 						importRehypeHighlightLibrary()
 					}
 					if (String(type) === 'li' && Array.isArray(children)
+						&& children.length !== 0
 						&& children[0].type === 'input'
 						&& children[0].props.type === 'checkbox') {
 						const [inputNode, , ...labelParts] = children


### PR DESCRIPTION
### ☑️ Resolves

- Fix `TypeError: can't access property "type", a[0] is undefined`

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
Error | <img width="220" height="371" alt="image" src="https://github.com/user-attachments/assets/b4e1fc08-f61e-481a-be7d-4814fef9342d" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
