### PR TITLE
fix(NcPopover): revert disabling close on click outside by default

### DIFF
--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -251,7 +251,8 @@ export default {
 		 */
 		closeOnClickOutside: {
 			type: Boolean,
-			default: false,
+			// eslint-disable-next-line vue/no-boolean-default
+			default: true,
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

- Close NcPopover on click outside by default
- Regression from: https://github.com/nextcloud-libraries/nextcloud-vue/pull/6802/
- `closeOnClickOutside` setting `autohide` has `default: false`, although in the past `autoHide` has `default: true`

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
