### PR TITLE
[stable8] fix(NcAvatar): log error and URL on error

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -896,8 +896,8 @@ export default {
 				// re-get to avoid concurrent access
 				setUserHasAvatar(this.user, true)
 			}
-			img.onerror = () => {
-				logger.debug('Invalid avatar url', url)
+			img.onerror = (error) => {
+				logger.debug('Invalid avatar url', { error, url })
 				// Avatar is invalid, reset
 				this.avatarUrlLoaded = null
 				this.avatarSrcSetLoaded = null


### PR DESCRIPTION
### ☑️ Resolves

- Gets insights into <img width="1167" height="122" alt="image" src="https://github.com/user-attachments/assets/1f50e4e6-b620-445a-814a-3139bd3cf875" />


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
n/a | n/a

### 🚧 Tasks

- [x] Work

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
