### PR TITLE
fix(NcAppNavigation): also emit `navigation-toggled` on mobile change

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigation.vue
+++ b/src/components/NcAppNavigation/NcAppNavigation.vue
@@ -197,12 +197,15 @@ watchEffect(() => {
 	}
 })
 
-watch(isMobile, () => {
-	open.value = !isMobile.value
+watch(isMobile, (value: boolean) => {
+	open.value = !value
 })
 
-watch(open, () => {
+watch(open, (value: boolean) => {
 	toggleFocusTrap()
+	emit('navigation-toggled', {
+		open: value,
+	})
 })
 
 onMounted(() => {


### PR DESCRIPTION
Since we keep and adjust the internal state and react to `isMobile`, we should advertise that state as we do for the normal open/close methods.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
