### PR TITLE
fix(NcCheckboxRadioSwitch): expose switch type with role=switch

### DIFF
--- a/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
+++ b/src/components/NcCheckboxRadioSwitch/NcCheckboxRadioSwitch.vue
@@ -300,6 +300,7 @@ export default {
 			class="checkbox-radio-switch__input"
 			:disabled="disabled"
 			:type="inputType"
+			:role="inputRole"
 			:value="value"
 			:checked="isChecked"
 			:indeterminate.prop="hasIndeterminate ? indeterminate : null"
@@ -616,6 +617,16 @@ export default {
 				return this.internalType
 			}
 			return TYPE_CHECKBOX
+		},
+
+		/**
+		 * ARIA role for the input. A switch renders as a native checkbox, so it
+		 * needs an explicit `switch` role to be announced correctly.
+		 *
+		 * @return {string|undefined}
+		 */
+		inputRole() {
+			return this.internalType === TYPE_SWITCH ? 'switch' : undefined
 		},
 
 		/**

--- a/tests/unit/components/NcCheckboxRadioSwitch/checkbox.spec.ts
+++ b/tests/unit/components/NcCheckboxRadioSwitch/checkbox.spec.ts
@@ -140,4 +140,30 @@ describe('NcCheckboxRadioSwitch', () => {
 
 		wrapper.unmount()
 	})
+
+	it('sets role="switch" on a switch input', () => {
+		const wrapper = mount(NcCheckboxRadioSwitch, {
+			props: {
+				type: 'switch',
+			},
+			slots: {
+				default: 'Test',
+			},
+		})
+
+		expect(wrapper.find('input').attributes('role')).toBe('switch')
+	})
+
+	it.each(['checkbox', 'radio'] as const)('does not set a role on a %s input', (type) => {
+		const wrapper = mount(NcCheckboxRadioSwitch, {
+			props: {
+				type,
+			},
+			slots: {
+				default: 'Test',
+			},
+		})
+
+		expect(wrapper.find('input').attributes('role')).toBeUndefined()
+	})
 })


### PR DESCRIPTION
https://developer.mozilla.org/fr/docs/Web/Accessibility/ARIA/Reference/Roles/switch_role

A `NcCheckboxRadioSwitch` with `type="switch"` renders as a native `<input type="checkbox">` (there is no native switch input type), so assistive technologies announce it as a checkbox rather than a switch.

This adds an explicit `role="switch"` on the input for the switch type only (checkbox / radio / button stay untouched). It is bound before `v-bind="$attrs"`, so a consumer-provided `role` still wins.

---
:robot: This change was AI-assisted; the human author has reviewed and owns it.