### PR TITLE
fix(NcActions): ignore redundant separators inside popover

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1360,6 +1360,26 @@ export default {
 		},
 
 		/**
+		 * `Array.filter` callback to drop redundant `NcActionSeparator` entries:
+		 * - the first or the last item in the list;
+		 * - a duplicate of the consequent separator (e.g. if action between them was hidden).
+		 *
+		 * @param {import('vue').VNode} action The action to check
+		 * @param {number} index The index of the action within `actionsList`
+		 * @param {import('vue').VNode[]} actionsList The full list of actions being filtered
+		 * @return {boolean} Whether the action should be kept
+		 */
+		isNotRedundantSeparator(action, index, actionsList) {
+			if (this.getActionName(action) !== 'NcActionSeparator') {
+				return true
+			}
+			if (index === 0 || index === actionsList.length - 1) {
+				return false
+			}
+			return this.getActionName(actionsList[index - 1]) !== 'NcActionSeparator'
+		},
+
+		/**
 		 * Check whether a icon prop value is an URL or not
 		 *
 		 * @param {string} url The icon prop value
@@ -1710,7 +1730,9 @@ export default {
 		/**
 		 * @type {import('vue').VNode[]}
 		 */
-		const menuActions = actions.filter((action) => !inlineActions.includes(action))
+		const menuActions = actions
+			.filter((action) => !inlineActions.includes(action))
+			.filter(this.isNotRedundantSeparator)
 
 		/**
 		 * Determine what kind of menu we have.
@@ -1961,7 +1983,7 @@ export default {
 				],
 			},
 			[
-				renderActionsPopover(actions),
+				renderActionsPopover(menuActions),
 			],
 		)
 	},

--- a/tests/unit/components/NcActions/NcActions.spec.ts
+++ b/tests/unit/components/NcActions/NcActions.spec.ts
@@ -4,10 +4,21 @@
  */
 
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import NcActionButton from '../../../../src/components/NcActionButton/NcActionButton.vue'
 import NcActions from '../../../../src/components/NcActions/NcActions.vue'
+import NcActionSeparator from '../../../../src/components/NcActionSeparator/NcActionSeparator.vue'
 import TestCompositionApi from './TestCompositionApi.vue'
+
+/**
+ * The popover menu content is teleported into `document.body` by floating-vue
+ * and is only present there a tick after `open` becomes true.
+ */
+async function waitForMenu(wrapper) {
+	await wrapper.vm.$nextTick()
+	await new Promise((resolve) => setTimeout(resolve, 50))
+	await wrapper.vm.$nextTick()
+}
 
 describe('NcActions.vue', () => {
 	'use strict'
@@ -172,6 +183,89 @@ describe('NcActions.vue', () => {
 			})
 
 			expect(wrapper.find('img[src="http://example.com/image.png"').exists()).toBe(true)
+		})
+
+		describe('separators', () => {
+			// The popover menu is teleported straight into `document.body` by floating-vue,
+			// outside of the mounted wrapper's root element, so it must be cleared manually.
+			afterEach(() => {
+				document.body.innerHTML = ''
+			})
+
+			it('drops a separator rendered as the first or last menu item', async () => {
+				const wrapper = mount(NcActions, {
+					attachTo: document.body,
+					props: {
+						open: true,
+					},
+					slots: {
+						default: [
+							'<NcActionSeparator />',
+							'<NcActionButton>Test1</NcActionButton>',
+							'<NcActionButton>Test2</NcActionButton>',
+							'<NcActionSeparator />',
+						],
+					},
+					global: {
+						stubs: { NcActionButton, NcActionSeparator },
+					},
+				})
+
+				await waitForMenu(wrapper)
+				expect(document.body.querySelectorAll('.action-separator').length).toBe(0)
+
+				wrapper.unmount()
+			})
+
+			it('drops consecutive separators, keeping only one', async () => {
+				const wrapper = mount(NcActions, {
+					attachTo: document.body,
+					props: {
+						open: true,
+					},
+					slots: {
+						default: [
+							'<NcActionButton>Test1</NcActionButton>',
+							'<NcActionSeparator />',
+							'<NcActionSeparator />',
+							'<NcActionSeparator />',
+							'<NcActionButton>Test2</NcActionButton>',
+						],
+					},
+					global: {
+						stubs: { NcActionButton, NcActionSeparator },
+					},
+				})
+
+				await waitForMenu(wrapper)
+				expect(document.body.querySelectorAll('.action-separator').length).toBe(1)
+
+				wrapper.unmount()
+			})
+
+			it('keeps a single separator placed between two actions', async () => {
+				const wrapper = mount(NcActions, {
+					attachTo: document.body,
+					props: {
+						open: true,
+					},
+					slots: {
+						default: [
+							'<NcActionButton>Test1</NcActionButton>',
+							'<NcActionSeparator />',
+							'<NcActionButton>Test2</NcActionButton>',
+						],
+					},
+					global: {
+						stubs: { NcActionButton, NcActionSeparator },
+					},
+				})
+
+				await waitForMenu(wrapper)
+				expect(document.body.querySelectorAll('.action-separator').length).toBe(1)
+
+				wrapper.unmount()
+			})
 		})
 	})
 })


### PR DESCRIPTION
### ☑️ Resolves

Offload app logic of keeping track, when a separator should be shown, to library
- do not render separator as a first/last item, or consequent duplicate
- do not construct complex conditions inside of app template

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 Tasks

More a POC drafted for discussion, current TODO:
- [ ] Manual test (in styleguide and app)
- [ ] Add screenshots

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
- [x] AI assisted