### PR TITLE
feat(NcModal): expose `initialFocus` prop for focus-trap options

### DIFF
--- a/src/components/NcDialog/NcDialog.vue
+++ b/src/components/NcDialog/NcDialog.vue
@@ -211,6 +211,7 @@ export default {
 </docs>
 
 <script setup lang="ts">
+import type { FocusTargetOrFalse } from 'focus-trap'
 import type { Slot } from 'vue'
 import type { ComponentProps, VueClassType } from '../../utils/VueTypes.ts'
 
@@ -236,6 +237,12 @@ const props = withDefaults(defineProps<{
 
 	/** Additional elements to add to the focus trap */
 	additionalTrapElements?: Array<string | HTMLElement>
+
+	/** Set element to return focus to after focus trap deactivation */
+	setReturnFocus?: FocusTargetOrFalse
+
+	/** Specify an element to receive initial focus after focus trap activation */
+	initialFocus?: FocusTargetOrFalse
 
 	/**
 	 * The element where to mount the dialog, if `null` is passed the dialog is mounted in place.
@@ -490,6 +497,8 @@ const modalProps = computed(() => ({
 	outTransition: props.outTransition,
 	closeOnClickOutside: props.closeOnClickOutside,
 	additionalTrapElements: props.additionalTrapElements,
+	setReturnFocus: props.setReturnFocus,
+	initialFocus: props.initialFocus,
 }))
 </script>
 

--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -558,6 +558,16 @@ export default {
 			default: undefined,
 			type: [Boolean, HTMLElement, SVGElement, String],
 		},
+
+		/**
+		 * Specify an element to receive initial focus after focus trap activation
+		 *
+		 * @type {import('focus-trap').FocusTargetValueOrFalse}
+		 */
+		initialFocus: {
+			default: undefined,
+			type: [Boolean, HTMLElement, SVGElement, String],
+		},
 	},
 
 	emits: [
@@ -863,6 +873,7 @@ export default {
 				// Focus trap is deactivated on modal close anyway.
 				escapeDeactivates: false,
 				setReturnFocus: this.setReturnFocus,
+				initialFocus: this.initialFocus,
 			}
 
 			// Init focus trap


### PR DESCRIPTION
### ☑️ Resolves

- Exposing `initialFocus` and `setReturnFocus` to NcModal and NcDialog consumers
	- See https://github.com/focus-trap/focus-trap#initialfocus
	- Allows to manipulate initial focus (e.g. in case first element in the trap is NcSelect and we don't want it to be open)


### 🖼️ Screenshots

### 🚧 Tasks

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
