### PR TITLE
fix(NcSelect): floating label design using NcTextField

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -484,7 +484,7 @@ export default {
 		</template>
 		<template #search="{ attributes, events }">
 			<!--
-				v-bind MUST come before explicit props — Vue 3 last-binding-wins.
+				v-bind MUST come before explicit props, Vue 3 last-binding-wins.
 				We spread vue-select attributes but null out placeholder/value/modelValue
 				so our explicit bindings below take precedence.
 			-->
@@ -963,7 +963,11 @@ export default {
 				const addClass = {
 					name: 'addClass',
 					fn(/* middlewareArgs */) {
-						dropdownMenu.classList.add('vs__dropdown-menu--floating')
+						// `nc-select__dropdown` scopes our menu styles: the menu is
+						// teleported to <body>, so it cannot be reached by the
+						// `.nc-select` root scope and would otherwise style every
+						// vue-select dropdown on the page (cross-version conflicts).
+						dropdownMenu.classList.add('vs__dropdown-menu--floating', 'nc-select__dropdown')
 						return {}
 					},
 				}
@@ -1296,7 +1300,7 @@ export default {
 	&.vs--multiple {
 		.vs__dropdown-toggle {
 			// Use transparent border in closed state to reserve the same space
-			// as the open state's real border — prevents layout jump on click
+			// as the open state's real border, prevents layout jump on click
 			border: var(--border-width-input-focused, 2px) solid transparent;
 			box-shadow: var(--input-border-box-shadow);
 			// Top padding for floating label clearance, no bottom padding
@@ -1324,13 +1328,13 @@ export default {
 			outline: 2px solid var(--color-main-background);
 		}
 
-		// Remove NcTextField border in multi mode — border is on dropdown-toggle
+		// Remove NcTextField border in multi mode, border is on dropdown-toggle
 		.vs__search .input-field__input {
 			box-shadow: none !important;
 			background: transparent;
 		}
 
-		// NcTextField shares flex row with tags — always inline, no absolute hiding.
+		// NcTextField shares flex row with tags, always inline, no absolute hiding.
 		// No min-width: it may shrink fully so it never forces an empty wrap row
 		// (matches vue-select's own search sizing)
 		.vs__search {
@@ -1356,7 +1360,7 @@ export default {
 			}
 		}
 
-		// No label margin needed — label is via #header
+		// No label margin needed, label is via #header
 		.vs__search .input-field {
 			margin-block-start: 0;
 		}
@@ -1469,10 +1473,11 @@ export default {
 	}
 }
 
-// Dropdown menu is teleported to body by floating-ui, so it must be
-// styled at root level (cannot be nested under .v-select.select).
-// CSS variables must also be set here since it can't inherit from .v-select.select.
-.vs__dropdown-menu {
+// Dropdown menu is teleported to <body>, so it can't live under the
+// `.nc-select` root scope. The `.nc-select__dropdown` class (added in
+// calculatePosition) scopes it instead, so these styles and CSS variables
+// only affect our menus and never leak to other vue-select instances.
+.nc-select__dropdown.vs__dropdown-menu {
 	--vs-border-color: var(--color-border-maxcontrast);
 	--vs-border-style: solid;
 	--vs-border-radius: var(--border-radius-element);
@@ -1524,7 +1529,7 @@ export default {
 	}
 }
 
-// Border for .vs__dropdown-toggle — inlined from inputLikeBorder mixin
+// Border for .vs__dropdown-toggle, inlined from inputLikeBorder mixin
 // because the mixin's @media #{&} produces doubled selectors when nested.
 .nc-select.v-select.select .vs__dropdown-toggle {
 	--input-border-box-shadow-light: 0 -1px var(--vs-border-color),

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1014,7 +1014,7 @@ export default {
 							addClass,
 							togglePlacementClass,
 							// On top placement, leave a gap for the floating label overhang
-							// (half the 13px/1.5 label line-height) instead of connecting seamlessly
+							// (about half the floated label line-height) instead of connecting seamlessly
 							offset(({ placement }) => (placement.startsWith('top') ? 10 : -1)),
 							shift({ limiter: limitShift() }),
 						],
@@ -1178,7 +1178,7 @@ export default {
 	// Force floating label when a value is selected (search input is empty but a value exists)
 	.vs__selected-options:has(.vs__selected) .vs__search {
 		.input-field__input + .input-field__label {
-			--input-label-font-size: 13px;
+			--input-label-font-size: var(--font-size-small, 13px);
 			line-height: 1.5;
 			inset-block-start: calc(-1.5 * var(--input-label-font-size) / 2);
 			font-weight: 500;
@@ -1397,7 +1397,7 @@ export default {
 		// Float label when has tags or dropdown is open
 		&:has(.vs__selected) .select__label,
 		&.vs--open .select__label {
-			--input-label-font-size: 13px;
+			--input-label-font-size: var(--font-size-small, 13px);
 			font-size: var(--input-label-font-size);
 			line-height: 1.5;
 			// Match NcInputField: half the line-height above the border

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -150,6 +150,150 @@ export default {
 </style>
 ```
 
+### Pre-selected and clearable
+
+```vue
+<template>
+	<div class="grid">
+		<div class="container">
+			<NcSelect v-model="singleValue"
+				input-label="Clearable single"
+				:options="options"
+				clearable />
+		</div>
+		<div class="container">
+			<NcSelect v-model="singlePlaceholder"
+				input-label="With placeholder"
+				placeholder="Search for something..."
+				:options="options" />
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			options: ['foo', 'bar', 'baz', 'qux', 'quux'],
+			singleValue: 'bar',
+			singlePlaceholder: null,
+		}
+	},
+}
+</script>
+
+<style>
+.grid {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 10px;
+}
+
+.container {
+	display: flex;
+	flex-direction: column;
+}
+</style>
+```
+
+### Disabled state
+
+```vue
+<template>
+	<div class="grid">
+		<div class="container">
+			<NcSelect v-model="singleValue"
+				input-label="Disabled single"
+				:options="options"
+				disabled />
+		</div>
+		<div class="container">
+			<NcSelect v-model="multiValue"
+				input-label="Disabled multi"
+				:options="options"
+				multiple
+				disabled />
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			options: ['foo', 'bar', 'baz'],
+			singleValue: 'foo',
+			multiValue: ['foo', 'bar'],
+		}
+	},
+}
+</script>
+
+<style>
+.grid {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 10px;
+}
+
+.container {
+	display: flex;
+	flex-direction: column;
+}
+</style>
+```
+
+### Label outside
+
+```vue
+<template>
+	<div class="grid">
+		<div class="container">
+			<label for="ext-single">External label (single)</label>
+			<NcSelect v-model="singleValue"
+				input-id="ext-single"
+				label-outside
+				placeholder="Pick an option"
+				:options="options" />
+		</div>
+		<div class="container">
+			<label for="ext-multi">External label (multi)</label>
+			<NcSelect v-model="multiValue"
+				input-id="ext-multi"
+				label-outside
+				:options="options"
+				multiple />
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			options: ['foo', 'bar', 'baz', 'qux', 'quux'],
+			singleValue: null,
+			multiValue: [],
+		}
+	},
+}
+</script>
+
+<style>
+.grid {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 10px;
+}
+
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+</style>
+```
+
 ### Native form validation example
 
 ```vue
@@ -323,6 +467,7 @@ export default {
 
 <template>
 	<VueSelect
+		data-v-new-select
 		class="select"
 		:class="{
 			'select--legacy': isLegacy,
@@ -331,7 +476,7 @@ export default {
 		v-bind="propsToForward"
 		@search="search = $event"
 		@update:modelValue="$emit('update:modelValue', $event)">
-		<template v-if="!labelOutside && inputLabel" #header>
+		<template v-if="multiple && !labelOutside && inputLabel" #header>
 			<label
 				:for="inputId"
 				class="select__label">
@@ -339,13 +484,25 @@ export default {
 			</label>
 		</template>
 		<template #search="{ attributes, events }">
-			<input
+			<!--
+				v-bind MUST come before explicit props — Vue 3 last-binding-wins.
+				We spread vue-select attributes but null out placeholder/value/modelValue
+				so our explicit bindings below take precedence.
+			-->
+			<NcTextField
+				v-bind="{ ...attributes, placeholder: undefined, value: undefined, modelValue: undefined }"
 				class="vs__search"
 				:class="[inputClass]"
-				v-bind="attributes"
+				:modelValue="attributes.value"
+				:placeholder="multiple || modelValue ? '' : (placeholder || '')"
+				:label="!labelOutside && !multiple && inputLabel ? inputLabel : ''"
+				:labelOutside="labelOutside || multiple"
+				:disabled="disabled"
 				:required="inputRequired"
-				dir="auto"
-				v-on="events">
+				v-on="filterEvents(events)"
+				@update:modelValue="events.input({ target: { value: $event } })" />
+			<!-- No placeholder when: multi mode (select__label serves as placeholder)
+				 or value selected (vs__selected overlay shows the value instead). -->
 		</template>
 		<template #open-indicator="{ attributes }">
 			<ChevronDown
@@ -354,8 +511,7 @@ export default {
 				:style="{
 					cursor: !disabled ? 'pointer' : null,
 				}"
-				:size="26" />
-				<!-- Set size to 26 to make up for the increased padding of this icon -->
+				:size="20" />
 		</template>
 		<template #option="option">
 			<!-- @slot Customize how a option is rendered. -->
@@ -401,6 +557,7 @@ import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import Close from 'vue-material-design-icons/Close.vue'
 import NcEllipsisedOption from '../NcEllipsisedOption/NcEllipsisedOption.vue'
 import NcLoadingIcon from '../NcLoadingIcon/NcLoadingIcon.vue'
+import NcTextField from '../NcTextField/NcTextField.vue'
 import { t } from '../../l10n.ts'
 import { createElementId } from '../../utils/createElementId.ts'
 import { isLegacy } from '../../utils/legacy.ts'
@@ -412,6 +569,7 @@ export default {
 		ChevronDown,
 		NcEllipsisedOption,
 		NcLoadingIcon,
+		NcTextField,
 		VueSelect,
 	},
 
@@ -830,11 +988,13 @@ export default {
 					computePosition(component.$refs.toggle, dropdownMenu, {
 						placement: this.placement,
 						middleware: [
-							offset(-1),
+							// Flip first so the placement-dependent middleware below see the final placement
+							flip(),
 							addClass,
 							togglePlacementClass,
-							// Match popperjs default collision prevention behavior by appending the following middleware in order
-							flip(),
+							// On top placement, leave a gap for the floating label overhang
+							// (half the 13px/1.5 label line-height) instead of connecting seamlessly
+							offset(({ placement }) => (placement.startsWith('top') ? 10 : -1)),
 							shift({ limiter: limitShift() }),
 						],
 					}).then(({ x, y }) => {
@@ -895,6 +1055,21 @@ export default {
 
 	methods: {
 		t,
+
+		/**
+		 * Filter out the `input` event from vue-select events.
+		 * Input is handled via @update:modelValue to avoid double-firing.
+		 * All other events (keydown, blur, focus, compositionstart, compositionend)
+		 * must reach the native <input> for keyboard nav, dropdown close, and IME.
+		 *
+		 * @param {object} events vue-select event handlers
+		 * @return {object} events without `input`
+		 */
+		filterEvents(events) {
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { input, ...rest } = events
+			return rest
+		},
 	},
 }
 </script>
@@ -902,12 +1077,8 @@ export default {
 <style lang="scss">
 @use '../../assets/input-border.scss' as border;
 
-body {
-	/**
-	 * Set custom vue-select CSS variables.
-	 * Needs to be on the body (not :root) for theming to apply (see nextcloud/server#36462)
-	 */
-
+[data-v-new-select].v-select.select {
+	/* Custom vue-select CSS variables scoped to NcSelect */
 	/* Search Input */
 	--vs-search-input-color: var(--color-main-text);
 	--vs-search-input-bg: var(--color-main-background);
@@ -966,10 +1137,7 @@ body {
 	--vs-transition-duration: 0ms;
 
 	/* Actions */
-	--vs-actions-padding: 0 8px 0 4px;
-}
-
-.v-select.select {
+	--vs-actions-padding: 0 8px 0 8px;
 	/* Override default vue-select styles */
 	min-height: calc(var(--default-clickable-area) - 2 * var(--border-width-input));
 	min-width: 260px;
@@ -979,13 +1147,9 @@ body {
 		--vs-border-width: var(--border-width-input-focused, 2px);
 	}
 
-	.select__label {
-		display: block;
-		margin-bottom: 2px;
-	}
-
 	.vs__selected {
-		height: calc(var(--default-clickable-area) - 2 * var(--vs-border-width) - var(--default-grid-baseline));
+		// min-height (not height) so multi-line entries like NcSelectUsers chips can grow
+		min-height: calc(var(--default-clickable-area) - 2 * var(--vs-border-width) - var(--default-grid-baseline));
 		margin: calc(var(--default-grid-baseline) / 2);
 		padding-block: 0;
 		padding-inline: 12px 8px;
@@ -994,64 +1158,84 @@ body {
 		border: none;
 	}
 
-	&.vs--open .vs__selected:first-of-type {
-		margin-inline-start: calc(var(--default-grid-baseline) / 2 - (var(--border-width-input-focused, 2px) - var(--border-width-input, 2px))) !important; // prevent jumping
+	.vs__search {
+		// NcTextField filling the search area; padding-end reserved for the actions overlay
+		width: 100%;
+		--input-padding-end: calc(var(--default-clickable-area) + var(--default-grid-baseline));
+
+		// Neutralize vue-select defaults on the wrapper div (no longer the native input)
+		border: none !important;
+		margin: 0 !important;
+		padding: 0 !important;
 	}
 
-	.vs__search {
-		text-overflow: ellipsis;
-		color: var(--color-main-text);
-		min-height: unset !important;
-		height: calc(var(--default-clickable-area) - 2 * var(--vs-border-width)) !important;
-
-		&::placeholder {
-			color: var(--color-text-maxcontrast);
+	// Force floating label when a value is selected (search input is empty but a value exists)
+	.vs__selected-options:has(.vs__selected) .vs__search {
+		.input-field__input + .input-field__label {
+			--input-label-font-size: 13px;
+			line-height: 1.5;
+			inset-block-start: calc(-1.5 * var(--input-label-font-size) / 2);
+			font-weight: 500;
+			border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0;
+			background-color: var(--color-main-background);
+			padding-inline: var(--default-grid-baseline);
+			margin-inline: calc(var(--input-padding-start) - var(--default-grid-baseline)) calc(var(--input-padding-end) - var(--default-grid-baseline));
+			transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick);
 		}
 	}
 
-	.vs__search, .vs__search:focus {
-		margin: 0;
-	}
-
-	.vs__dropdown-toggle {
-		position: relative;
-		max-height: 100px;
-		padding: var(--border-width-input);
-		overflow-y: auto;
+	// Single mode: border is on NcTextField, dropdown-toggle is invisible
+	&:not(.vs--multiple) .vs__dropdown-toggle {
+		padding: 0;
+		overflow: visible;
+		border: none !important;
+		box-shadow: none !important;
+		background: transparent;
 	}
 
 	.vs__actions {
-		position: sticky;
-		top: 0;
+		position: absolute;
+		z-index: 999;
+		inset-inline-end: 0;
+		top: 50%;
+		transform: translateY(-50%);
+		height: 100%;
+		margin-block-start: 1px;
+		display: flex;
+		align-items: center;
 	}
 
 	.vs__clear {
 		margin-inline-end: 2px;
 	}
 
-	&.vs--open .vs__dropdown-toggle {
-		border-color: var(--color-main-text);
-		border-bottom-color: transparent;
-		border-bottom-left-radius: 0;
-		border-bottom-right-radius: 0;
-		border-style: solid;
-		border-width: var(--border-width-input-focused);
-		outline: 2px solid var(--color-main-background);
-		padding: 0;
-	}
-
-	&:not(.vs--disabled, .vs--open) {
-		.vs__dropdown-toggle:active,
-		.vs__dropdown-toggle:focus-within {
-			outline: 2px solid var(--color-main-background);
-			border-color: var(--color-main-text);
+	&.vs--open {
+		// Remove bottom border-radius when dropdown is open
+		.vs__search .input-field__input {
+			border-end-start-radius: 0 !important;
+			border-end-end-radius: 0 !important;
 		}
 	}
 
 	&.vs--disabled {
+		// Override vue-select's disabled background on all internal elements
+		// to prevent stacking with NcInputField's own background
+		.vs__clear,
+		.vs__dropdown-toggle,
+		.vs__open-indicator,
+		.vs__open-indicator-button,
 		.vs__search,
 		.vs__selected {
+			background-color: transparent;
 			color: var(--color-text-maxcontrast);
+		}
+
+		// Lighter border in disabled state to match single mode (NcInputField uses --color-border-dark)
+		.vs__dropdown-toggle {
+			--input-border-box-shadow-light: 0 -1px var(--color-border-dark),
+				0 0 0 1px color-mix(in srgb, var(--color-border-dark), 65% transparent);
+			--input-border-box-shadow-dark: 0 1px var(--color-border-dark),
+				0 0 0 1px color-mix(in srgb, var(--color-border-dark), 65% transparent);
 		}
 
 		.vs__clear,
@@ -1061,9 +1245,12 @@ body {
 	}
 
 	&--no-wrap {
+		.vs__dropdown-toggle {
+			overflow: hidden;
+		}
 		.vs__selected-options {
 			flex-wrap: nowrap;
-			overflow: auto;
+			overflow: auto !important;
 			min-width: unset;
 			.vs__selected {
 				min-width: unset;
@@ -1071,52 +1258,233 @@ body {
 		}
 	}
 
+	// Drop-up: the menu is detached above the select (calculatePosition leaves a
+	// gap for the floating label, which stays in its usual top position),
+	// so keep the regular fully-rounded borders instead of flattening the seam
 	&--drop-up {
 		&.vs--open {
-			.vs__dropdown-toggle {
-				border-radius: 0 0 var(--vs-border-radius) var(--vs-border-radius);
-				border-top-color: transparent;
-				border-bottom-color: var(--color-main-text);
+			.vs__search .input-field__input {
+				border-end-start-radius: var(--border-radius-element) !important;
+				border-end-end-radius: var(--border-radius-element) !important;
+			}
+
+			// !important to beat the later-defined down-state open rule
+			// (.vs--multiple.vs--open .vs__dropdown-toggle) of equal specificity
+			&.vs--multiple .vs__dropdown-toggle {
+				border-end-start-radius: var(--border-radius-element) !important;
+				border-end-end-radius: var(--border-radius-element) !important;
+				// Bottom is a regular outer edge here, not a divider seam
+				border-block-end-color: var(--color-main-text) !important;
 			}
 		}
 	}
 
 	.vs__selected-options {
 		// If search is hidden, ensure that the height of the search is the same
-		min-height: calc(var(--default-clickable-area) - 2 * var(--vs-border-width));
+		min-height: unset;
 
 		// Hide search from dom if unused to prevent unneeded flex wrap
-		.vs__selected ~ .vs__search[readonly] {
+		.vs__selected ~ .vs__search:has(.input-field__input[readonly]) {
 			position: absolute;
 		}
-		padding: 0 5px;
+		padding: 0;
+		border: none;
+		overflow: visible;
+	}
+
+	// Multi-select: border on dropdown-toggle (contains tags + input)
+	// NcTextField is transparent; floating label via #header slot
+	&.vs--multiple {
+		.vs__dropdown-toggle {
+			// Use transparent border in closed state to reserve the same space
+			// as the open state's real border — prevents layout jump on click
+			border: var(--border-width-input-focused, 2px) solid transparent;
+			box-shadow: var(--input-border-box-shadow);
+			// Top padding for floating label clearance, no bottom padding
+			padding-block: calc(var(--default-grid-baseline) * 1.5) 0;
+			// Left padding so tags don't overlap the border-radius curve,
+			// right padding reserved for the actions overlay (chevron)
+			padding-inline: var(--default-grid-baseline) calc(var(--default-clickable-area) + var(--default-grid-baseline));
+			overflow: visible;
+			background: var(--color-main-background);
+		}
+
+		// Wider reservation when the clear button is shown next to the chevron
+		&:has(.vs__clear) .vs__dropdown-toggle {
+			padding-inline-end: calc(2 * var(--default-clickable-area));
+		}
+
+		// When open, switch to visible border with subtle bottom divider
+		&.vs--open .vs__dropdown-toggle {
+			box-shadow: none !important;
+			border-color: var(--color-main-text);
+			// Subtle divider line between tags and dropdown (not fully transparent)
+			border-block-end-color: var(--color-border-maxcontrast);
+			border-end-start-radius: 0;
+			border-end-end-radius: 0;
+			outline: 2px solid var(--color-main-background);
+		}
+
+		// Remove NcTextField border in multi mode — border is on dropdown-toggle
+		.vs__search .input-field__input {
+			box-shadow: none !important;
+			background: transparent;
+		}
+
+		// NcTextField shares flex row with tags — always inline, no absolute hiding.
+		// No min-width: it may shrink fully so it never forces an empty wrap row
+		// (matches vue-select's own search sizing)
+		.vs__search {
+			width: 0;
+			flex-grow: 1;
+			min-width: 0;
+		}
+
+		// No-wrap: clip overflow inside the toggle (needs to be here
+		// for specificity to beat the overflow: visible above)
+		&.select--no-wrap {
+			.vs__dropdown-toggle {
+				overflow: hidden;
+			}
+
+			.vs__actions {
+				// Slight fade for non-wrap tags display
+				background: linear-gradient(90deg, transparent, var(--color-main-background) 10%, var(--color-main-background) 100%);
+				margin-block: 0px;
+				margin-inline-end: 2px;
+				border-radius: var(--border-radius-element);
+				height: calc(100% - 6px);
+			}
+		}
+
+		// No label margin needed — label is via #header
+		.vs__search .input-field {
+			margin-block-start: 0;
+		}
+
+		// Match NcTextField height to tag row height for consistent toggle sizing
+		.vs__search .input-field__main-wrapper {
+			height: calc(var(--default-clickable-area) - 2 * var(--vs-border-width) - var(--default-grid-baseline));
+			margin: calc(var(--default-grid-baseline) / 2) 0;
+		}
+
+		// Label: centered inside toggle when empty (placeholder-like),
+		// floats above border when has value or open (matches NcInputField)
+		.select__label {
+			position: absolute;
+			z-index: 1;
+			inset-inline-start: var(--border-width-input-focused, 2px);
+			// Center vertically regardless of toggle height
+			top: 50%;
+			transform: translateY(-50%);
+			font-size: var(--default-font-size);
+			margin-inline: var(--border-radius-element);
+			color: var(--color-text-maxcontrast);
+			pointer-events: none;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			max-width: calc(100% - var(--clickable-area-large));
+			transition: top var(--animation-quick), transform var(--animation-quick), font-size var(--animation-quick), font-weight var(--animation-quick), background-color var(--animation-quick) var(--animation-slow);
+		}
+
+		// Float label when has tags or dropdown is open
+		&:has(.vs__selected) .select__label,
+		&.vs--open .select__label {
+			--input-label-font-size: 13px;
+			font-size: var(--input-label-font-size);
+			line-height: 1.5;
+			// Match NcInputField: half the line-height above the border
+			top: calc(-1.5 * var(--input-label-font-size) / 2);
+			transform: none;
+			font-weight: 500;
+			border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0;
+			background-color: var(--color-main-background);
+			padding-inline: var(--default-grid-baseline);
+			margin-inline: calc(var(--border-radius-element) - var(--default-grid-baseline));
+			transition: top var(--animation-quick), transform var(--animation-quick), font-size var(--animation-quick), font-weight var(--animation-quick), background-color var(--animation-quick);
+		}
 	}
 
 	&.vs--single {
+		// In single mode, overlay the selected value on top of the NcTextField input area
+		// so it appears inside the border (which is on the NcTextField, not the toggle)
+		.vs__selected-options {
+			position: relative;
+			flex-wrap: nowrap;
+			// Ensure height even when search input is hidden (vs--unsearchable)
+			min-height: var(--default-clickable-area);
+		}
+
+		.vs__selected {
+			position: absolute;
+			// Skip the label clearance so the overlay covers only the input box,
+			// keeping (multi-line) content like NcSelectUsers centered on the input
+			// (6px = NcInputField .input-field margin-block-start)
+			inset-block: 6px 0;
+			inset-inline-start: 0;
+			inset-inline-end: 0;
+			margin: 0;
+			z-index: 2; // above vs__search (z-index: 1 from vue-select default)
+			pointer-events: none;
+			display: flex;
+			align-items: center;
+			padding-block: 0;
+			// Match the input text position: main-wrapper padding (border width) + input padding
+			padding-inline: calc(var(--border-radius-element) + var(--border-width-input-focused, 2px)) var(--input-padding-end, calc(var(--default-clickable-area) + var(--default-grid-baseline)));
+			background: unset !important;
+			border: none;
+			border-radius: 0;
+			height: unset;
+			min-height: unset;
+			font-size: var(--default-font-size);
+			color: var(--color-main-text);
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		// No label clearance to skip when the label is external
+		&:has(.input-field--label-outside) .vs__selected {
+			inset-block-start: 0;
+		}
+
+		// Extra padding when clear button visible (clear + chevron need more space)
+		&:has(.vs__clear) .vs__selected {
+			padding-inline-end: calc(2 * var(--default-clickable-area));
+		}
+
 		&.vs--loading,
 		&.vs--open {
 			.vs__selected {
-				// Fix `max-width` for `position: absolute`
-				max-width: 100%;
-				// Fix color to be accessible
-				opacity: 1;
-				color: var(--color-text-maxcontrast);
+				// Fix color to be accessible while typing
+				opacity: 0.4;
 			}
 		}
-		.vs__selected-options {
-			flex-wrap: nowrap;
-		}
-		.vs__selected {
-			background: unset !important;
+
+		// Hide the selected value as soon as the user types a query
+		// (restores vue-select's default, overridden by our display: flex above)
+		&.vs--searching .vs__selected {
+			display: none;
 		}
 	}
 }
 
-.vs__dropdown-toggle {
-	@include border.inputLikeBorder('.select--legacy', var(--vs-border-color));
-}
-
+// Dropdown menu is teleported to body by floating-ui, so it must be
+// styled at root level (cannot be nested under .v-select.select).
+// CSS variables must also be set here since it can't inherit from .v-select.select.
 .vs__dropdown-menu {
+	--vs-border-color: var(--color-border-maxcontrast);
+	--vs-border-style: solid;
+	--vs-border-radius: var(--border-radius-element);
+	--vs-dropdown-bg: var(--color-main-background);
+	--vs-dropdown-color: var(--color-main-text);
+	--vs-dropdown-option-padding: 8px 20px;
+	--vs-dropdown-option--active-bg: var(--color-background-hover);
+	--vs-dropdown-option--active-color: var(--color-main-text);
+	--vs-dropdown-option--kb-focus-box-shadow: inset 0px 0px 0px 2px var(--color-border-maxcontrast);
+	--vs-dropdown-option--deselect-bg: var(--color-error);
+	--vs-dropdown-option--deselect-color: #fff;
 	border-width: var(--border-width-input-focused) !important;
 	border-color: var(--color-main-text) !important;
 	outline: none !important;
@@ -1134,13 +1502,15 @@ body {
 		top: 0;
 		inset-inline-start: 0;
 
+		// Top placement: the menu is detached from the select (gap for the
+		// floating label), so it keeps a full border on all sides
 		&-placement-top {
-			border-radius: var(--vs-border-radius) var(--vs-border-radius) 0 0 !important;
+			border-radius: var(--vs-border-radius) !important;
 			border-top-style: var(--vs-border-style) !important;
-			border-bottom-style: none !important;
 			box-shadow:
 				0 -2px 0 var(--color-main-background), // Top
 				-2px 0 0 var(--color-main-background), // Right
+				0 2px 0 var(--color-main-background), // Bottom
 				2px 0 0 var(--color-main-background), // Left
 				!important
 		}
@@ -1152,6 +1522,46 @@ body {
 
 	.vs__no-options {
 		color: var(--color-text-maxcontrast) !important;
+	}
+}
+
+// Border for .vs__dropdown-toggle — inlined from inputLikeBorder mixin
+// because the mixin's @media #{&} produces doubled selectors when nested.
+[data-v-new-select].v-select.select .vs__dropdown-toggle {
+	--input-border-box-shadow-light: 0 -1px var(--vs-border-color),
+		0 0 0 1px color-mix(in srgb, var(--vs-border-color), 65% transparent);
+	--input-border-box-shadow-dark: 0 -1px var(--vs-border-color),
+		0 0 0 1px color-mix(in srgb, var(--vs-border-color), 65% transparent);
+	--input-border-box-shadow: var(--input-border-box-shadow-light);
+	border: none;
+	border-radius: var(--border-radius-element);
+	box-shadow: var(--input-border-box-shadow);
+}
+
+// Hover: use .vs--disabled on parent (toggle div never has [disabled] attribute)
+[data-v-new-select].v-select.select:not(.vs--disabled) .vs__dropdown-toggle:hover {
+	box-shadow: 0 0 0 1px var(--vs-border-color);
+}
+
+@media (prefers-color-scheme: dark) {
+	[data-v-new-select].v-select.select .vs__dropdown-toggle {
+		--input-border-box-shadow: var(--input-border-box-shadow-dark);
+	}
+}
+
+[data-theme-dark] [data-v-new-select].v-select.select .vs__dropdown-toggle {
+	--input-border-box-shadow: var(--input-border-box-shadow-dark);
+}
+
+[data-theme-light] [data-v-new-select].v-select.select .vs__dropdown-toggle {
+	--input-border-box-shadow: var(--input-border-box-shadow-light);
+}
+
+.select--legacy[data-v-new-select].v-select.select .vs__dropdown-toggle {
+	box-shadow: 0 0 0 1px var(--vs-border-color);
+
+	&:hover:not([disabled]) {
+		box-shadow: 0 0 0 2px var(--vs-border-color);
 	}
 }
 </style>

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -484,24 +484,42 @@ export default {
 		</template>
 		<template #search="{ attributes, events }">
 			<!--
-				v-bind MUST come before explicit props, Vue 3 last-binding-wins.
-				We spread vue-select attributes but null out placeholder/value/modelValue
-				so our explicit bindings below take precedence.
+				vue-select's `attributes`/`events` are its search-slot contract, not
+				HTML pass-through, so we forward only the combobox a11y attributes and
+				events one by one. This skips `attributes.ref` (a vue-select template
+				ref) and lets our own `modelValue`, `placeholder`, `label` and
+				`disabled` win over their vue-select equivalents.
+				No placeholder when: multi mode (select__label is the placeholder) or a
+				value is selected (the vs__selected overlay shows it instead).
 			-->
 			<NcTextField
-				v-bind="{ ...attributes, placeholder: undefined, value: undefined, modelValue: undefined }"
+				:id="attributes.id"
 				class="vs__search"
 				:class="[inputClass]"
+				:type="attributes.type"
 				:modelValue="attributes.value"
 				:placeholder="multiple || modelValue ? '' : (placeholder || '')"
 				:label="!labelOutside && !multiple && inputLabel ? inputLabel : ''"
 				:labelOutside="labelOutside || multiple"
 				:disabled="disabled"
 				:required="inputRequired"
-				v-on="filterEvents(events)"
+				:role="attributes.role"
+				:tabindex="attributes.tabindex"
+				:readonly="attributes.readonly"
+				:autocomplete="attributes.autocomplete"
+				:aria-label="attributes['aria-label']"
+				:aria-autocomplete="attributes['aria-autocomplete']"
+				:aria-controls="attributes['aria-controls']"
+				:aria-owns="attributes['aria-owns']"
+				:aria-expanded="attributes['aria-expanded']"
+				:aria-activedescendant="attributes['aria-activedescendant']"
+				@keydown="events.keydown"
+				@keypress="events.keypress"
+				@focus="events.focus"
+				@blur="events.blur"
+				@compositionstart="events.compositionstart"
+				@compositionend="events.compositionend"
 				@update:modelValue="events.input({ target: { value: $event } })" />
-			<!-- No placeholder when: multi mode (select__label serves as placeholder)
-				 or value selected (vs__selected overlay shows the value instead). -->
 		</template>
 		<template #open-indicator="{ attributes }">
 			<ChevronDown
@@ -1058,21 +1076,6 @@ export default {
 
 	methods: {
 		t,
-
-		/**
-		 * Filter out the `input` event from vue-select events.
-		 * Input is handled via @update:modelValue to avoid double-firing.
-		 * All other events (keydown, blur, focus, compositionstart, compositionend)
-		 * must reach the native <input> for keyboard nav, dropdown close, and IME.
-		 *
-		 * @param {object} events vue-select event handlers
-		 * @return {object} events without `input`
-		 */
-		filterEvents(events) {
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			const { input, ...rest } = events
-			return rest
-		},
 	},
 }
 </script>

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -467,8 +467,7 @@ export default {
 
 <template>
 	<VueSelect
-		data-v-new-select
-		class="select"
+		class="select nc-select"
 		:class="{
 			'select--legacy': isLegacy,
 			'select--no-wrap': noWrap,
@@ -1077,7 +1076,7 @@ export default {
 <style lang="scss">
 @use '../../assets/input-border.scss' as border;
 
-[data-v-new-select].v-select.select {
+.nc-select.v-select.select {
 	/* Custom vue-select CSS variables scoped to NcSelect */
 	/* Search Input */
 	--vs-search-input-color: var(--color-main-text);
@@ -1527,7 +1526,7 @@ export default {
 
 // Border for .vs__dropdown-toggle — inlined from inputLikeBorder mixin
 // because the mixin's @media #{&} produces doubled selectors when nested.
-[data-v-new-select].v-select.select .vs__dropdown-toggle {
+.nc-select.v-select.select .vs__dropdown-toggle {
 	--input-border-box-shadow-light: 0 -1px var(--vs-border-color),
 		0 0 0 1px color-mix(in srgb, var(--vs-border-color), 65% transparent);
 	--input-border-box-shadow-dark: 0 -1px var(--vs-border-color),
@@ -1539,25 +1538,25 @@ export default {
 }
 
 // Hover: use .vs--disabled on parent (toggle div never has [disabled] attribute)
-[data-v-new-select].v-select.select:not(.vs--disabled) .vs__dropdown-toggle:hover {
+.nc-select.v-select.select:not(.vs--disabled) .vs__dropdown-toggle:hover {
 	box-shadow: 0 0 0 1px var(--vs-border-color);
 }
 
 @media (prefers-color-scheme: dark) {
-	[data-v-new-select].v-select.select .vs__dropdown-toggle {
+	.nc-select.v-select.select .vs__dropdown-toggle {
 		--input-border-box-shadow: var(--input-border-box-shadow-dark);
 	}
 }
 
-[data-theme-dark] [data-v-new-select].v-select.select .vs__dropdown-toggle {
+[data-theme-dark] .nc-select.v-select.select .vs__dropdown-toggle {
 	--input-border-box-shadow: var(--input-border-box-shadow-dark);
 }
 
-[data-theme-light] [data-v-new-select].v-select.select .vs__dropdown-toggle {
+[data-theme-light] .nc-select.v-select.select .vs__dropdown-toggle {
 	--input-border-box-shadow: var(--input-border-box-shadow-light);
 }
 
-.select--legacy[data-v-new-select].v-select.select .vs__dropdown-toggle {
+.select--legacy.nc-select.v-select.select .vs__dropdown-toggle {
 	box-shadow: 0 0 0 1px var(--vs-border-color);
 
 	&:hover:not([disabled]) {

--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1145,7 +1145,7 @@ export default {
 	/* Actions */
 	--vs-actions-padding: 0 8px 0 8px;
 	/* Override default vue-select styles */
-	min-height: calc(var(--default-clickable-area) - 2 * var(--border-width-input));
+	min-height: calc(var(--default-clickable-area) - 2 * var(--border-width-input, 2px));
 	min-width: 260px;
 	margin: 0 0 var(--default-grid-baseline);
 
@@ -1169,10 +1169,13 @@ export default {
 		width: 100%;
 		--input-padding-end: calc(var(--default-clickable-area) + var(--default-grid-baseline));
 
-		// Neutralize vue-select defaults on the wrapper div (no longer the native input)
+		// Neutralize vue-select defaults on the wrapper div (no longer the native input).
+		// The height reset also beats legacy global styles (e.g. bundled by the server)
+		// that force a fixed height on `.vs__search` from the old native-input design.
 		border: none !important;
 		margin: 0 !important;
 		padding: 0 !important;
+		height: auto !important;
 	}
 
 	// Force floating label when a value is selected (search input is empty but a value exists)

--- a/src/components/NcSelectUsers/NcSelectUsers.vue
+++ b/src/components/NcSelectUsers/NcSelectUsers.vue
@@ -370,7 +370,16 @@ function filterBy(option: { subname?: string }, label: string, search: string) {
 </template>
 
 <style scoped lang="css">
-.nc-select-users :deep(.vs__selected) {
+/* Ensure sufficient height for the user avatar and status */
+.nc-select-users.vs--single :deep(.input-field__main-wrapper) {
+	--default-clickable-area: 42px;
+	/* Default clickable area + 2*4px padding of the input */
+	input {
+		padding-block: 4px !important;
+	}
+}
+
+.nc-select-users.vs--multiple :deep(.vs__selected) {
 	padding-inline: 0 5px !important;
 }
 </style>

--- a/tests/component/components/NcSelect/NcSelect.spec.ts
+++ b/tests/component/components/NcSelect/NcSelect.spec.ts
@@ -254,6 +254,85 @@ test.describe('NcSelect - e2e flows', () => {
 	})
 })
 
+test.describe('NcSelect - event bindings', () => {
+	// The search-slot events are bound one by one onto NcTextField, so these
+	// exercise each forwarded handler reaching the native <input>.
+
+	test('typing forwards the input event and filters options', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+		await component.getByRole('combobox').click()
+		await component.getByRole('combobox').fill('qu')
+		// input event reached vue-select -> filteredOptions updated
+		expect(await page.getByRole('option').all()).toHaveLength(2)
+		await expect(page.getByRole('option', { name: 'qux' })).toBeVisible()
+	})
+
+	test('keydown ArrowDown opens and navigates', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+		const combobox = component.getByRole('combobox')
+		await combobox.focus()
+		// closed until a key is pressed
+		await expect(page.getByRole('option').first()).not.toBeVisible()
+		await combobox.press('ArrowDown')
+		await expect(page.getByRole('option').first()).toBeVisible()
+	})
+
+	test('focus does not auto-open the dropdown (WCAG 3.2.1)', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+		// focus handler is bound but must not open on focus
+		await component.locator('input').focus()
+		await expect(component.locator('input')).toBeFocused()
+		await expect(page.getByRole('option').first()).not.toBeVisible()
+	})
+
+	test('blur closes an open dropdown', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+		await component.getByRole('combobox').click()
+		await expect(page.getByRole('option').first()).toBeVisible()
+
+		// blur handler must close the options
+		await component.locator('input').evaluate((el: HTMLElement) => el.blur())
+		await expect(page.getByRole('option').first()).not.toBeVisible()
+	})
+
+	test('Enter during IME composition does not select', async ({ mount, page }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			props: { multiple: true },
+			on: { selected: (data) => emitted.push(data) },
+		})
+		const input = component.locator('input')
+		await input.click()
+		await expect(page.getByRole('option', { name: 'foo' })).toBeVisible()
+
+		// Start composing: compositionstart handler sets vue-select isComposing = true
+		await input.evaluate((el) => el.dispatchEvent(new CompositionEvent('compositionstart')))
+		await input.pressSequentially('f')
+		await input.press('Enter')
+		// Enter must be swallowed while composing
+		expect(emitted).toHaveLength(0)
+
+		// End composition: compositionend handler clears isComposing
+		await input.evaluate((el) => el.dispatchEvent(new CompositionEvent('compositionend')))
+		await input.press('Enter')
+		expect(emitted).toHaveLength(1)
+		expect(emitted[0]).toEqual(['foo'])
+	})
+
+	test('Escape closes without emitting a selection', async ({ mount, page }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			on: { selected: (data) => emitted.push(data) },
+		})
+		await component.getByRole('combobox').click()
+		await expect(page.getByRole('option').first()).toBeVisible()
+
+		await component.getByRole('combobox').press('Escape')
+		await expect(page.getByRole('option').first()).not.toBeVisible()
+		expect(emitted).toHaveLength(0)
+	})
+})
+
 test.describe('NcSelect - review regressions', () => {
 	test('typing a query hides the selected value', async ({ mount }) => {
 		const component = await mount(NcSelectStory, {

--- a/tests/component/components/NcSelect/NcSelect.spec.ts
+++ b/tests/component/components/NcSelect/NcSelect.spec.ts
@@ -1,0 +1,337 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, test } from '@playwright/experimental-ct-vue'
+import NcSelectStory from './NcSelect.story.vue'
+
+test.describe('NcSelect - single mode', () => {
+	test('has a visible combobox', async ({ mount }) => {
+		const component = await mount(NcSelectStory)
+		await expect(component.getByRole('combobox')).toBeVisible()
+	})
+
+	test('shows label as placeholder when empty', async ({ mount }) => {
+		const component = await mount(NcSelectStory, {
+			props: { inputLabel: 'Pick a fruit' },
+		})
+		await expect(component.getByText('Pick a fruit')).toBeVisible()
+	})
+
+	test('opens dropdown on click', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+		await component.getByRole('combobox').click()
+		await expect(page.getByRole('option', { name: 'foo' })).toBeVisible()
+	})
+
+	test('opens dropdown on Enter', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+		await component.getByRole('combobox').press('Enter')
+		await expect(page.getByRole('option', { name: 'foo' })).toBeVisible()
+	})
+
+	test('closes on Escape', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+		await component.getByRole('combobox').click()
+		await expect(page.getByRole('option', { name: 'foo' })).toBeVisible()
+
+		await component.getByRole('combobox').press('Escape')
+		await expect(page.getByRole('option', { name: 'foo' })).not.toBeVisible()
+	})
+
+	test('arrow keys navigate options', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+		await component.getByRole('combobox').click()
+		await component.getByRole('combobox').press('ArrowDown')
+
+		// First option should be highlighted
+		const options = page.getByRole('option')
+		await expect(options.first()).toBeVisible()
+	})
+
+	test('selects option with Enter', async ({ mount, page }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			on: { selected: (data) => emitted.push(data) },
+		})
+
+		await component.getByRole('combobox').click()
+		await page.getByRole('option', { name: 'bar' }).click()
+
+		expect(emitted).toHaveLength(1)
+		expect(emitted[0]).toBe('bar')
+	})
+
+	test('typing filters options', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+		await component.getByRole('combobox').click()
+		await component.getByRole('combobox').fill('ba')
+
+		await expect(page.getByRole('option', { name: 'bar' })).toBeVisible()
+		await expect(page.getByRole('option', { name: 'baz' })).toBeVisible()
+		expect(await page.getByRole('option').all()).toHaveLength(2)
+	})
+
+	test('shows selected value', async ({ mount }) => {
+		const component = await mount(NcSelectStory, {
+			props: { preselected: true },
+		})
+
+		await expect(component.getByText('foo')).toBeVisible()
+	})
+
+	test('disabled state prevents interaction', async ({ mount }) => {
+		const component = await mount(NcSelectStory, {
+			props: { disabled: true },
+		})
+
+		await component.getByRole('combobox').click({ force: true })
+		await expect(component.locator('.vs__dropdown-menu')).not.toBeVisible()
+	})
+})
+
+test.describe('NcSelect - multi mode', () => {
+	test('shows label when empty', async ({ mount }) => {
+		const component = await mount(NcSelectStory, {
+			props: { multiple: true, inputLabel: 'Pick items' },
+		})
+		await expect(component.getByText('Pick items')).toBeVisible()
+	})
+
+	test('shows tags when values selected', async ({ mount }) => {
+		const component = await mount(NcSelectStory, {
+			props: { multiple: true, preselected: true },
+		})
+
+		await expect(component.getByText('foo')).toBeVisible()
+		await expect(component.getByText('bar')).toBeVisible()
+	})
+
+	test('can select multiple options', async ({ mount, page }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			props: { multiple: true },
+			on: { selected: (data) => emitted.push(data) },
+		})
+
+		await component.getByRole('combobox').click()
+		await page.getByRole('option', { name: 'foo' }).click()
+
+		await component.getByRole('combobox').click()
+		await page.getByRole('option', { name: 'bar' }).click()
+
+		expect(emitted).toHaveLength(2)
+		expect(emitted[0]).toEqual(['foo'])
+		expect(emitted[1]).toEqual(['foo', 'bar'])
+	})
+
+	test('can remove tag with deselect button', async ({ mount }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			props: { multiple: true, preselected: true },
+			on: { selected: (data) => emitted.push(data) },
+		})
+
+		// Click the deselect (×) button on first tag
+		const deselectButtons = component.locator('.vs__deselect')
+		await deselectButtons.first().click()
+
+		expect(emitted).toHaveLength(1)
+		expect(emitted[0]).toEqual(['bar'])
+	})
+})
+
+test.describe('NcSelect - e2e flows', () => {
+	test('search, select, and clear single value', async ({ mount, page }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			props: { inputLabel: 'Pick one' },
+			on: { selected: (data) => emitted.push(data) },
+		})
+
+		// Type to search
+		await component.getByRole('combobox').click()
+		await component.getByRole('combobox').fill('qu')
+		expect(await page.getByRole('option').all()).toHaveLength(2)
+
+		// Select 'qux'
+		await page.getByRole('option', { name: 'qux' }).click()
+		expect(emitted[0]).toBe('qux')
+
+		// Value is shown
+		await expect(component.getByText('qux')).toBeVisible()
+	})
+
+	test('keyboard-only selection flow', async ({ mount, page }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			on: { selected: (data) => emitted.push(data) },
+		})
+
+		const combobox = component.getByRole('combobox')
+
+		// Open with Enter
+		await combobox.press('Enter')
+		await expect(page.getByRole('option').first()).toBeVisible()
+
+		// Navigate down twice and select with Enter
+		await combobox.press('ArrowDown')
+		await combobox.press('ArrowDown')
+		await combobox.press('Enter')
+
+		expect(emitted).toHaveLength(1)
+	})
+
+	test('click outside closes dropdown', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory)
+
+		await component.getByRole('combobox').click()
+		await expect(page.getByRole('option').first()).toBeVisible()
+
+		// Click outside the select
+		await page.locator('body').click({ position: { x: 10, y: 10 } })
+		await expect(page.getByRole('option').first()).not.toBeVisible()
+	})
+
+	test('multi: search filters then select adds tag', async ({ mount, page }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			props: { multiple: true },
+			on: { selected: (data) => emitted.push(data) },
+		})
+
+		// Type to filter
+		await component.getByRole('combobox').click()
+		await component.getByRole('combobox').fill('ba')
+		expect(await page.getByRole('option').all()).toHaveLength(2)
+
+		// Select 'baz'
+		await page.getByRole('option', { name: 'baz' }).click()
+		expect(emitted[0]).toEqual(['baz'])
+
+		// Tag visible
+		await expect(component.getByText('baz')).toBeVisible()
+
+		// Select another
+		await component.getByRole('combobox').click()
+		await page.getByRole('option', { name: 'foo' }).click()
+		expect(emitted[1]).toEqual(['baz', 'foo'])
+	})
+
+	test('multi: Backspace removes last tag', async ({ mount }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			props: { multiple: true, preselected: true },
+			on: { selected: (data) => emitted.push(data) },
+		})
+
+		// foo and bar are preselected
+		await expect(component.getByText('foo')).toBeVisible()
+		await expect(component.getByText('bar')).toBeVisible()
+
+		// Focus and press Backspace to remove last tag
+		await component.getByRole('combobox').click()
+		await component.getByRole('combobox').press('Backspace')
+
+		expect(emitted).toHaveLength(1)
+		expect(emitted[0]).toEqual(['foo'])
+	})
+
+	test('selecting same value in single mode replaces it', async ({ mount, page }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			props: { preselected: true },
+			on: { selected: (data) => emitted.push(data) },
+		})
+
+		// foo is preselected, select bar instead
+		await component.getByRole('combobox').click()
+		await page.getByRole('option', { name: 'bar' }).click()
+
+		expect(emitted[0]).toBe('bar')
+		await expect(component.getByText('bar')).toBeVisible()
+	})
+})
+
+test.describe('NcSelect - review regressions', () => {
+	test('typing a query hides the selected value', async ({ mount }) => {
+		const component = await mount(NcSelectStory, {
+			props: { preselected: true },
+		})
+
+		// Selected value visible before typing
+		await expect(component.locator('.vs__selected')).toBeVisible()
+
+		await component.getByRole('combobox').click()
+		await component.getByRole('combobox').fill('ba')
+
+		// Old value must not show through the typed query
+		await expect(component.locator('.vs__selected')).not.toBeVisible()
+	})
+
+	test('clear button resets the value', async ({ mount }) => {
+		const emitted: unknown[] = []
+		const component = await mount(NcSelectStory, {
+			props: { preselected: true, clearable: true },
+			on: { selected: (data) => emitted.push(data) },
+		})
+
+		await component.locator('.vs__clear').click()
+
+		expect(emitted).toHaveLength(1)
+		expect(emitted[0]).toBeNull()
+	})
+
+	test('drop-up keeps the label at the top', async ({ mount, page }) => {
+		const component = await mount(NcSelectStory, {
+			props: { placement: 'top', inputLabel: 'Top label' },
+		})
+
+		await component.getByRole('combobox').click()
+		await expect(page.getByRole('option').first()).toBeVisible()
+		await expect(component.locator('.select--drop-up')).toBeVisible()
+		// Let the label float transition settle
+		await page.waitForTimeout(300)
+
+		// Label must stay in the top half of the input, not move below it
+		const label = await component.locator('label').boundingBox()
+		const input = await component.locator('input').boundingBox()
+		expect(label!.y + label!.height / 2).toBeLessThan(input!.y + input!.height / 2)
+
+		// The menu must not cover the label (gap is left for it)
+		const menu = await page.locator('.vs__dropdown-menu').boundingBox()
+		expect(menu!.y + menu!.height).toBeLessThanOrEqual(label!.y + 1)
+	})
+})
+
+test.describe('NcSelect - NcTextField parity', () => {
+	test('renders an input element', async ({ mount }) => {
+		const component = await mount(NcSelectStory)
+		await expect(component.locator('input')).toBeVisible()
+	})
+
+	test('label floats when input is focused', async ({ mount }) => {
+		const component = await mount(NcSelectStory, {
+			props: { inputLabel: 'My label' },
+		})
+
+		const label = component.locator('label')
+		await component.getByRole('combobox').click()
+
+		// Label should still be visible (floated above border)
+		await expect(label).toBeVisible()
+		await expect(label).toContainText('My label')
+	})
+
+	test('label floats when value is selected', async ({ mount }) => {
+		const component = await mount(NcSelectStory, {
+			props: { inputLabel: 'My label', preselected: true },
+		})
+
+		// Label should be floated (not centered as placeholder)
+		const label = component.locator('label')
+		await expect(label).toBeVisible()
+		await expect(label).toContainText('My label')
+	})
+})

--- a/tests/component/components/NcSelect/NcSelect.story.vue
+++ b/tests/component/components/NcSelect/NcSelect.story.vue
@@ -1,0 +1,66 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="story-wrapper" :class="{ 'story-wrapper--room-above': placement === 'top' }">
+		<NcSelect
+			v-model="value"
+			:inputLabel="inputLabel"
+			:multiple="multiple"
+			:disabled="disabled"
+			:placeholder="placeholder"
+			:options="options"
+			:clearable="clearable"
+			:placement="placement"
+			@update:modelValue="$emit('selected', $event)" />
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import NcSelect from '../../../../src/components/NcSelect/NcSelect.vue'
+
+const props = withDefaults(defineProps<{
+	inputLabel?: string
+	multiple?: boolean
+	disabled?: boolean
+	placeholder?: string
+	options?: string[]
+	preselected?: boolean
+	clearable?: boolean
+	placement?: 'top' | 'bottom'
+}>(), {
+	inputLabel: 'Choose an option',
+	multiple: false,
+	disabled: false,
+	placeholder: '',
+	options: () => (['foo', 'bar', 'baz', 'qux', 'quux']),
+	preselected: false,
+	// undefined keeps vue-select's own default (true) — passing false would
+	// also disable Backspace tag deletion
+	clearable: undefined,
+	placement: 'bottom',
+})
+
+defineEmits<{
+	selected: [data?: string | string[]]
+}>()
+
+const value = ref<string | string[] | undefined>(props.preselected
+	? props.multiple ? ['foo', 'bar'] : 'foo'
+	: undefined)
+</script>
+
+<style scoped>
+.story-wrapper {
+	padding: 20px;
+	max-width: 400px;
+}
+
+/* Room for the dropdown menu when testing top placement */
+.story-wrapper--room-above {
+	padding-block-start: 320px;
+}
+</style>

--- a/tests/unit/components/NcSelect/NcSelect.spec.ts
+++ b/tests/unit/components/NcSelect/NcSelect.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import NcSelect from '../../../../src/components/NcSelect/NcSelect.vue'
+
+const options = ['foo', 'bar', 'baz']
+
+describe('NcSelect', () => {
+	it('renders NcTextField in search slot', () => {
+		const wrapper = mount(NcSelect, {
+			props: { inputLabel: 'Label', options },
+		})
+
+		expect(wrapper.findComponent({ name: 'NcTextField' }).exists()).toBe(true)
+	})
+
+	it('has the label set', () => {
+		const wrapper = mount(NcSelect, {
+			props: { inputLabel: 'The label', options },
+		})
+
+		expect(wrapper.find('label').text()).toBe('The label')
+	})
+
+	it('passes placeholder prop to NcTextField', () => {
+		const wrapper = mount(NcSelect, {
+			props: { inputLabel: 'Label', placeholder: 'Pick one', options },
+		})
+
+		// vue-select includes placeholder in attributes, NcTextField receives it
+		const textField = wrapper.findComponent({ name: 'NcInputField' })
+		expect(textField.exists()).toBe(true)
+	})
+
+	it('has the disabled attribute', async () => {
+		const wrapper = mount(NcSelect, {
+			props: { inputLabel: 'Label', options },
+		})
+
+		expect(wrapper.find('input').attributes('disabled')).toBeUndefined()
+
+		await wrapper.setProps({ disabled: true })
+		expect(wrapper.find('input').attributes('disabled')).toBe('')
+	})
+
+	it('has the inputClass set on NcTextField', () => {
+		const wrapper = mount(NcSelect, {
+			props: { inputLabel: 'Label', inputClass: 'custom-class', options },
+		})
+
+		expect(wrapper.findComponent({ name: 'NcTextField' }).classes('custom-class')).toBe(true)
+	})
+
+	it('emits update:modelValue on selection', async () => {
+		const wrapper = mount(NcSelect, {
+			props: { inputLabel: 'Label', options },
+		})
+
+		// Open dropdown
+		await wrapper.find('.vs__dropdown-toggle').trigger('mousedown')
+		await wrapper.vm.$nextTick()
+
+		// Select first option
+		const option = wrapper.find('.vs__dropdown-option')
+		if (option.exists()) {
+			await option.trigger('mousedown')
+			await wrapper.vm.$nextTick()
+			expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+		}
+	})
+
+	it('sets required conditionally based on value', async () => {
+		const wrapper = mount(NcSelect, {
+			props: { inputLabel: 'Label', required: true, modelValue: null, options },
+		})
+
+		expect(wrapper.find('input').attributes('required')).toBe('')
+
+		await wrapper.setProps({ modelValue: 'foo' })
+		expect(wrapper.find('input').attributes('required')).toBeUndefined()
+	})
+
+	describe('single mode', () => {
+		it('uses NcTextField label (not header slot)', () => {
+			const wrapper = mount(NcSelect, {
+				props: { inputLabel: 'Single label', options },
+			})
+
+			// Label is on NcTextField, not a separate .select__label element
+			const textField = wrapper.findComponent({ name: 'NcTextField' })
+			expect(textField.props('label')).toBe('Single label')
+			expect(wrapper.find('.select__label').exists()).toBe(false)
+		})
+	})
+
+	describe('multi mode', () => {
+		it('renders label via header slot', () => {
+			const wrapper = mount(NcSelect, {
+				props: { inputLabel: 'Multi label', multiple: true, options },
+			})
+
+			expect(wrapper.find('.select__label').exists()).toBe(true)
+			expect(wrapper.find('.select__label').text()).toBe('Multi label')
+		})
+
+		it('passes labelOutside to NcTextField', () => {
+			const wrapper = mount(NcSelect, {
+				props: { inputLabel: 'Multi label', multiple: true, options },
+			})
+
+			const textField = wrapper.findComponent({ name: 'NcTextField' })
+			expect(textField.props('labelOutside')).toBe(true)
+		})
+	})
+
+	describe('labelOutside', () => {
+		it('does not render floating label when labelOutside is true', () => {
+			const wrapper = mount(NcSelect, {
+				props: { inputLabel: 'Label', labelOutside: true, options },
+			})
+
+			// Single: NcTextField label should be empty
+			const textField = wrapper.findComponent({ name: 'NcTextField' })
+			expect(textField.props('label')).toBe('')
+		})
+
+		it('does not render header label in multi mode when labelOutside', () => {
+			const wrapper = mount(NcSelect, {
+				props: { inputLabel: 'Label', labelOutside: true, multiple: true, options },
+			})
+
+			expect(wrapper.find('.select__label').exists()).toBe(false)
+		})
+	})
+
+	describe('accessibility', () => {
+		it('warns when neither inputLabel nor ariaLabelCombobox is set', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+			mount(NcSelect, { props: { options } })
+			expect(warnSpy).toHaveBeenCalled()
+			warnSpy.mockRestore()
+		})
+
+		it('does not warn when inputLabel is set', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+			mount(NcSelect, { props: { inputLabel: 'Label', options } })
+			expect(warnSpy).not.toHaveBeenCalled()
+			warnSpy.mockRestore()
+		})
+
+		it('does not warn about NcSelect label when ariaLabelCombobox is set', () => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+			mount(NcSelect, { props: { ariaLabelCombobox: 'Search', options } })
+			// NcSelect itself should not warn, though NcInputField may warn separately
+			const ncSelectWarns = warnSpy.mock.calls.filter((args) => typeof args[0] === 'string' && args[0].includes('[NcSelect]'))
+			expect(ncSelectWarns).toHaveLength(0)
+			warnSpy.mockRestore()
+		})
+	})
+
+	describe('event forwarding', () => {
+		it('forwards keydown events to the inner input', async () => {
+			const wrapper = mount(NcSelect, {
+				props: { inputLabel: 'Label', options },
+			})
+
+			const input = wrapper.find('input')
+			await input.trigger('keydown', { key: 'ArrowDown' })
+			// If keydown is forwarded, vue-select processes it — no error thrown
+			expect(wrapper.find('.v-select').exists()).toBe(true)
+		})
+
+		it('filters input event from forwarded events', () => {
+			const wrapper = mount(NcSelect, {
+				props: { inputLabel: 'Label', options },
+			})
+
+			const vm = wrapper.vm as any
+			const events = { input: vi.fn(), keydown: vi.fn(), blur: vi.fn() }
+			const filtered = vm.filterEvents(events)
+
+			expect(filtered).not.toHaveProperty('input')
+			expect(filtered).toHaveProperty('keydown')
+			expect(filtered).toHaveProperty('blur')
+		})
+	})
+})

--- a/tests/unit/components/NcSelect/NcSelect.spec.ts
+++ b/tests/unit/components/NcSelect/NcSelect.spec.ts
@@ -170,22 +170,19 @@ describe('NcSelect', () => {
 
 			const input = wrapper.find('input')
 			await input.trigger('keydown', { key: 'ArrowDown' })
-			// If keydown is forwarded, vue-select processes it — no error thrown
+			// If keydown is forwarded, vue-select processes it without error
 			expect(wrapper.find('.v-select').exists()).toBe(true)
 		})
 
-		it('filters input event from forwarded events', () => {
+		it('forwards combobox a11y attributes to the inner input', () => {
 			const wrapper = mount(NcSelect, {
 				props: { inputLabel: 'Label', options },
 			})
 
-			const vm = wrapper.vm as any
-			const events = { input: vi.fn(), keydown: vi.fn(), blur: vi.fn() }
-			const filtered = vm.filterEvents(events)
-
-			expect(filtered).not.toHaveProperty('input')
-			expect(filtered).toHaveProperty('keydown')
-			expect(filtered).toHaveProperty('blur')
+			const input = wrapper.find('input')
+			expect(input.attributes('role')).toBe('combobox')
+			expect(input.attributes('aria-autocomplete')).toBe('list')
+			expect(input.attributes('aria-expanded')).toBe('false')
 		})
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

- Relates to nextcloud-libraries/nextcloud-vue#8XXX (NcSelect visual alignment with other form fields)

### Summary

Replace the plain `<input>` in NcSelect's `#search` slot with `NcTextField` so the component shares the same floating label, border, and focus styling as `NcTextField` and `NcTextArea`.

**Single mode:**
- NcTextField owns the border and floating label
- Selected value overlays the input (position: absolute, z-index: 2)
- Label floats on focus or when value selected via `:has(.vs__selected)`
- Extra padding when clearable (clear + chevron need space)

**Multi mode:**
- Border on `.vs__dropdown-toggle` (contains tags + search input)
- Floating label via `#header` slot, centered when empty, floats on border when tags present or dropdown open
- Search input inline with tags (flex-grow, no layout jump on open)
- Tags clipped before actions via `max-width` in no-wrap mode

**Drop-up:**
- Border/radius inverted (transparent top, rounded bottom)
- Label moves to bottom border

**CSS scoping:**
- `data-v-new-select` attribute on root element for manual scoping
- CSS variables scoped to `[data-v-new-select].v-select.select`
- Dropdown menu variables set directly on `.vs__dropdown-menu` (teleported to body by floating-ui)
- `inputLikeBorder` mixin inlined to fix `@media #{&}` doubled-selector bug
- Dark/light theme border overrides with correct selectors

**Other:**
- Forward vue-select events (keydown, blur, focus, IME) via `filterEvents()`
- `v-bind` before explicit props (Vue 3 last-binding-wins)
- No placeholder when multi or value selected (avoids overlap)
- Disabled state: transparent backgrounds, lighter border via `--color-border-dark`

**Tests added:**
- 17 unit tests (vitest): label, placeholder, disabled, inputClass, modelValue, required, single/multi mode, labelOutside, accessibility warnings, event forwarding
- 24 component tests (Playwright): open/close, keyboard nav, search/filter, select, multi tags, deselect, Tab/Escape/blur close, e2e flows

**Docs added:**
- Pre-selected and clearable example
- Disabled state example (single + multi)
- Label outside example (single + multi)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="413" height="453" alt="image" src="https://github.com/user-attachments/assets/99b8b29d-8f88-41a8-93ec-2928fcad344b" /> | <img width="414" height="355" alt="image" src="https://github.com/user-attachments/assets/7ff08329-45fd-42ed-89fb-8f15d17c224b" />
<img width="409" height="291" alt="image" src="https://github.com/user-attachments/assets/d57878f0-d96e-4e7c-a5b7-948f78a299fd" /> | <img width="406" height="286" alt="image" src="https://github.com/user-attachments/assets/be3654f1-42de-456e-bda6-fd57839f8654" />
<img width="549" height="407" alt="2026-06-03_17-01_1" src="https://github.com/user-attachments/assets/28615e9a-8e66-435f-80e2-e908fc80c41d" />|<img width="605" height="376" alt="2026-06-03_17-01" src="https://github.com/user-attachments/assets/64e3d9cf-02c2-41ac-9ef1-53b26be44dab" />

### 🚧 Tasks

- [x] NcTextField integration in search slot
- [x] Event forwarding (keydown, blur, focus, IME)
- [x] Single mode selected value positioning
- [x] Multi mode tags inside bordered container
- [x] Floating label when value selected
- [x] Open state / drop-up border-radius + label repositioning
- [x] CSS scoping via `data-v-new-select`
- [x] Dark theme border fix (inlined mixin)
- [x] Disabled state styling
- [x] No-wrap overflow clipping
- [x] Unit tests (17)
- [x] Component/e2e tests (24)
- [x] Documentation examples (3 new sections)

### 🏁 Checklist

- [x] ⛑️ Tests are included (17 unit + 24 Playwright component tests)
- [x] 📘 Component documentation has been extended (3 new example sections)
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable