### PR TITLE
fix(NcDateTimePicker): avoid rerendering picker on locale change

### DIFF
--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -289,7 +289,7 @@ import {
 } from '@nextcloud/l10n'
 import VueDatePicker from '@vuepic/vue-datepicker'
 import { parse } from 'date-fns/parse'
-import { computed, useTemplateRef, warn, watchEffect } from 'vue'
+import { computed, useTemplateRef, warn, watch, watchEffect } from 'vue'
 import NcIconSvgWrapper from '../NcIconSvgWrapper/NcIconSvgWrapper.vue'
 import NcTimezonePicker from '../NcTimezonePicker/NcTimezonePicker.vue'
 import { t } from '../../l10n.ts'
@@ -545,7 +545,16 @@ const placeholderFallback = computed(() => {
 	return t('Select date and time')
 })
 
-const dateFnsLocale = useDateFnsLocale(realLocale)
+const { isLoading: dateFnsLocaleIsLoading, locale: dateFnsLocale } = useDateFnsLocale()
+watch(dateFnsLocale, () => {
+	// Force reformating of values once the locale updates.
+	// By default Existing values are not reformated once locale is updated.
+	// See https://github.com/Vuepic/vue-datepicker/issues/1284
+	pickerInstance.value?.parseModel()
+}, {
+	// Apply only after new locale was reaplied to VueDatePicker.
+	flush: 'post',
+})
 
 /**
  * The date (time) formatting to be used by the library.
@@ -811,12 +820,8 @@ function sameDay(a: Date, b: Date): boolean {
 
 <template>
 	<div class="vue-date-time-picker__wrapper">
-		<!-- Setting :key="dateFnsLocale.code" forces the component to rerender when `:formatLocale` changes.
-             Without it, the formatted date only changes after the user focuses on the text input.
-             This issue was only observed with :format="realFormat" being a pattern, e.g., 'dd MMM yyyy'.
-             See https://github.com/Vuepic/vue-datepicker/issues/1284  -->
+		<!-- :readonly="dateFnsLocaleIsLoading" avoids discarding user input if the locale finishes loading after the user started input. -->
 		<VueDatePicker
-			:key="dateFnsLocale?.code"
 			ref="picker"
 			:aria-labels
 			:autoApply="!confirm"
@@ -829,6 +834,7 @@ function sameDay(a: Date, b: Date): boolean {
 			:format="realFormat"
 			:locale="realLocale"
 			:formatLocale="dateFnsLocale"
+			:readonly="dateFnsLocaleIsLoading"
 			:minDate="calcMinMaxTime.minDate"
 			:maxDate="calcMinMaxTime.maxDate"
 			:minTime="calcMinMaxTime.minTime"

--- a/src/components/NcDateTimePicker/useDateFnsLocale.ts
+++ b/src/components/NcDateTimePicker/useDateFnsLocale.ts
@@ -4,39 +4,85 @@
  */
 
 import type { Locale } from 'date-fns'
-import type { ComputedRef, MaybeRefOrGetter } from 'vue'
+import type { Ref } from 'vue'
 
-import { computedAsync } from '@vueuse/core'
+import { getCanonicalLocale } from '@nextcloud/l10n'
 import { enUS } from 'date-fns/locale/en-US'
-import { computed, toValue } from 'vue'
+import { ref } from 'vue'
+import { logger } from '../../utils/logger.ts'
 import loader from './dateFnsLocaleLoader.ts'
 
+const FALLBACK_LOCALE = enUS
+let cachedLocale: undefined | Promise<Locale> | Locale
+
 /**
- * Given a locale try to load the corresponding locale from date-fns.
- * Fall back to en-US while loading, if the request locale does not exist or could not be loaded.
+ * Reset locale cache. Only used for tests.
  *
- * @param locale locale code (e.g., 'de-DE')
+ * @internal
  */
-export default function useDateFnsLocale(locale: MaybeRefOrGetter<string>): ComputedRef<Locale> {
-	const loadedLocale = computedAsync(() => loadDateFnsLocale(toValue(locale)))
-	return computed(() => loadedLocale.value ?? enUS)
+export function resetDateFnsLocaleCache(): void {
+	cachedLocale = undefined
+}
+
+/**
+ * Try to load the corresponding locale from date-fns for {@link getCanonicalLocale()}.
+ * Fall back to {@link enUS} while loading, if the requested locale does not exist or could not be loaded.
+ */
+export default function useDateFnsLocale(): { isLoading: Ref<boolean>, locale: Ref<Locale> } {
+	const localeCode = getCanonicalLocale()
+	if (localeCode === FALLBACK_LOCALE.code) {
+		return {
+			isLoading: ref(false),
+			locale: ref(FALLBACK_LOCALE),
+		}
+	}
+
+	if (cachedLocale === undefined) {
+		cachedLocale = loadDateFnsLocale(localeCode)
+	}
+
+	if (cachedLocale instanceof Promise) {
+		const isLoading = ref(true)
+		const locale = ref(FALLBACK_LOCALE)
+		cachedLocale
+			.then((loadedLocale) => {
+				cachedLocale = loadedLocale
+				isLoading.value = false
+				locale.value = cachedLocale
+			})
+		return {
+			isLoading,
+			locale,
+		}
+	}
+
+	return {
+		isLoading: ref(false),
+		locale: ref(cachedLocale),
+	}
 }
 
 /**
  * Given a locale code load the locale from the loader.
  *
- * @param locale Locale code (e.g, nl-BE.js)
+ * @param localeCode Locale code (e.g, "nl-BE")
  */
-async function loadDateFnsLocale(locale: string): Promise<Locale | undefined> {
-	if (locale in loader) {
-		return await loader[locale]()
+async function loadDateFnsLocale(localeCode: string): Promise<Locale> {
+	if (localeCode in loader) {
+		try {
+			return await loader[localeCode]()
+		} catch (error) {
+			logger.warn('Failed to load locale.', { localeCode, error })
+			return FALLBACK_LOCALE
+		}
 	}
 
-	if (locale.includes('-')) {
+	if (localeCode.includes('-')) {
 		// Try without region
-		const shortLocale = locale.split('-')[0]
+		const shortLocale = localeCode.split('-')[0]
 		return loadDateFnsLocale(shortLocale)
 	}
 
-	return undefined
+	logger.warn('Found no locale to load.', { localeCode })
+	return FALLBACK_LOCALE
 }

--- a/tests/unit/components/NcDateTimePicker/NcDateTimePicker.spec.js
+++ b/tests/unit/components/NcDateTimePicker/NcDateTimePicker.spec.js
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { setLocale } from '@nextcloud/l10n'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import NcDateTimePicker from '../../../../src/components/NcDateTimePicker/NcDateTimePicker.vue'
+import useDateFnsLocale, { resetDateFnsLocaleCache } from '../../../../src/components/NcDateTimePicker/useDateFnsLocale.ts'
+
+describe('NcDateTimePicker.vue', () => {
+	describe('Locale loading', async () => {
+		beforeEach(() => {
+			resetDateFnsLocaleCache()
+		})
+
+		it('Make immediately writable for cached local', async () => {
+			setLocale('de')
+			const { isLoading } = useDateFnsLocale()
+			await vi.waitUntil(() => !isLoading.value)
+
+			const wrapper = mount(NcDateTimePicker, {
+				props: {
+					type: 'date',
+				},
+			})
+			const input = wrapper.find('input')
+			await input.setValue('11.02.2000')
+
+			const emitted = wrapper.emitted('update:modelValue')
+			expect(emitted).toBeTruthy()
+			expect(emitted.at(0)[0]).toBeTruthy()
+		})
+
+		it('Make writable after laoding locale', async () => {
+			setLocale('de')
+			const wrapper = mount(NcDateTimePicker, {
+				props: {
+					type: 'date',
+				},
+			})
+
+			const input = wrapper.find('input')
+			await vi.waitUntil(() => !input.element.readOnly)
+			await input.setValue('11.02.2000')
+
+			const emitted = wrapper.emitted('update:modelValue')
+			expect(emitted).toBeTruthy()
+			expect(emitted.at(0)[0]).toBeTruthy()
+		})
+
+		it('Make readonly while loading locale', async () => {
+			setLocale('de')
+			const wrapper = mount(NcDateTimePicker, {
+				props: {
+					type: 'date',
+				},
+			})
+
+			expect(wrapper.find('input').element.readOnly).toBeTruthy()
+		})
+
+		it('Make switch formatting after laoding locale', async () => {
+			setLocale('de')
+			const wrapper = mount(NcDateTimePicker, {
+				props: {
+					type: 'date',
+					modelValue: new Date(2026, 1, 10),
+				},
+			})
+			await nextTick()
+			expect(wrapper.find('input').element.value).toBe('Feb 10, 2026')
+
+			await vi.waitFor(() => {
+				expect(wrapper.find('input').element.value).toBe('10.02.2026')
+			})
+		})
+	})
+})


### PR DESCRIPTION
Avoid rerendering picker on locale change.

Also avoid changing text input while users edits by making the input read only while a locale is loading.
Introduces caching to avoid unneeded intermediate read only state.

### ☑️ Resolves

User can start using the picker while the locale is loading.
After the locale loaded, we rerendered the component.
If locale loading was slow, it could happen that we rerender the component while the user is using it.

### 🖼️ Screenshots

This issue hard encounter outside of tests.

### 🏁 Checklist

- [x] ⛑️ Tests are **included** or are not applicable
- [x] 📘 Component documentation has been extended, updated or is **not applicable**
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or **not applicable**
