### PR TITLE
fix(actions): top-align icons with multi-line action labels

### DIFF
--- a/src/assets/action.scss
+++ b/src/assets/action.scss
@@ -75,6 +75,7 @@
 		&:deep(.material-design-icon) {
 			width: var(--default-clickable-area);
 			height: var(--default-clickable-area);
+			align-self: flex-start;
 			opacity: $opacity_full;
 
 			.material-design-icon__svg {

--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -128,6 +128,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 			:class="{
 				'action-input-picker--disabled': disabled,
 				'action-input--visible-label': labelOutside && label,
+				'action-input--tight-label': isNativePicker || isMultiselectType,
 			}"
 			@mouseleave="onLeave">
 			<span class="action-input__icon-wrapper">
@@ -535,7 +536,8 @@ $input-margin: 4px;
 
 	&__icon-wrapper {
 		display: flex;
-		align-self: center;
+		align-self: flex-start;
+		margin-top: var(--default-grid-baseline);
 		align-items: center;
 		justify-content: center;
 
@@ -548,6 +550,12 @@ $input-margin: 4px;
 				vertical-align: middle;
 			}
 		}
+	}
+
+	// NcSelect and the native date picker render their own label with a tighter
+	// line-height. Extra margin drops the icon too low, so omitting it there.
+	&--tight-label &__icon-wrapper {
+		margin-top: 0;
 	}
 
 	& > span {

--- a/src/components/NcActionTextEditable/NcActionTextEditable.vue
+++ b/src/components/NcActionTextEditable/NcActionTextEditable.vue
@@ -239,6 +239,8 @@ $input-margin: 4px;
 	&:deep(.material-design-icon) {
 		width: var(--default-clickable-area);
 		height: var(--default-clickable-area);
+		align-self: flex-start;
+		margin-top: var(--default-grid-baseline);
 		opacity: $opacity_full;
 
 		.material-design-icon__svg {


### PR DESCRIPTION
The icons in the action menu are vertically center-aligned for multi-line entries (especially visible in Mail). This looks a bit unorganized and they should be top-aligned.

The fix is overriding the global `.material-design-icon { align-self: center; }`.


### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/5284

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="472" height="422" alt="Screenshot From 2026-07-13 13-45-56" src="https://github.com/user-attachments/assets/06fbef5c-bd38-4f34-9713-3fdb371a98e2" />|<img width="472" height="422" alt="Screenshot From 2026-07-13 13-46-01" src="https://github.com/user-attachments/assets/63f1b928-352b-4aa3-a785-98d3c204283a" />



### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable

Assisted-by: ClaudeCode:claude-opus-4-8