### PR TITLE
feat(NcAppNavigation): add animation effect for navigation items

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -263,6 +263,17 @@
 	}
 }
 
+// When the parent list renders a sliding highlight, suppress the per-entry
+// hover/focus background of non-active entries so only the moving highlight
+// is visible. Active entries keep their own static highlight and stripe.
+// The leading list class keeps these more specific than the rules above.
+.app-navigation-list--animated-highlight {
+	.app-navigation-entry:not(.active):hover,
+	.app-navigation-entry:not(.active):focus-within {
+		background-color: transparent !important;
+	}
+}
+
 @keyframes nc-nav-stripe-in {
 	from {
 		transform: scaleY(0);

--- a/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
+++ b/src/components/NcAppNavigationItem/NcAppNavigationItem.vue
@@ -318,13 +318,16 @@ Just set the `pinned` prop.
 			v-slot="{ href: routerLinkHref, navigate, isActive }"
 			v-bind="{ ...isRouterLink && { custom: true, to } }">
 			<div
+				ref="entry"
 				class="app-navigation-entry"
 				:class="{
 					'app-navigation-entry--editing': editingActive,
 					'app-navigation-entry--deleted': undo,
 					'app-navigation-entry--legacy': isLegacy34,
 					active: (to && isActive) || active,
-				}">
+				}"
+				@pointerenter="requestHighlight"
+				@focusin="requestHighlight">
 				<!-- Icon and name -->
 				<a
 					v-if="!undo"
@@ -449,6 +452,7 @@ import { createElementId } from '../../utils/createElementId.ts'
 import { isLegacy34 } from '../../utils/legacy.ts'
 import NcActionButton from '../NcActionButton/index.js'
 import NcActions from '../NcActions/index.js'
+import { APP_NAVIGATION_HIGHLIGHT } from '../NcAppNavigationList/highlight.ts'
 import NcLoadingIcon from '../NcLoadingIcon/index.ts'
 import NcVNodes from '../NcVNodes/index.ts'
 
@@ -464,6 +468,11 @@ export default {
 		NcVNodes,
 		Pencil,
 		Undo,
+	},
+
+	inject: {
+		// Provided by NcAppNavigationList, absent when used outside of one
+		highlight: { from: APP_NAVIGATION_HIGHLIGHT, default: null },
 	},
 
 	props: {
@@ -718,7 +727,26 @@ export default {
 		this.actionsBoundariesElement = document.querySelector('#content-vue') || undefined
 	},
 
+	beforeUnmount() {
+		// Release the highlight, e.g. when a virtual scroller drops this entry
+		this.releaseHighlight()
+	},
+
 	methods: {
+		/** Ask the parent list to move its highlight onto this entry */
+		requestHighlight() {
+			// Entries being edited have their own UI
+			if (this.editingActive) {
+				return
+			}
+			this.highlight?.show(this.$refs.entry)
+		},
+
+		/** Tell the parent list this entry no longer wants the highlight */
+		releaseHighlight() {
+			this.highlight?.hide(this.$refs.entry)
+		},
+
 		// sync opened menu state with prop
 		onMenuToggle(state) {
 			this.$emit('update:menuOpen', state)

--- a/src/components/NcAppNavigationList/NcAppNavigationList.vue
+++ b/src/components/NcAppNavigationList/NcAppNavigationList.vue
@@ -8,6 +8,16 @@
 
 List wrapper for use in NcAppNavigation.
 
+The list renders a single hover/focus highlight that slides between entries
+instead of every entry painting its own hover background. When it slides onto
+the active entry it turns transparent, so the active entry keeps its own
+static highlight.
+
+Entries ask for the highlight themselves - `NcAppNavigationItem` does this out
+of the box. The list never inspects the DOM to find out what is hovered, so it
+also works when entries are rendered by a virtual scroller. If no entry ever
+asks for it the per-entry hover background is used as a fallback.
+
 #### Example
 
 Usage with NcAppNavigationCaption as a heading.
@@ -30,15 +40,159 @@ Usage with NcAppNavigationCaption as a heading.
 </docs>
 
 <template>
-	<ul class="app-navigation-list">
+	<ul
+		ref="list"
+		class="app-navigation-list"
+		:class="{ 'app-navigation-list--animated-highlight': visible }"
+		@pointerleave="hideNow"
+		@focusout="onFocusOut"
+		@scroll.passive="onScroll">
+		<div
+			class="app-navigation-list__highlight"
+			:class="{
+				'app-navigation-list__highlight--visible': visible,
+				'app-navigation-list__highlight--animated': animated,
+				'app-navigation-list__highlight--over-active': overActive,
+			}"
+			:style="highlightStyle"
+			aria-hidden="true" />
 		<slot />
 	</ul>
 </template>
 
 <script lang="ts">
-export default {
+import { defineComponent } from 'vue'
+import { APP_NAVIGATION_HIGHLIGHT } from './highlight.ts'
+
+export default defineComponent({
 	name: 'NcAppNavigationList',
-}
+
+	provide() {
+		return {
+			[APP_NAVIGATION_HIGHLIGHT]: {
+				show: this.show,
+				hide: this.hide,
+			},
+		}
+	},
+
+	data() {
+		return {
+			/** Entry the highlight is on, as reported by that entry itself */
+			entry: null as HTMLElement | null,
+			/** Whether the highlight is shown */
+			visible: false,
+			/** Whether position changes should transition (slide) or snap */
+			animated: false,
+			/** Whether the highlight sits on the active entry (turns transparent) */
+			overActive: false,
+			/** Vertical offset of the highlight inside the scrollable content */
+			top: 0,
+			/** Height of the highlight */
+			height: 0,
+			/** Pending animation frame for re-measuring while scrolling */
+			scrollFrame: 0,
+		}
+	},
+
+	computed: {
+		highlightStyle(): Record<string, string> {
+			return {
+				transform: `translateY(${this.top}px)`,
+				height: `${this.height}px`,
+			}
+		},
+	},
+
+	beforeUnmount() {
+		if (this.scrollFrame) {
+			cancelAnimationFrame(this.scrollFrame)
+		}
+	},
+
+	methods: {
+		/**
+		 * Move the highlight onto an entry. It slides there if already visible,
+		 * otherwise it snaps into place so it does not slide in from the entry
+		 * that was hovered before. Over the active entry it turns transparent so
+		 * that entry keeps its own static highlight.
+		 *
+		 * @param entry the entry element asking for the highlight
+		 */
+		show(entry: HTMLElement) {
+			this.entry = entry
+			this.overActive = entry.classList.contains('active')
+			if (this.visible) {
+				this.animated = true
+				this.measure()
+				return
+			}
+			// Re-appearing: snap to the new position, then allow sliding again
+			this.animated = false
+			this.measure()
+			this.visible = true
+			this.$nextTick(() => requestAnimationFrame(() => {
+				this.animated = true
+			}))
+		},
+
+		/**
+		 * Hide the highlight if it is on the given entry, e.g. because that entry
+		 * is being removed. While the pointer only moves between entries the
+		 * highlight stays visible, so it can slide on to the next one.
+		 *
+		 * @param entry the entry element that no longer wants the highlight
+		 */
+		hide(entry: HTMLElement) {
+			if (this.entry === entry) {
+				this.hideNow()
+			}
+		},
+
+		/** Hide the highlight, as the pointer or focus left the list */
+		hideNow() {
+			this.visible = false
+		},
+
+		/**
+		 * Hide the highlight once focus leaves the list entirely
+		 *
+		 * @param event the focusout event
+		 */
+		onFocusOut(event: FocusEvent) {
+			const list = this.$refs.list as HTMLElement
+			if (!list.contains(event.relatedTarget as Node | null)) {
+				this.hideNow()
+			}
+		},
+
+		/** Read the current entry's geometry relative to the list content */
+		measure() {
+			const list = this.$refs.list as HTMLElement | undefined
+			if (!list || !this.entry) {
+				return
+			}
+			const entryRect = this.entry.getBoundingClientRect()
+			const listRect = list.getBoundingClientRect()
+			this.top = entryRect.top - listRect.top + list.scrollTop
+			this.height = entryRect.height
+		},
+
+		/**
+		 * Keep the highlight on its entry while scrolling. Needed because a
+		 * virtual scroller repositions its entries as the list scrolls.
+		 */
+		onScroll() {
+			if (!this.visible || this.scrollFrame) {
+				return
+			}
+			this.scrollFrame = requestAnimationFrame(() => {
+				this.scrollFrame = 0
+				this.measure()
+			})
+		},
+	},
+})
 </script>
 
 <style lang="scss" scoped>
@@ -51,5 +205,54 @@ export default {
 	flex-direction: column;
 	gap: var(--default-grid-baseline, 4px);
 	padding: var(--app-navigation-padding);
+	isolation: isolate; // keep the highlight layered predictably within the list
+
+	&__highlight {
+		// Half of --animation-quick, so the highlight keeps up with the pointer
+		--highlight-animation-duration: calc(var(--animation-quick) / 2);
+		position: absolute;
+		inset-inline: var(--app-navigation-padding);
+		top: 0;
+		height: 0;
+		// As the first positioned child it paints below the entry wrappers
+		// (also positioned), so it sits behind the entry content.
+		z-index: 0;
+		pointer-events: none;
+		opacity: 0;
+		border-radius: var(--border-radius-element);
+		// Matches the per-entry hover background of non-legacy entries.
+		background-color: color-mix(in srgb, var(--color-primary-element) 8%, transparent);
+		// Only the position is transitioned, height snaps. Entries in a list are
+		// usually equally high, so this is not visible, and it keeps the slide off
+		// the layout path.
+		will-change: transform;
+		// The fade and the background morph are always transitioned; sliding is
+		// opt-in via --animated so the highlight snaps when it (re)appears.
+		// ease-out so it leaves the old entry immediately and feels responsive.
+		transition:
+			opacity var(--highlight-animation-duration) ease-out,
+			background-color var(--highlight-animation-duration) ease-out;
+
+		&--animated {
+			transition:
+				transform var(--highlight-animation-duration) ease-out,
+				opacity var(--highlight-animation-duration) ease-out,
+				background-color var(--highlight-animation-duration) ease-out;
+		}
+
+		&--visible {
+			opacity: 1;
+		}
+
+		// Over the active entry the highlight turns transparent so the active
+		// entry's own static highlight shows through unchanged, while the
+		// highlight still slides on and off it for a continuous motion.
+		&--over-active {
+			background-color: transparent;
+		}
+	}
+	// Reduced motion is handled globally: the --animation-quick variable is
+	// collapsed under a prefers-reduced-motion media query by the server theme,
+	// so these transitions become instant without a component-level override.
 }
 </style>

--- a/src/components/NcAppNavigationList/highlight.ts
+++ b/src/components/NcAppNavigationList/highlight.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { InjectionKey } from 'vue'
+
+/**
+ * Lets navigation entries ask the list to move its shared hover highlight onto
+ * them, so the list never has to read the DOM to find out what is hovered.
+ */
+export interface AppNavigationHighlight {
+	/** Move the highlight onto the given entry element */
+	show(entry: HTMLElement): void
+	/** Hide the highlight if it is currently on the given entry element */
+	hide(entry: HTMLElement): void
+}
+
+export const APP_NAVIGATION_HIGHLIGHT = Symbol('nc:app-navigation-highlight') as InjectionKey<AppNavigationHighlight>

--- a/tests/unit/components/NcAppNavigationList/NcAppNavigationList.spec.js
+++ b/tests/unit/components/NcAppNavigationList/NcAppNavigationList.spec.js
@@ -1,0 +1,218 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import NcAppNavigationList from '../../../../src/components/NcAppNavigationList/NcAppNavigationList.vue'
+
+/**
+ * Stub getBoundingClientRect, which jsdom always reports as zero.
+ *
+ * @param {Element} el the element to stub
+ * @param {number} top the top offset to report
+ * @param {number} height the height to report
+ */
+function setRect(el, top, height) {
+	el.getBoundingClientRect = () => ({
+		top,
+		height,
+		bottom: top + height,
+		left: 0,
+		right: 0,
+		width: 0,
+		x: 0,
+		y: top,
+		toJSON: () => ({}),
+	})
+}
+
+/**
+ * Mount the list with a plain entry and an active one, each with a stubbed
+ * geometry. Entries are plain elements: the list must not depend on their
+ * markup, only on them asking for the highlight.
+ */
+function mountList() {
+	const wrapper = mount(NcAppNavigationList, {
+		slots: {
+			default: '<div class="entry" data-id="one">One</div>'
+				+ '<div class="entry active" data-id="two">Two</div>',
+		},
+	})
+	setRect(wrapper.element, 0, 300)
+	const entries = wrapper.findAll('.entry').map((e) => e.element)
+	setRect(entries[0], 0, 44)
+	setRect(entries[1], 50, 44)
+	return { wrapper, entries, api: wrapper.vm }
+}
+
+describe('NcAppNavigationList.vue', () => {
+	let rafQueue = new Map()
+	let rafId = 0
+
+	beforeEach(() => {
+		rafQueue = new Map()
+		rafId = 0
+		vi.stubGlobal('requestAnimationFrame', (cb) => {
+			rafQueue.set(++rafId, cb)
+			return rafId
+		})
+		// Cancelling has to actually drop the callback, otherwise a flush runs
+		// frames the component already cancelled
+		vi.stubGlobal('cancelAnimationFrame', (id) => rafQueue.delete(id))
+	})
+
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	/** Run the queued requestAnimationFrame callbacks. */
+	const flushRaf = () => {
+		const queued = [...rafQueue.values()]
+		rafQueue.clear()
+		queued.forEach((cb) => cb())
+	}
+
+	it('renders the highlight hidden until an entry asks for it', () => {
+		const { wrapper } = mountList()
+		// Always rendered, so moving it can transition from a painted position
+		expect(wrapper.get('.app-navigation-list__highlight').classes())
+			.not.toContain('app-navigation-list__highlight--visible')
+	})
+
+	it('shows and positions the highlight on the requesting entry', async () => {
+		const { wrapper, entries, api } = mountList()
+
+		api.show(entries[0])
+		await nextTick()
+
+		expect(api.visible).toBe(true)
+		expect(api.top).toBe(0)
+		expect(api.height).toBe(44)
+		expect(api.overActive).toBe(false)
+		expect(wrapper.get('.app-navigation-list__highlight').classes())
+			.toContain('app-navigation-list__highlight--visible')
+	})
+
+	it('snaps when appearing, then enables sliding', async () => {
+		const { api } = mountList()
+
+		api.show(api.$el.querySelector('[data-id="one"]'))
+		expect(api.animated).toBe(false)
+
+		await nextTick()
+		flushRaf()
+		expect(api.animated).toBe(true)
+	})
+
+	it('slides when moving between entries while visible', async () => {
+		const { entries, api } = mountList()
+
+		api.show(entries[0])
+		await nextTick()
+		flushRaf()
+		api.show(entries[1])
+
+		expect(api.animated).toBe(true)
+		expect(api.top).toBe(50)
+	})
+
+	it('turns transparent over the active entry', async () => {
+		const { wrapper, entries, api } = mountList()
+
+		api.show(entries[1])
+		await nextTick()
+
+		expect(api.overActive).toBe(true)
+		expect(wrapper.get('.app-navigation-list__highlight').classes())
+			.toContain('app-navigation-list__highlight--over-active')
+	})
+
+	it('hides when the entry holding the highlight releases it', async () => {
+		const { entries, api } = mountList()
+
+		api.show(entries[0])
+		// E.g. a virtual scroller dropping the entry the highlight sits on
+		api.hide(entries[0])
+
+		expect(api.visible).toBe(false)
+	})
+
+	it('keeps sliding when the pointer dwells between entries', async () => {
+		const { wrapper, entries, api } = mountList()
+
+		api.show(entries[0])
+		await nextTick()
+		flushRaf()
+
+		// The pointer sits in the gap between two entries for a while. No entry is
+		// entered, and the list was not left, so the highlight must stay put.
+		flushRaf()
+		expect(api.visible).toBe(true)
+
+		api.show(entries[1])
+		await nextTick()
+
+		// Must not have dropped to the snapping path
+		expect(api.visible).toBe(true)
+		expect(api.animated).toBe(true)
+		expect(api.top).toBe(50)
+		expect(wrapper.get('.app-navigation-list__highlight').classes())
+			.toContain('app-navigation-list__highlight--animated')
+	})
+
+	it('hides when the pointer leaves the list', async () => {
+		const { wrapper, entries, api } = mountList()
+
+		api.show(entries[0])
+		await nextTick()
+		expect(api.visible).toBe(true)
+
+		await wrapper.trigger('pointerleave')
+
+		expect(api.visible).toBe(false)
+	})
+
+	it('ignores a release from an entry that no longer holds the highlight', async () => {
+		const { entries, api } = mountList()
+
+		api.show(entries[0])
+		await nextTick()
+		// Pointer moved to the next entry before the previous one reported leaving
+		api.show(entries[1])
+		api.hide(entries[0])
+
+		expect(api.visible).toBe(true)
+		expect(api.top).toBe(50)
+	})
+
+	it('re-measures on scroll, so it follows virtualised entries', async () => {
+		const { wrapper, entries, api } = mountList()
+
+		api.show(entries[0])
+		await nextTick()
+		flushRaf()
+
+		// A virtual scroller repositions its entries as the list scrolls
+		setRect(entries[0], 120, 44)
+		await wrapper.trigger('scroll')
+		flushRaf()
+
+		expect(api.top).toBe(120)
+	})
+
+	it('does not re-measure on scroll while hidden', async () => {
+		const { wrapper, entries, api } = mountList()
+
+		api.show(entries[0])
+		api.hide(entries[0])
+		flushRaf()
+		setRect(entries[0], 200, 44)
+		await wrapper.trigger('scroll')
+		flushRaf()
+
+		expect(api.top).toBe(0)
+	})
+})


### PR DESCRIPTION
### ☑️ Resolves

It would be nice to have an animation of the hover feedback highlight of the NcAppNavigation. This makes it feel nicer and smoother, like you are actually interacting with something.

This is a prototype to see how that could look like. Has been tested in the styleguide.
@susnux @ShGKme please check if this would this be good as a base, or should take a different approach.


### 🖼️ Screenshots

#### 🏚️ Before

[Screencast From 2026-06-27 01-40-20.webm](https://github.com/user-attachments/assets/30489d44-fdab-4fe2-b63b-d329f60789b2)


#### 🏡 After

[Screencast From 2026-06-27 01-34-40.webm](https://github.com/user-attachments/assets/c8d94f73-00dd-4dec-ad5c-ed3a27e4469f)



### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable

Assisted-by: ClaudeCode:claude-opus-4-8