### PR TITLE
fix: generating avatar with unusual display name

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -619,7 +619,7 @@ export default {
 					return initials
 				}
 
-				const filtered = filteredChars.join('')
+				const filtered = filteredChars.join('').trim()
 				const idx = filtered.lastIndexOf(' ')
 				initials = String.fromCodePoint(filtered.codePointAt(0))
 				if (idx !== -1) {

--- a/tests/unit/components/NcAvatar/NcAvatar.spec.ts
+++ b/tests/unit/components/NcAvatar/NcAvatar.spec.ts
@@ -100,6 +100,7 @@ describe('NcAvatar.vue', () => {
 			displayName             | initials | case
 			${''}                   | ${'?'}   | ${'empty user'}
 			${'Jane Doe'}           | ${'JD'}  | ${'display name property'}
+			${'Jane Doe !'}         | ${'JD'}  | ${'trailing space before special character'}
 			${'Jane (Doe)'}         | ${'JD'}  | ${'special characters in name'}
 			${'jane doe'}           | ${'JD'}  | ${'lower case name'}
 			${'Jane Some Name Doe'} | ${'JD'}  | ${'middle names'}


### PR DESCRIPTION
Fixes an edge case in extracting initials for the generic avatar.

Without this, strings like `John Doe !` (note the blank space before the exclamation mark) generate a runtime error in the JS console: "RangeError: Invalid code point NaN"