### PR TITLE
fix(NcDateTimePicker): use proper day names

### DIFF
--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -516,9 +516,13 @@ function formatLibraryTime(time: LibraryTimeObject): Date {
 
 // Localization
 
-const dayNames = getDayNamesMin()
-
 const weekStart = getFirstDay()
+
+const dayNames = [...getDayNamesMin()]
+// see https://github.com/Vuepic/vue-datepicker/issues/1159
+for (let i = 0; i < weekStart; i++) {
+	dayNames.push(dayNames.shift() as string)
+}
 
 // TRANSLATORS: A very short abbrevation used as a heading for "week number"
 const weekNumName = t('W')


### PR DESCRIPTION
### ☑️ Resolves

- https://github.com/nextcloud-libraries/nextcloud-vue/issues/7469

* ref https://github.com/Vuepic/vue-datepicker/issues/1159

Either this is a bug in the upstream library or wrong documentation. It seems to require the day names in the same order as they would be shown, so first day name is always the `week-start`.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
