### PR TITLE
fix(NcDateTimePicker): respect `locale` prop for default date formatting

### DIFF
--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -20,10 +20,23 @@ For those cases this component can be used.
 			<NcCheckboxRadioSwitch v-model="type" type="radio" value="month">Month</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch v-model="type" type="radio" value="year">Year</NcCheckboxRadioSwitch>
 		</fieldset>
-		<NcDateTimePicker
-			v-model="time"
-			:type />
-		<span>{{ time }}</span>
+		<fieldset>
+			<legend>Picker locale</legend>
+			<NcInputField v-model="locale" labelOutside label="Locale" list="sample-locales"/>
+			<datalist id="sample-locales">
+				<option value="en-US"></option>
+				<option value="en-CA"></option>
+				<option value="es"></option>
+				<option value="de"></option>
+				<option value="ja"></option>
+				<option value="zh"></option>
+			</datalist>
+		</fieldset>
+		<fieldset>
+			<legend>Picker</legend>
+			<NcDateTimePicker v-model="time" :type :locale />
+			<span>{{ time }}</span>
+		</fieldset>
 	</div>
 </template>
 <script>
@@ -32,6 +45,7 @@ export default {
 		return {
 			type: 'date',
 			time: new Date('2022-10-10 10:10:10'),
+			locale: 'en-US'
 		}
 	},
 }
@@ -545,17 +559,18 @@ const realFormat = computed<LibraryFormatOptions>(() => {
 		return 'RR-II'
 	}
 
+	const formatLocale = props.locale
 	let formatter: Intl.DateTimeFormat | undefined
 	if (props.type === 'date' || props.type === 'date-range') {
-		formatter = new Intl.DateTimeFormat(getCanonicalLocale(), { dateStyle: 'medium' })
+		formatter = new Intl.DateTimeFormat(formatLocale, { dateStyle: 'medium' })
 	} else if (props.type === 'time' || props.type === 'time-range') {
-		formatter = new Intl.DateTimeFormat(getCanonicalLocale(), { timeStyle: 'short' })
+		formatter = new Intl.DateTimeFormat(formatLocale, { timeStyle: 'short' })
 	} else if (props.type === 'datetime' || props.type === 'datetime-range') {
-		formatter = new Intl.DateTimeFormat(getCanonicalLocale(), { dateStyle: 'medium', timeStyle: 'short' })
+		formatter = new Intl.DateTimeFormat(formatLocale, { dateStyle: 'medium', timeStyle: 'short' })
 	} else if (props.type === 'month') {
-		formatter = new Intl.DateTimeFormat(getCanonicalLocale(), { year: 'numeric', month: '2-digit' })
+		formatter = new Intl.DateTimeFormat(formatLocale, { year: 'numeric', month: '2-digit' })
 	} else if (props.type === 'year') {
-		formatter = new Intl.DateTimeFormat(getCanonicalLocale(), { year: 'numeric' })
+		formatter = new Intl.DateTimeFormat(formatLocale, { year: 'numeric' })
 	}
 
 	if (formatter) {

--- a/tests/component/components/NcDateTimePicker.spec.ts
+++ b/tests/component/components/NcDateTimePicker.spec.ts
@@ -62,6 +62,18 @@ for (const [type, modelValue, locale, expectedValue] of l10nTestcases) {
 	})
 }
 
+test('Use provided locale for formatting date input', async ({ mount, page }) => {
+	await mount(NcDateTimePicker, {
+		props: {
+			modelValue: new Date(2026, 5, 16),
+			locale: 'de-DE',
+			type: 'date',
+		},
+	})
+
+	await expect(page.getByRole('textbox')).toHaveValue('16.06.2026')
+})
+
 test('Today is selected by default', async ({ mount, page }) => {
 	await page.clock.setSystemTime(new Date(2000, 0, 22))
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix #8639 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="836" height="232" alt="image" src="https://github.com/user-attachments/assets/50406f2d-452e-4465-8e19-ae3e7adcbadb" /> | <img width="836" height="232" alt="image" src="https://github.com/user-attachments/assets/fdf76b72-be46-4629-85f0-6a330bbe2eb3" />


### 🏁 Checklist

- [x] ⛑️ Tests **are included** or are not applicable
- [x] 📘 Component documentation has been extended, updated or is **not applicable**
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or **not applicable**
