### PR TITLE
[stable8] fix(NcAppContent): add reactivity to pane config key 

### DIFF
--- a/src/components/NcAppContent/NcAppContent.vue
+++ b/src/components/NcAppContent/NcAppContent.vue
@@ -397,6 +397,13 @@ export default {
 				}
 			},
 		},
+
+		paneConfigKey: {
+			immediate: true,
+			handler() {
+				this.restorePaneConfig()
+			},
+		},
 	},
 
 	updated() {


### PR DESCRIPTION
☑️ Resolves

Previously if changing the pane config key the settings of the pane would not update automatically, now they do.
