### PR TITLE
fix(NcAppNavigationItem): backwards tabbing action selection

### DIFF
--- a/src/assets/NcAppNavigationItem.scss
+++ b/src/assets/NcAppNavigationItem.scss
@@ -4,6 +4,23 @@
  */
 @use './variables.scss' as *;
 
+// The actions of an entry are only shown if the entry is active, hovered or focused.
+// They must not be hidden using `display: none` (or `visibility: hidden`) as this would
+// remove them from the tab order: when tabbing backwards (shift + tab) into an entry the
+// entry is not focused yet, so the actions would simply be skipped. See #8143.
+// Instead they are only hidden visually and taken out of the layout flow.
+@mixin actions-hidden {
+	position: absolute;
+	opacity: 0;
+	pointer-events: none;
+}
+
+@mixin actions-visible {
+	position: relative;
+	opacity: 1;
+	pointer-events: auto;
+}
+
 .app-navigation-entry {
 	position: relative;
 	display: flex;
@@ -92,7 +109,7 @@
 	&:focus-within,
 	&:hover {
 		.app-navigation-entry__utils .app-navigation-entry__actions {
-			display: inline-block;
+			@include actions-visible;
 		}
 	}
 
@@ -211,7 +228,7 @@
 	flex: 0 1 auto;
 	justify-content: flex-end;
 	&#{&}--display-actions .action-item.app-navigation-entry__actions {
-		display: inline-block;
+		@include actions-visible;
 	}
 	/* counter */
 	.app-navigation-entry__counter-wrapper {
@@ -223,7 +240,7 @@
 	}
 	/* actions */
 	.action-item.app-navigation-entry__actions {
-		display: none;
+		@include actions-hidden;
 	}
 }
 


### PR DESCRIPTION
### ☑️ Resolves

- Fix https://github.com/nextcloud-libraries/nextcloud-vue/issues/8143

- [x] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
