### PR TITLE
fix(NcInputField): use empty string to fix label position

### DIFF
--- a/src/components/NcInputField/NcInputField.vue
+++ b/src/components/NcInputField/NcInputField.vue
@@ -163,7 +163,17 @@ const inputElement = useTemplateRef('input')
 
 const hasTrailingIcon = computed(() => props.showTrailingButton || props.success)
 
-const internalPlaceholder = computed(() => props.placeholder || (isLegacy ? props.label : undefined))
+const internalPlaceholder = computed(() => {
+	if (props.placeholder) {
+		return props.placeholder
+	}
+	if (props.label) {
+		// if there is a label we use it as fallback on legacy but on current we need
+		// to pass at least an empty string as placeholder to make css `:placeholder-shown` work.
+		return isLegacy ? props.label : ''
+	}
+	return undefined
+})
 
 const isValidLabel = computed(() => {
 	const isValidLabel = props.label || props.labelOutside


### PR DESCRIPTION
### ☑️ Resolves

If there is no placeholder we need still at least an empty string to make the label animation with `:placeholder-shown` work.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
