### PR TITLE
feat(NcAppSidebarTab): add animation effect for tab button

### DIFF
--- a/src/components/NcAppSidebar/NcAppSidebar.vue
+++ b/src/components/NcAppSidebar/NcAppSidebar.vue
@@ -41,14 +41,17 @@ Using `v-show` directly will result in usability issues due to internal focus tr
 				Search tab content
 			</NcAppSidebarTab>
 			<NcAppSidebarTab name="Settings" id="settings-tab">
-				<template #icon>
-					<IconCogOutline :size="20" />
+				<!-- The active tab uses the filled icon variant -->
+				<template #icon="{ selected }">
+					<IconCog v-if="selected" :size="20" />
+					<IconCogOutline v-else :size="20" />
 				</template>
 				Settings tab content
 			</NcAppSidebarTab>
 			<NcAppSidebarTab name="Sharing" id="share-tab">
-				<template #icon>
-					<IconShareVariantOutline :size="20" />
+				<template #icon="{ selected }">
+					<IconShareVariant v-if="selected" :size="20" />
+					<IconShareVariantOutline v-else :size="20" />
 				</template>
 				Sharing tab content
 			</NcAppSidebarTab>
@@ -58,12 +61,16 @@ Using `v-show` directly will result in usability issues due to internal focus tr
 
 <script>
 	import IconMagnify from 'vue-material-design-icons/Magnify.vue'
+	import IconCog from 'vue-material-design-icons/Cog.vue'
 	import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
+	import IconShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 	import IconShareVariantOutline from 'vue-material-design-icons/ShareVariantOutline.vue'
 
 	export default {
 		components: {
 			IconMagnify,
+			IconCog,
+			IconShareVariant,
 			IconCogOutline,
 			IconShareVariantOutline,
 		},
@@ -138,14 +145,16 @@ Single tab is rendered without navigation, but it is possible to force it.
 				Search tab content
 			</NcAppSidebarTab>
 			<NcAppSidebarTab v-if="showTabs[1]" name="Settings" id="settings-tab">
-				<template #icon>
-					<IconCogOutline :size="20" />
+				<template #icon="{ selected }">
+					<IconCog v-if="selected" :size="20" />
+					<IconCogOutline v-else :size="20" />
 				</template>
 				Settings
 			</NcAppSidebarTab>
 			<NcAppSidebarTab v-if="showTabs[2]" name="Sharing" id="share-tab">
-				<template #icon>
-					<IconShareVariantOutline :size="20" />
+				<template #icon="{ selected }">
+					<IconShareVariant v-if="selected" :size="20" />
+					<IconShareVariantOutline v-else :size="20" />
 				</template>
 				Sharing tab content
 			</NcAppSidebarTab>
@@ -155,13 +164,17 @@ Single tab is rendered without navigation, but it is possible to force it.
 
 <script>
 	import IconMagnify from 'vue-material-design-icons/Magnify.vue'
+	import IconCog from 'vue-material-design-icons/Cog.vue'
 	import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
+	import IconShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 	import IconShareVariantOutline from 'vue-material-design-icons/ShareVariantOutline.vue'
 
 	export default {
 		components: {
 			IconMagnify,
+			IconCog,
 			IconCogOutline,
+			IconShareVariant,
 			IconShareVariantOutline,
 		},
 		provide() {
@@ -228,14 +241,16 @@ To customize the order of tabs, ``order`` prop can be used on child components.
 				Search tab content
 			</NcAppSidebarTab>
 			<NcAppSidebarTab name="Settings" id="settings-tab" :order="2">
-				<template #icon>
-					<IconCogOutline :size="20" />
+				<template #icon="{ selected }">
+					<IconCog v-if="selected" :size="20" />
+					<IconCogOutline v-else :size="20" />
 				</template>
 				Settings
 			</NcAppSidebarTab>
 			<NcAppSidebarTab name="Sharing" id="share-tab" :order="1">
-				<template #icon>
-					<IconShareVariantOutline :size="20" />
+				<template #icon="{ selected }">
+					<IconShareVariant v-if="selected" :size="20" />
+					<IconShareVariantOutline v-else :size="20" />
 				</template>
 				Sharing tab content
 			</NcAppSidebarTab>
@@ -245,13 +260,17 @@ To customize the order of tabs, ``order`` prop can be used on child components.
 
 <script>
 	import IconMagnify from 'vue-material-design-icons/Magnify.vue'
+	import IconCog from 'vue-material-design-icons/Cog.vue'
 	import IconCogOutline from 'vue-material-design-icons/CogOutline.vue'
+	import IconShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 	import IconShareVariantOutline from 'vue-material-design-icons/ShareVariantOutline.vue'
 
 	export default {
 		components: {
 			IconMagnify,
+			IconCog,
 			IconCogOutline,
+			IconShareVariant,
 			IconShareVariantOutline,
 		},
 		provide() {

--- a/src/components/NcAppSidebar/NcAppSidebarTabs.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabs.vue
@@ -11,6 +11,7 @@
 		<!-- 33 and 34 code is for page up and page down -->
 		<div
 			v-if="hasMultipleTabs || showForSingleTab"
+			ref="nav"
 			role="tablist"
 			class="app-sidebar-tabs__nav"
 			:class="{ 'app-sidebar-tabs__nav--legacy': isLegacy34 }"
@@ -20,7 +21,21 @@
 			@keydown.home.exact.prevent.stop="focusFirstTab"
 			@keydown.end.exact.prevent.stop="focusLastTab"
 			@keydown.page-up.exact.prevent.stop="focusFirstTab"
-			@keydown.page-down.exact.prevent.stop="focusLastTab">
+			@keydown.page-down.exact.prevent.stop="focusLastTab"
+			@pointerover="handleHighlight"
+			@pointerleave="hideHighlight"
+			@focusin="handleHighlight"
+			@focusout="onHighlightFocusOut">
+			<div
+				v-if="highlightEnabled"
+				class="app-sidebar-tabs__highlight"
+				:class="{
+					'app-sidebar-tabs__highlight--visible': highlightVisible,
+					'app-sidebar-tabs__highlight--animated': highlightAnimated,
+					'app-sidebar-tabs__highlight--over-active': highlightOverActive,
+				}"
+				:style="highlightStyle"
+				aria-hidden="true" />
 			<NcAppSidebarTabsButton
 				v-for="tab in tabs"
 				:id="`tab-button-${tab.id}`"
@@ -28,6 +43,7 @@
 				class="app-sidebar-tabs__tab"
 				:aria-controls="`tab-${tab.id}`"
 				:selected="activeTab === tab.id"
+				:animatedHighlight="highlightEnabled"
 				:tab
 				@update:selected="setActive(tab.id)" />
 		</div>
@@ -96,6 +112,19 @@ export default {
 			 */
 			activeTab: props.active,
 			isLegacy34,
+			/** Whether the sliding highlight runs (JS mounted, non-legacy design) */
+			highlightEnabled: false,
+			/** Whether the highlight is currently shown */
+			highlightVisible: false,
+			/** Whether position changes should transition (slide) or snap */
+			highlightAnimated: false,
+			/** Whether the highlight sits on the active tab (turns transparent) */
+			highlightOverActive: false,
+			/** Highlight geometry inside the tablist, in pixels */
+			highlightLeft: 0,
+			highlightTop: 0,
+			highlightWidth: 0,
+			highlightHeight: 0,
 		}
 	},
 
@@ -116,6 +145,14 @@ export default {
 		currentTabIndex() {
 			return this.tabs.findIndex((tab) => tab.id === this.activeTab)
 		},
+
+		highlightStyle() {
+			return {
+				transform: `translate(${this.highlightLeft}px, ${this.highlightTop}px)`,
+				width: `${this.highlightWidth}px`,
+				height: `${this.highlightHeight}px`,
+			}
+		},
 	},
 
 	watch: {
@@ -131,6 +168,15 @@ export default {
 				this.updateActive()
 			}
 		},
+	},
+
+	mounted() {
+		// The tab the highlight currently covers. Deliberately not in data(): a
+		// reactive proxy of the element would not match the element from an event.
+		this.highlightedButton = null
+		// Progressive enhancement: the sliding highlight only runs once mounted,
+		// and only for the current design (the legacy tabs keep their own look).
+		this.highlightEnabled = !this.isLegacy34
 	},
 
 	methods: {
@@ -242,6 +288,73 @@ export default {
 				this.updateActive()
 			}
 		},
+
+		/**
+		 * Move the sliding highlight onto a tab button. It slides there if
+		 * already visible, otherwise it snaps into place so it does not slide in
+		 * from a previously hovered tab. Over the active tab it turns transparent
+		 * so the active tab keeps its own static background.
+		 *
+		 * @param {HTMLElement} button the tab button element to cover
+		 */
+		showHighlightOn(button) {
+			const buttonRect = button.getBoundingClientRect()
+			const navRect = this.$refs.nav.getBoundingClientRect()
+			const wasVisible = this.highlightVisible
+
+			// Re-appearing: snap into place first so it does not slide in from the
+			// tab that was hovered before
+			this.highlightAnimated = wasVisible
+			this.highlightOverActive = button.getAttribute('aria-selected') === 'true'
+			this.highlightLeft = buttonRect.left - navRect.left
+			this.highlightTop = buttonRect.top - navRect.top
+			this.highlightWidth = buttonRect.width
+			this.highlightHeight = buttonRect.height
+
+			if (!wasVisible) {
+				this.highlightVisible = true
+				// Enable sliding again once it is in place and faded in
+				this.$nextTick(() => requestAnimationFrame(() => {
+					this.highlightAnimated = true
+				}))
+			}
+		},
+
+		/** Hide the sliding highlight */
+		hideHighlight() {
+			this.highlightVisible = false
+			this.highlightedButton = null
+		},
+
+		/**
+		 * Move the highlight to the tab button under the pointer or focus
+		 *
+		 * @param {Event} event the pointer or focus event
+		 */
+		handleHighlight(event) {
+			if (!this.highlightEnabled) {
+				return
+			}
+			const button = event.target?.closest?.('.app-sidebar-tabs__tab')
+			// pointerover fires again for every element inside a tab (icon, label),
+			// so skip the measuring when the highlight already covers this tab
+			if (!button || button === this.highlightedButton || !this.$refs.nav.contains(button)) {
+				return
+			}
+			this.highlightedButton = button
+			this.showHighlightOn(button)
+		},
+
+		/**
+		 * Hide the highlight once focus leaves the tablist entirely
+		 *
+		 * @param {FocusEvent} event the focusout event
+		 */
+		onHighlightFocusOut(event) {
+			if (this.highlightEnabled && !this.$refs.nav.contains(event.relatedTarget)) {
+				this.hideHighlight()
+			}
+		},
 	},
 }
 </script>
@@ -254,10 +367,12 @@ export default {
 	flex: 1 1 100%;
 
 	&__nav {
+		position: relative;
 		display: flex;
 		justify-content: stretch;
 		margin: 10px 8px 0 8px;
 		border-bottom: 1px solid var(--color-border);
+		isolation: isolate; // keep the highlight layered predictably within the nav
 
 		&:not(&--legacy) {
 			gap: var(--default-grid-baseline);
@@ -265,7 +380,56 @@ export default {
 		}
 	}
 
+	&__highlight {
+		position: absolute;
+		top: 0;
+		// Physical left to match the physical offset computed from
+		// getBoundingClientRect (see showHighlightOn), so it stays correct in RTL.
+		// stylelint-disable-next-line csstools/use-logical
+		left: 0;
+		width: 0;
+		height: 0;
+		// Painted below the tab buttons (which are positioned), so it sits behind
+		// the button content.
+		z-index: 0;
+		pointer-events: none;
+		opacity: 0;
+		border-radius: var(--border-radius-element);
+		// Matches the hover highlight of the navigation entries.
+		background-color: color-mix(in srgb, var(--color-primary-element) 8%, transparent);
+		will-change: transform, width, height;
+		// The fade and the background morph are always transitioned; sliding is
+		// opt-in via --animated so the highlight snaps when it (re)appears.
+		// Durations use --animation-quick (matching the navigation entries), which
+		// the reduced-motion theme
+		// collapses to 0.
+		transition:
+			opacity var(--animation-quick) ease-in-out,
+			background-color var(--animation-quick) ease-in-out;
+
+		&--animated {
+			transition:
+				transform var(--animation-quick) ease-in-out,
+				width var(--animation-quick) ease-in-out,
+				height var(--animation-quick) ease-in-out,
+				opacity var(--animation-quick) ease-in-out,
+				background-color var(--animation-quick) ease-in-out;
+		}
+
+		&--visible {
+			opacity: 1;
+		}
+
+		// Over the active tab the highlight turns transparent so the active tab's
+		// own background shows through, while it still slides on and off it.
+		&--over-active {
+			background-color: transparent;
+		}
+	}
+
 	&__tab {
+		position: relative; // sit above the sliding highlight
+		z-index: 1;
 		flex: 1 1 1px;
 	}
 

--- a/src/components/NcAppSidebar/NcAppSidebarTabsButton.vue
+++ b/src/components/NcAppSidebar/NcAppSidebarTabsButton.vue
@@ -6,6 +6,7 @@
 <script setup lang="ts">
 import type NcAppSidebarTab from '../NcAppSidebarTab/NcAppSidebarTab.vue'
 
+import { ref } from 'vue'
 import NcVNodes from '../NcVNodes/NcVNodes.vue'
 import { isLegacy34 } from '../../utils/legacy.ts'
 
@@ -16,7 +17,30 @@ defineProps<{
 	 * The sidebar tab this button controls
 	 */
 	tab: InstanceType<typeof NcAppSidebarTab>
+
+	/**
+	 * Whether the parent tablist renders a sliding highlight. When set, the
+	 * button drops its own hover background so only the moving highlight shows.
+	 */
+	animatedHighlight?: boolean
 }>()
+
+/** Whether the icon is playing its click "pop" animation */
+const popping = ref(false)
+
+/**
+ * Activate the tab and replay the icon pop (a brief enlarge) as click feedback.
+ * Restarting on every click (not only on becoming selected) keeps the feedback
+ * even when re-clicking the active tab. Under reduced motion --animation-slow
+ * collapses to 0, so the pop is instant.
+ */
+function onClick() {
+	selected.value = true
+	popping.value = false
+	requestAnimationFrame(() => {
+		popping.value = true
+	})
+}
 </script>
 
 <template>
@@ -25,15 +49,28 @@ defineProps<{
 		:class="[$style.sidebarTabsButton, {
 			[$style.sidebarTabsButton_selected]: selected,
 			[$style.sidebarTabsButton_legacy]: isLegacy34,
+			[$style.sidebarTabsButton_animatedHighlight]: animatedHighlight,
 		}]"
 		role="tab"
 		:aria-selected="selected"
 		:tabindex="selected ? 0 : -1"
-		@click="selected = true">
-		<span :class="$style.sidebarTabsButton__icon">
-			<NcVNodes :vnodes="tab.renderIcon()">
-				<span :class="[$style.sidebarTabsButton__legacyIcon, tab.icon]" />
-			</NcVNodes>
+		@click="onClick">
+		<span
+			:class="[$style.sidebarTabsButton__icon, { [$style.sidebarTabsButton__icon_pop]: popping }]"
+			@animationend="popping = false">
+			<!-- Both icon variants are stacked and crossfaded on selection, so the
+				outline fades into the filled variant (and back) instead of snapping.
+				Consumers that render a single icon simply crossfade it with itself. -->
+			<span :class="[$style.sidebarTabsButton__iconLayer, { [$style.sidebarTabsButton__iconLayer_hidden]: selected }]">
+				<NcVNodes :vnodes="tab.renderIcon(false)">
+					<span :class="[$style.sidebarTabsButton__legacyIcon, tab.icon]" />
+				</NcVNodes>
+			</span>
+			<span :class="[$style.sidebarTabsButton__iconLayer, { [$style.sidebarTabsButton__iconLayer_hidden]: !selected }]">
+				<NcVNodes :vnodes="tab.renderIcon(true)">
+					<span :class="[$style.sidebarTabsButton__legacyIcon, tab.icon]" />
+				</NcVNodes>
+			</span>
 		</span>
 		<span :class="$style.sidebarTabsButton__name">
 			{{ tab.name }}
@@ -120,15 +157,31 @@ defineProps<{
 }
 
 .sidebarTabsButton:not(.sidebarTabsButton_legacy).sidebarTabsButton_selected {
-	background-color: var(--color-background-hover);
+	// Same tint as the hover highlight of the tablist, so the highlight sliding
+	// on and off the active tab stays seamless.
+	background-color: color-mix(in srgb, var(--color-primary-element) 8%, transparent);
 
 	&::after {
 		width: 80%;
 		opacity: 1;
 	}
 
+	// Kept identical on hover: the highlight turns transparent over the active
+	// tab, so any other colour here would show up as a jump.
 	&:hover {
-		background-color: var(--color-background-dark);
+		background-color: color-mix(in srgb, var(--color-primary-element) 8%, transparent);
+	}
+}
+
+// When the tablist renders a sliding highlight, the hover background is drawn
+// by that moving element, which sits behind the buttons. Non-selected buttons
+// must stay fully transparent so it shows through; the active tab keeps its own
+// static background from the rule above, which is more specific.
+.sidebarTabsButton_animatedHighlight:not(.sidebarTabsButton_legacy) {
+	background-color: transparent;
+
+	&:hover {
+		background-color: transparent;
 	}
 }
 
@@ -154,10 +207,41 @@ defineProps<{
 	font-weight: var(--font-weight-element, bold);
 }
 
+// The two icon layers are stacked in the same grid cell so they overlap and
+// the container still sizes to the icon.
 .sidebarTabsButton__icon {
+	display: inline-grid;
+	place-items: center;
+}
+
+.sidebarTabsButton__iconLayer {
+	grid-area: 1 / 1;
 	display: inline-flex;
-	align-items: center;
-	justify-content: center;
+	// Crossfade between the outline and filled variant. --animation-slow collapses
+	// to 0 under reduced motion, so the swap becomes instant.
+	transition: opacity var(--animation-slow) ease-in-out;
+}
+
+.sidebarTabsButton__iconLayer_hidden {
+	opacity: 0;
+}
+
+// Brief enlarge as click feedback. Duration uses --animation-slow, which the
+// reduced-motion theme collapses to 0, so the pop is skipped there.
+.sidebarTabsButton__icon_pop {
+	animation: sidebar-tab-icon-pop var(--animation-slow) ease-in-out;
+}
+
+@keyframes sidebar-tab-icon-pop {
+	0% {
+		transform: scale(1);
+	}
+	40% {
+		transform: scale(1.2);
+	}
+	100% {
+		transform: scale(1);
+	}
 }
 
 .sidebarTabsButton__legacyIcon {

--- a/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
+++ b/src/components/NcAppSidebarTab/NcAppSidebarTab.vue
@@ -6,6 +6,28 @@
 <!-- Follows the tab aria guidelines
 	https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html -->
 
+<docs>
+A tab of the `NcAppSidebar`. The default slot is the tab panel content.
+
+### Tab icon
+
+The `icon` slot renders the icon in the tab navigation. It is passed whether the
+tab is currently active, so a filled icon variant can be used for the active tab
+and an outlined one for the others. The two are crossfaded on selection.
+
+```vue
+<NcAppSidebarTab id="settings" name="Settings">
+	<template #icon="{ selected }">
+		<IconCog v-if="selected" :size="20" />
+		<IconCogOutline v-else :size="20" />
+	</template>
+	Settings tab content
+</NcAppSidebarTab>
+```
+
+Passing a single icon is still supported - it is then used for both states.
+</docs>
+
 <template>
 	<section
 		:id="`tab-${id}`"
@@ -49,7 +71,10 @@ export default {
 		},
 
 		/**
-		 * Tab icon's html class in navigation. Used if #icon slot is not provided
+		 * Tab icon's html class in navigation. Used if #icon slot is not provided.
+		 *
+		 * The #icon slot receives the tab's active state as `{ selected }`, so a
+		 * filled icon variant can be rendered for the active tab.
 		 */
 		icon: {
 			type: String,
@@ -112,12 +137,16 @@ export default {
 		},
 
 		/**
-		 * Render tab's icon slot if any
+		 * Render tab's icon slot if any.
+		 * The active state is passed to the slot so consumers can render a
+		 * filled icon variant for the active tab, e.g.
+		 * `<template #icon="{ selected }">`.
 		 *
+		 * @param {boolean} selected whether the tab is currently active
 		 * @return {import('vue').VNode[]}
 		 */
-		renderIcon() {
-			return this.$slots.icon?.()
+		renderIcon(selected = false) {
+			return this.$slots.icon?.({ selected })
 		},
 	},
 }

--- a/tests/component/components/NcAppSidebar/NcAppSidebarTabs.spec.ts
+++ b/tests/component/components/NcAppSidebar/NcAppSidebarTabs.spec.ts
@@ -5,6 +5,7 @@
 
 import { expect, test } from '@playwright/experimental-ct-vue'
 import NcAppSidebarTabsStory from './NcAppSidebarTabs.story.vue'
+import NcAppSidebarTabsIconsStory from './NcAppSidebarTabsIcons.story.vue'
 import NcAppSidebarTabsSingleStory from './NcAppSidebarTabsSingle.story.vue'
 
 test('single sidebar tab', async ({ mount, page }) => {
@@ -77,5 +78,109 @@ test.describe('multiple sidebar tabs', () => {
 		await expect(selectedTab).toContainText('Tab1')
 		await selectedTab.press('PageDown')
 		await expect(selectedTab).toContainText('Tab3')
+	})
+
+	test('sliding highlight follows the hovered tab', async ({ page }) => {
+		const tablist = page.getByRole('tablist')
+		const highlight = tablist.locator('.app-sidebar-tabs__highlight')
+		const tab1 = tablist.getByRole('tab', { name: /Tab1/ })
+		const activeTab = tablist.getByRole('tab', { selected: true })
+
+		// Hidden until a tab is hovered
+		await expect(highlight).not.toHaveClass(/highlight--visible/)
+
+		// Over a non-active tab it shows
+		await tab1.hover()
+		await expect(highlight).toHaveClass(/highlight--visible/)
+		await expect(highlight).not.toHaveClass(/highlight--over-active/)
+
+		// Over the active tab it turns transparent so the tab's own background shows
+		await activeTab.hover()
+		await expect(highlight).toHaveClass(/highlight--over-active/)
+
+		// Hidden again once the pointer leaves the tablist
+		await page.mouse.move(0, 0)
+		await expect(highlight).not.toHaveClass(/highlight--visible/)
+	})
+
+	test('keyboard focus moves the highlight and hides it when focus leaves', async ({ page }) => {
+		const tablist = page.getByRole('tablist')
+		const highlight = tablist.locator('.app-sidebar-tabs__highlight')
+
+		await expect(highlight).not.toHaveClass(/highlight--visible/)
+
+		// Focusing a tab shows the highlight on it, without any pointer involved
+		await tablist.getByRole('tab', { selected: true }).focus()
+		await expect(highlight).toHaveClass(/highlight--visible/)
+
+		// It covers the focused tab
+		const coversFocusedTab = async () => {
+			const [hl, tab] = await Promise.all([
+				highlight.boundingBox(),
+				tablist.locator('[role="tab"]:focus').boundingBox(),
+			])
+			return hl && tab ? Math.abs(hl.x - tab.x) <= 1 && Math.abs(hl.width - tab.width) <= 1 : false
+		}
+		await expect.poll(coversFocusedTab).toBe(true)
+
+		// Arrow keys move the focus, and the highlight follows it
+		await page.keyboard.press('ArrowLeft')
+		await expect(highlight).toHaveClass(/highlight--visible/)
+		await expect.poll(coversFocusedTab).toBe(true)
+
+		// Moving focus out of the tablist hides it again
+		await page.locator('body').evaluate((body) => {
+			const outside = document.createElement('button')
+			outside.textContent = 'outside'
+			body.append(outside)
+			outside.focus()
+		})
+		await expect(highlight).not.toHaveClass(/highlight--visible/)
+	})
+})
+
+test.describe('sidebar tab click feedback', () => {
+	test('clicking a tab plays the icon pop animation', async ({ mount, page }) => {
+		await mount(NcAppSidebarTabsStory)
+		const tablist = page.getByRole('tablist')
+		const tab1 = tablist.getByRole('tab', { name: /Tab1/ })
+		// The icon wrapper is the first child element of the button
+		const icon = tab1.locator('> span').first()
+
+		// No animation until the tab is clicked
+		await expect
+			.poll(async () => icon.evaluate((el) => getComputedStyle(el).animationName))
+			.toBe('none')
+
+		await tab1.click()
+
+		// The pop keyframes run as click feedback
+		await expect
+			.poll(async () => icon.evaluate((el) => getComputedStyle(el).animationName))
+			.toContain('sidebar-tab-icon-pop')
+	})
+})
+
+test.describe('sidebar tab icons', () => {
+	test('active tab crossfades to the filled icon variant, others show the outline', async ({ mount, page }) => {
+		await mount(NcAppSidebarTabsIconsStory)
+
+		// Both variants are always rendered (stacked) so they can crossfade; the
+		// active one is opaque and the other is transparent. The layer is the
+		// marker's parent element.
+		const layer = (testid: string) => page.locator(`[data-testid="${testid}"]`).locator('xpath=..')
+
+		// Tab2 is active: filled visible, outline hidden. Tab1 is the opposite.
+		await expect(layer('second-filled')).toHaveCSS('opacity', '1')
+		await expect(layer('second-outline')).toHaveCSS('opacity', '0')
+		await expect(layer('first-outline')).toHaveCSS('opacity', '1')
+		await expect(layer('first-filled')).toHaveCSS('opacity', '0')
+
+		// Switching crossfades the newly active tab to filled and the old one back
+		await page.getByRole('tab', { name: /Tab1/ }).click()
+		await expect(layer('first-filled')).toHaveCSS('opacity', '1')
+		await expect(layer('first-outline')).toHaveCSS('opacity', '0')
+		await expect(layer('second-outline')).toHaveCSS('opacity', '1')
+		await expect(layer('second-filled')).toHaveCSS('opacity', '0')
 	})
 })

--- a/tests/component/components/NcAppSidebar/NcAppSidebarTabsIcons.story.vue
+++ b/tests/component/components/NcAppSidebar/NcAppSidebarTabsIcons.story.vue
@@ -1,0 +1,30 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import NcAppSidebarTabs from '../../../../src/components/NcAppSidebar/NcAppSidebarTabs.vue'
+import NcAppSidebarTab from '../../../../src/components/NcAppSidebarTab/NcAppSidebarTab.vue'
+
+const active = ref('second')
+</script>
+
+<template>
+	<NcAppSidebarTabs v-model:active="active">
+		<NcAppSidebarTab id="first" name="Tab1">
+			<!-- The active tab renders the filled icon variant, others the outline -->
+			<template #icon="{ selected }">
+				<span :data-testid="selected ? 'first-filled' : 'first-outline'" />
+			</template>
+			Tab1
+		</NcAppSidebarTab>
+		<NcAppSidebarTab id="second" name="Tab2">
+			<template #icon="{ selected }">
+				<span :data-testid="selected ? 'second-filled' : 'second-outline'" />
+			</template>
+			Tab2
+		</NcAppSidebarTab>
+	</NcAppSidebarTabs>
+</template>

--- a/tests/unit/components/NcAppSidebar/NcAppSidebarTabs.spec.ts
+++ b/tests/unit/components/NcAppSidebar/NcAppSidebarTabs.spec.ts
@@ -1,0 +1,204 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { nextTick } from 'vue'
+import NcAppSidebarTabs from '../../../../src/components/NcAppSidebar/NcAppSidebarTabs.vue'
+import NcAppSidebarTab from '../../../../src/components/NcAppSidebarTab/NcAppSidebarTab.vue'
+
+// The test environment reports Nextcloud 32, but the sliding highlight only runs
+// on the current design, so opt into it here.
+vi.mock('../../../../src/utils/legacy.ts', () => ({ isLegacy: false, isLegacy34: false }))
+
+/**
+ * Stub getBoundingClientRect, which jsdom always reports as zero.
+ *
+ * @param el the element to stub
+ * @param left the left offset to report
+ * @param width the width to report
+ */
+function setRect(el: Element, left: number, width: number) {
+	el.getBoundingClientRect = () => ({
+		left,
+		width,
+		top: 0,
+		height: 44,
+		right: left + width,
+		bottom: 44,
+		x: left,
+		y: 0,
+		toJSON: () => ({}),
+	})
+}
+
+/**
+ * Mount the tabs with three tabs, the second one active, and a stubbed geometry:
+ * the tablist starts at 0 and each tab is 100 wide.
+ *
+ * @return the mounted wrapper
+ */
+async function mountTabs() {
+	const wrapper = mount(NcAppSidebarTabs, {
+		props: { active: 'second' },
+		slots: {
+			default: [
+				'<NcAppSidebarTab id="first" name="Tab1">Tab1</NcAppSidebarTab>',
+				'<NcAppSidebarTab id="second" name="Tab2">Tab2</NcAppSidebarTab>',
+				'<NcAppSidebarTab id="third" name="Tab3">Tab3</NcAppSidebarTab>',
+			].join(''),
+		},
+		global: {
+			components: { NcAppSidebarTab },
+		},
+	})
+	// The tabs register themselves as they are created, so the tab navigation
+	// only exists after the following render
+	await nextTick()
+	setRect(wrapper.find('[role="tablist"]').element, 0, 300)
+	wrapper.findAll('[role="tab"]').forEach((tab, index) => setRect(tab.element, index * 100, 100))
+	return wrapper
+}
+
+describe('NcAppSidebarTabs sliding highlight', () => {
+	beforeEach(() => {
+		// Run the frame callback synchronously so the snap-then-slide handoff is
+		// settled by the time a test asserts on it
+		vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+			cb(0)
+			return 0
+		})
+	})
+
+	afterEach(() => vi.unstubAllGlobals())
+
+	test('is rendered but hidden until a tab is hovered', async () => {
+		const wrapper = await mountTabs()
+		await nextTick()
+
+		const highlight = wrapper.find('.app-sidebar-tabs__highlight')
+		expect(highlight.exists()).toBe(true)
+		expect(highlight.classes()).not.toContain('app-sidebar-tabs__highlight--visible')
+	})
+
+	test('covers the hovered tab', async () => {
+		const wrapper = await mountTabs()
+		await nextTick()
+
+		await wrapper.findAll('[role="tab"]')[0].trigger('pointerover')
+		await nextTick()
+
+		const highlight = wrapper.find('.app-sidebar-tabs__highlight')
+		expect(highlight.classes()).toContain('app-sidebar-tabs__highlight--visible')
+		expect(highlight.attributes('style')).toContain('translate(0px, 0px)')
+		expect(highlight.attributes('style')).toContain('width: 100px')
+	})
+
+	test('slides to the next hovered tab', async () => {
+		const wrapper = await mountTabs()
+		await nextTick()
+		const tabs = wrapper.findAll('[role="tab"]')
+
+		await tabs[0].trigger('pointerover')
+		await nextTick()
+		await tabs[2].trigger('pointerover')
+		await nextTick()
+
+		const highlight = wrapper.find('.app-sidebar-tabs__highlight')
+		// Sliding is enabled once it is already visible
+		expect(highlight.classes()).toContain('app-sidebar-tabs__highlight--animated')
+		expect(highlight.attributes('style')).toContain('translate(200px, 0px)')
+	})
+
+	test('turns transparent over the active tab', async () => {
+		const wrapper = await mountTabs()
+		await nextTick()
+		const tabs = wrapper.findAll('[role="tab"]')
+
+		await tabs[0].trigger('pointerover')
+		await nextTick()
+		expect(wrapper.find('.app-sidebar-tabs__highlight').classes())
+			.not.toContain('app-sidebar-tabs__highlight--over-active')
+
+		// The second tab is the active one
+		await tabs[1].trigger('pointerover')
+		await nextTick()
+		expect(wrapper.find('.app-sidebar-tabs__highlight').classes())
+			.toContain('app-sidebar-tabs__highlight--over-active')
+	})
+
+	test('is hidden again when the pointer leaves the tablist', async () => {
+		const wrapper = await mountTabs()
+		await nextTick()
+
+		await wrapper.findAll('[role="tab"]')[0].trigger('pointerover')
+		await nextTick()
+		await wrapper.find('[role="tablist"]').trigger('pointerleave')
+		await nextTick()
+
+		expect(wrapper.find('.app-sidebar-tabs__highlight').classes())
+			.not.toContain('app-sidebar-tabs__highlight--visible')
+	})
+
+	test('follows keyboard focus and hides when focus leaves the tablist', async () => {
+		const wrapper = await mountTabs()
+		await nextTick()
+		const tabs = wrapper.findAll('[role="tab"]')
+
+		await tabs[2].trigger('focusin')
+		await nextTick()
+		const highlight = wrapper.find('.app-sidebar-tabs__highlight')
+		expect(highlight.classes()).toContain('app-sidebar-tabs__highlight--visible')
+		expect(highlight.attributes('style')).toContain('translate(200px, 0px)')
+
+		// Focus moving to something outside the tablist hides it
+		await wrapper.find('[role="tablist"]').trigger('focusout', { relatedTarget: document.body })
+		await nextTick()
+		expect(wrapper.find('.app-sidebar-tabs__highlight').classes())
+			.not.toContain('app-sidebar-tabs__highlight--visible')
+	})
+
+	test('keeps the highlight when focus moves within the tablist', async () => {
+		const wrapper = await mountTabs()
+		await nextTick()
+		const tabs = wrapper.findAll('[role="tab"]')
+
+		await tabs[0].trigger('focusin')
+		await nextTick()
+		await wrapper.find('[role="tablist"]').trigger('focusout', { relatedTarget: tabs[1].element })
+		await nextTick()
+
+		expect(wrapper.find('.app-sidebar-tabs__highlight').classes())
+			.toContain('app-sidebar-tabs__highlight--visible')
+	})
+
+	test('clicking a tab activates it', async () => {
+		const wrapper = await mountTabs()
+		await nextTick()
+
+		await wrapper.findAll('[role="tab"]')[2].trigger('click')
+		await nextTick()
+
+		expect(wrapper.emitted('update:active')?.at(-1)).toEqual(['third'])
+		expect(wrapper.findAll('[role="tab"]')[2].attributes('aria-selected')).toBe('true')
+	})
+
+	test('does not measure again while the pointer stays on the same tab', async () => {
+		const wrapper = await mountTabs()
+		await nextTick()
+		const tab = wrapper.findAll('[role="tab"]')[0]
+
+		await tab.trigger('pointerover')
+		await nextTick()
+		const measured = vi.spyOn(tab.element, 'getBoundingClientRect')
+
+		// pointerover fires again for the icon and label inside the same tab
+		await tab.trigger('pointerover')
+		await tab.trigger('pointerover')
+		await nextTick()
+
+		expect(measured).not.toHaveBeenCalled()
+	})
+})

--- a/tests/unit/components/NcAppSidebar/legacy.spec.ts
+++ b/tests/unit/components/NcAppSidebar/legacy.spec.ts
@@ -1,0 +1,48 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { expect, test, vi } from 'vitest'
+import { nextTick } from 'vue'
+import NcAppSidebarTabs from '../../../../src/components/NcAppSidebar/NcAppSidebarTabs.vue'
+import NcAppSidebarTab from '../../../../src/components/NcAppSidebarTab/NcAppSidebarTab.vue'
+
+vi.mock('../../../../src/utils/legacy.ts', () => ({ isLegacy: false, isLegacy34: true }))
+
+/**
+ * Mount the tabs with two child tabs so the tab navigation is rendered.
+ */
+function mountTabs() {
+	return mount(NcAppSidebarTabs, {
+		slots: {
+			default: [
+				'<NcAppSidebarTab id="first" name="Tab1">Tab1</NcAppSidebarTab>',
+				'<NcAppSidebarTab id="second" name="Tab2">Tab2</NcAppSidebarTab>',
+			].join(''),
+		},
+		global: {
+			components: { NcAppSidebarTab },
+		},
+	})
+}
+
+test('the sliding highlight is not rendered on Nextcloud < 34', async () => {
+	const wrapper = mountTabs()
+	await nextTick()
+
+	// The legacy tab design keeps its own look, so the moving highlight is off
+	expect(wrapper.find('.app-sidebar-tabs__nav--legacy').exists()).toBe(true)
+	expect(wrapper.find('.app-sidebar-tabs__highlight').exists()).toBe(false)
+})
+
+test('hovering a tab does not create a highlight on Nextcloud < 34', async () => {
+	const wrapper = mountTabs()
+	await nextTick()
+
+	await wrapper.find('[role="tab"]').trigger('pointerover')
+	await nextTick()
+
+	expect(wrapper.find('.app-sidebar-tabs__highlight').exists()).toBe(false)
+})


### PR DESCRIPTION
Same as https://github.com/nextcloud-libraries/nextcloud-vue/pull/8685 but for the sidebar tabs.

### ☑️ Resolves

- Part of https://github.com/nextcloud/server/issues/47739

### 🖼️ Screenshots

#### 🏚️ Before 

[Screencast From 2026-07-30 07-43-34.webm](https://github.com/user-attachments/assets/bc60d0f9-4bd3-4df0-a242-665a999ecd1a)


#### 🏡 After

[Screencast From 2026-07-30 17-02-40.webm](https://github.com/user-attachments/assets/b8d3361a-4e7c-4d37-99c0-4bcf9aa5939a)


**Just for the record: Previous versions with different active / highlight color**

[Screencast From 2026-07-30 07-33-28.webm](https://github.com/user-attachments/assets/fd283686-8d19-4817-aac4-00c9ddf06e2a)



### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
