### PR TITLE
fix(NcReferenceWidget): harden checks for reference = null

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -104,14 +104,23 @@ export default {
 		},
 
 		hasFullWidth() {
+			if (!this.reference) {
+				return false
+			}
 			return hasFullWidth(this.reference.richObjectType)
 		},
 
 		hasCustomWidget() {
+			if (!this.reference) {
+				return false
+			}
 			return isWidgetRegistered(this.reference.richObjectType)
 		},
 
 		hasInteractiveView() {
+			if (!this.reference) {
+				return false
+			}
 			return isWidgetRegistered(this.reference.richObjectType) && hasInteractiveView(this.reference.richObjectType)
 		},
 
@@ -139,6 +148,9 @@ export default {
 		},
 
 		compactLink() {
+			if (!this.reference) {
+				return ''
+			}
 			const link = this.reference.openGraphObject.link
 			if (!link) {
 				return ''
@@ -154,6 +166,9 @@ export default {
 		},
 
 		route() {
+			if (!this.reference) {
+				return null
+			}
 			return getRoute(this.$router, this.reference.openGraphObject.link)
 		},
 
@@ -162,6 +177,9 @@ export default {
 		},
 
 		referenceWidgetLinkProps() {
+			if (!this.reference) {
+				return undefined
+			}
 			return this.route
 				? { to: this.route }
 				: { href: this.reference.openGraphObject.link, target: '_blank' }
@@ -208,11 +226,15 @@ export default {
 		},
 
 		renderWidget() {
+			if (!this.reference) {
+				return
+			}
+
 			if (!this.$refs.customWidget) {
 				return
 			}
 
-			if (this?.reference?.richObjectType === 'open-graph') {
+			if (this.reference.richObjectType === 'open-graph') {
 				return
 			}
 
@@ -233,8 +255,8 @@ export default {
 		},
 
 		destroyWidget() {
-			if (this.rendered) {
-				destroyWidget(this.reference.richObjectType, this.$el)
+			if (this.rendered && this.widgetRoot) {
+				destroyWidget(this.reference.richObjectType, this.widgetRoot)
 				this.rendered = false
 			}
 		},


### PR DESCRIPTION
### ☑️ Resolves

- Fix #7423 
- Prerequisite to TS migration (I migrated then fixed all type errors to got the coverage for the issue)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="453" height="104" alt="2025-09-09_15h50_55" src="https://github.com/user-attachments/assets/bcf655bf-d975-43d7-9c48-75aba05c275e" /> | <img width="507" height="74" alt="2025-09-09_15h48_59" src="https://github.com/user-attachments/assets/f04a9dc5-981d-425f-bd2a-a7664c151d3a" />
<img width="441" height="139" alt="2025-09-09_15h51_07" src="https://github.com/user-attachments/assets/18fc42a8-4b30-4890-bec0-97ffe9b8e121" /> | Clean


### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
