### PR TITLE
fix(widgets): show description even on smaller embeds

### DIFF
--- a/src/components/NcRichText/NcReferenceWidget.vue
+++ b/src/components/NcRichText/NcReferenceWidget.vue
@@ -73,8 +73,8 @@ const noAccess = computed(() => {
 })
 
 const numberOfLines = computed(() => {
-	// no description for width < 450, one line until 550 and so on
-	const lineCountOffsets = [450, 550, 650, Infinity]
+	// no description for width < 250, one line until 550 and so on
+	const lineCountOffsets = [250, 550, 650, Infinity]
 	return lineCountOffsets.findIndex((max) => width.value < max)
 })
 
@@ -293,7 +293,8 @@ function destroyReferenceWidget() {
 
 	&--details {
 		padding: calc(var(--default-grid-baseline, 4px) * 3);
-		width: 60%;
+		width: 0;
+		flex-grow: 1;
 
 		p {
 			margin: 0;


### PR DESCRIPTION
### ☑️ Resolves

- Fix #8524, only observed results in the usage of the Talk app only. Other consumers may see changed behavior with rich widgets that are < 450px.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="338" height="217" alt="image" src="https://github.com/user-attachments/assets/bd0b9f17-29b6-4473-8fc9-3df016445846" /> | <img width="340" height="235" alt="image" src="https://github.com/user-attachments/assets/6b5d31ff-db92-4013-9a10-ae99791201d9" />


### 🚧 Tasks

- [X] ...

### 🏁 Checklist

- [X] ⛑️ Tests are included or are not applicable (NA)
- [X] 📘 Component documentation has been extended, updated or is not applicable (NA)
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
