### PR TITLE
fix(NcCheckboxRadioSwitch): ensure label less radio has proper size

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxContent.vue
@@ -40,7 +40,7 @@
 			</slot>
 		</span>
 
-		<span class="checkbox-content__wrapper">
+		<span v-if="$slots.default || $slots.description" class="checkbox-content__wrapper">
 			<span
 				v-if="$slots.default"
 				:id="labelId"


### PR DESCRIPTION
### ☑️ Resolves

When there is no visual label the checkbox / radio should be square.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1260" height="148" alt="Bildschirmfoto_20250908_153835" src="https://github.com/user-attachments/assets/03ec11ed-4eb1-4be7-ae66-81f6634cb56b" />|<img width="1261" height="123" alt="Bildschirmfoto_20250908_153924" src="https://github.com/user-attachments/assets/a6df6442-c519-461e-9539-f4413d89a009" />

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
