### PR TITLE
fix(useHotKey): use correct callback type

### DIFF
--- a/src/composables/useHotKey/index.ts
+++ b/src/composables/useHotKey/index.ts
@@ -112,11 +112,11 @@ function eventHandler(callback: KeyboardEventHandler, options: UseHotKeyOptions)
  * @param keysOrFilter - keyboard key(s) to listen to, or filter function or pass `true` for listening to all keys
  * @param callback - callback function
  * @param options - composable options
- * @see docs/composables/usekeystroke.md
+ * @see docs/composables/useHotKey.md
  */
 export function useHotKey(
 	keysOrFilter: true | string | string[] | ((e: KeyboardEvent) => boolean),
-	callback = () => {},
+	callback: KeyboardEventHandler = () => {},
 	options: UseHotKeyOptions = {},
 ) {
 	if (disableKeyboardShortcuts) {


### PR DESCRIPTION
### ☑️ Resolves

Use the correct type for the callback method as otherwise it will be a typescript error when you try to access the event.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
