### PR TITLE
fix(NcAppNavigationToggle): Use more common left panel toggle icon

### DIFF
--- a/src/components/NcAppNavigation/NcAppNavigationToggle.vue
+++ b/src/components/NcAppNavigation/NcAppNavigationToggle.vue
@@ -4,7 +4,7 @@
   -->
 
 <script setup lang="ts">
-import { mdiMenu, mdiMenuOpen } from '@mdi/js'
+import { mdiDockLeft } from '@mdi/js'
 import { computed } from 'vue'
 import NcIconSvgWrapper from '../NcIconSvgWrapper/NcIconSvgWrapper.vue'
 import { t } from '../../l10n.ts'
@@ -31,7 +31,7 @@ const title = computed(() => open.value ? t('Close navigation') : t('Open naviga
 			variant="tertiary"
 			@click="open = !open">
 			<template #icon>
-				<NcIconSvgWrapper :path="open ? mdiMenuOpen : mdiMenu" />
+				<NcIconSvgWrapper :path="mdiDockLeft" directional />
 			</template>
 		</NcButton>
 	</div>


### PR DESCRIPTION
The old icon is used more so for non-persistent sidebars. Ones that close after you interact with them.

For example, non-persistent on GitHub and our own website, persistent on Safari or Firefox.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="53" height="49" alt="image" src="https://github.com/user-attachments/assets/084dbc5f-a06d-4358-9d84-e9a71f9bfa8d" /> | <img width="53" height="49" alt="image" src="https://github.com/user-attachments/assets/f665b4b8-ca5b-40bc-9b9f-3b52f6e5a984" />

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable

PS: I hope I did the RTL thing correctly? I looked at how it's done elsewhere.