### PR TITLE
feat(NcPopover): replace `closeOnClickOutside` with `noCloseOnClickOutside`

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1788,7 +1788,7 @@ export default {
 					...this.manualOpen && {
 						triggers: [],
 					},
-					closeOnClickOutside: !this.manualOpen,
+					noCloseOnClickOutside: this.manualOpen,
 					popoverBaseClass: 'action-item__popper',
 					popupRole: this.config.popupRole,
 					setReturnFocus: this.config.withFocusTrap ? this.$refs.triggerButton?.$el : undefined,

--- a/src/components/NcPopover/NcPopover.vue
+++ b/src/components/NcPopover/NcPopover.vue
@@ -179,7 +179,7 @@ See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/
 		ref="popover"
 		v-model:shown="internalShown"
 		:arrow-padding="10"
-		:auto-hide="closeOnClickOutside"
+		:auto-hide="!noCloseOnClickOutside && closeOnClickOutside"
 		:boundary="boundary || undefined"
 		:container
 		:delay
@@ -248,11 +248,21 @@ export default {
 
 		/**
 		 * Automatically hide the popover on click outside.
+		 *
+		 * @deprecated Use `no-close-on-click-outside` instead (inverted value)
 		 */
 		closeOnClickOutside: {
 			type: Boolean,
 			// eslint-disable-next-line vue/no-boolean-default
 			default: true,
+		},
+
+		/**
+		 * Disable the automatic popover hide on click outside.
+		 */
+		noCloseOnClickOutside: {
+			type: Boolean,
+			default: false,
 		},
 
 		/**


### PR DESCRIPTION
### ☑️ Resolves

- On top of: https://github.com/nextcloud-libraries/nextcloud-vue/pull/7524
- Keeping boolean props `false` by default

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
