### PR TITLE
fix(NcProgressBar): properly assign attributes

### DIFF
--- a/src/components/NcProgressBar/NcProgressBar.vue
+++ b/src/components/NcProgressBar/NcProgressBar.vue
@@ -57,6 +57,21 @@ import { computed } from 'vue'
 
 const props = withDefaults(defineProps<{
 	/**
+	 * The accessible label for the progressbar.
+	 */
+	ariaLabel?: string | undefined
+
+	/**
+	 * The id of the element that labels the progressbar.
+	 */
+	ariaLabelledby?: string | undefined
+
+	/**
+	 * The id of the element that describes the progressbar.
+	 */
+	ariaDescribedby?: string | undefined
+
+	/**
 	 * An integer between 0 and 100
 	 */
 	value?: number
@@ -86,6 +101,9 @@ const props = withDefaults(defineProps<{
 	 */
 	showValue?: boolean
 }>(), {
+	ariaLabel: undefined,
+	ariaLabelledby: undefined,
+	ariaDescribedby: undefined,
 	value: 0,
 	color: 'var(--color-primary-element)',
 	size: 'small',
@@ -135,10 +153,13 @@ const clickableAreaSmall = Number.parseInt(window.getComputedStyle(document.body
 <template>
 	<span
 		v-if="type === 'circular'"
-		role="progressbar"
-		:aria-valuenow="value"
+		class="progress-bar progress-bar--circular"
 		:class="{ 'progress-bar--error': error }"
-		class="progress-bar progress-bar--circular">
+		:aria-label
+		:aria-labelledby
+		:aria-describedby
+		:aria-valuenow="value"
+		role="progressbar">
 		<svg
 			:height="height"
 			:width="height">
@@ -166,10 +187,13 @@ const clickableAreaSmall = Number.parseInt(window.getComputedStyle(document.body
 		<progress
 			class="progress-bar progress-bar--linear vue"
 			:class="{ 'progress-bar--error': error }"
+			:aria-label
+			:aria-labelledby
+			:aria-describedby
 			:value
 			max="100" />
 
-		<span v-if="showValue" class="progress-bar__value">{{ value }}%</span>
+		<span v-if="showValue" aria-hidden="true" class="progress-bar__value">{{ value }}%</span>
 	</div>
 </template>
 

--- a/tests/unit/components/NcProgressBar/NcProgressBar.spec.ts
+++ b/tests/unit/components/NcProgressBar/NcProgressBar.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import NcProgressBar from '../../../../src/components/NcProgressBar/NcProgressBar.vue'
+
+describe('NcProgressBar', () => {
+	describe.each([
+		['linear' as const, 'progress'],
+		['circular' as const, 'span[role="progressbar"]'],
+	])('type "%s"', (type, progressSelector) => {
+		it('sets accessibility attributes on the progress element', () => {
+			const wrapper = mount(NcProgressBar, {
+				props: {
+					type,
+					value: 42,
+					ariaLabel: 'Upload progress',
+					ariaLabelledby: 'upload-label',
+					ariaDescribedby: 'upload-description',
+				},
+			})
+
+			const progress = wrapper.get(progressSelector)
+			expect(progress.attributes('aria-label')).toBe('Upload progress')
+			expect(progress.attributes('aria-labelledby')).toBe('upload-label')
+			expect(progress.attributes('aria-describedby')).toBe('upload-description')
+		})
+
+		it('passes other attributes to the root element', () => {
+			const wrapper = mount(NcProgressBar, {
+				props: { type, value: 42 },
+				attrs: {
+					id: 'my-progress',
+					'data-test': 'foo',
+				},
+			})
+
+			expect(wrapper.attributes('id')).toBe('my-progress')
+			expect(wrapper.attributes('data-test')).toBe('foo')
+		})
+
+		it('hides the value text from assistive technology', () => {
+			const wrapper = mount(NcProgressBar, { props: { value: 42, showValue: true } })
+			expect(wrapper.get('.progress-bar__value').attributes('aria-hidden')).toBe('true')
+		})
+	})
+})


### PR DESCRIPTION
### ☑️ Resolves

Logically passing attributes like `aria-label` or `aria-describedby` to give information about the progress are expected to label the `progress` component and not a wrapper with `role = representation`.

So this forwards the attributes to the actual progress element.

But special attributes like `class` or `style` are expected to only affect the outer wrapper "public api" of the component.

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable

### AI
AI was used for unit test generation but afterwards reviewed by me.