### PR TITLE
fix(useFormatDateTime): properly handle invalid dates

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -241,6 +241,9 @@ msgstr ""
 msgid "Increment seconds"
 msgstr ""
 
+msgid "Invalid date"
+msgstr ""
+
 msgid "invisible"
 msgstr ""
 

--- a/src/composables/useFormatDateTime/index.ts
+++ b/src/composables/useFormatDateTime/index.ts
@@ -80,19 +80,27 @@ export function useFormatRelativeTime(
 	 * The formatted relative time
 	 */
 	const relativeTime = ref('')
-	watchEffect(() => updateRelativeTime())
+	watchEffect(updateRelativeTime)
 
 	/**
 	 * Update the relative time string.
 	 * This is the callback for the interval.
 	 */
 	function updateRelativeTime() {
-		relativeTime.value = formatRelativeTime(date.value, options.value)
+		const timestamp = date.value.getTime()
+		if (Number.isNaN(timestamp)) {
+			// likely parsed "Date" from "Infinity" or "NaN"
+			relativeTime.value = t('Invalid date')
+			// no further update until the timestamp is valid again
+			return
+		} else {
+			relativeTime.value = formatRelativeTime(date.value, options.value)
+		}
 
 		if (toValue(opts).update !== false) {
-			const diff = Math.abs(Date.now() - new Date(toValue(timestamp)).getTime())
-			const interval = diff > 120000 || options.value.ignoreSeconds
-				? Math.min(diff / 60, 1800000)
+			const diff = Math.abs(Date.now() - timestamp)
+			const interval = diff > 120_000 || options.value.ignoreSeconds
+				? Math.min(diff / 60, 1_800_000) // max. 30 minutes
 				: 1000
 			timeoutId = window.setTimeout(updateRelativeTime, interval)
 		}

--- a/tests/unit/composables/useFormatDateTime.spec.js
+++ b/tests/unit/composables/useFormatDateTime.spec.js
@@ -11,7 +11,11 @@ describe('useFormatRelativeTime composable', () => {
 	const time = Date.parse('2025-01-01T00:00:00Z')
 
 	beforeAll(() => vi.useFakeTimers())
-	beforeEach(() => vi.setSystemTime(time + 60000))
+	beforeEach(() => {
+		// composables of previous tests are never unmounted, so drop their pending timers
+		vi.clearAllTimers()
+		vi.setSystemTime(time + 60000)
+	})
 
 	it('works with timestamp', () => {
 		const formatted = useFormatRelativeTime(time)
@@ -63,6 +67,51 @@ describe('useFormatRelativeTime composable', () => {
 		// and wait for it (Vue's computed calculation)
 		await vi.advanceTimersToNextTimerAsync()
 		expect(formatted.value).toBe('4 minutes ago')
+	})
+
+	it.each`
+	name                 | timestamp
+	${'NaN'}             | ${Number.NaN}
+	${'Infinity'}        | ${Number.POSITIVE_INFINITY}
+	${'-Infinity'}       | ${Number.NEGATIVE_INFINITY}
+	${'an invalid date'} | ${new Date('not a date')}
+	${'out of range'}    | ${new Date(8.64e15 + 1)}
+	`('handles $name', ({ timestamp }) => {
+		const formatted = useFormatRelativeTime(timestamp)
+		expect(formatted.value).toBe('Invalid date')
+	})
+
+	it('does not schedule updates for an invalid date', async () => {
+		const formatted = useFormatRelativeTime(Number.NaN)
+		expect(formatted.value).toBe('Invalid date')
+		expect(vi.getTimerCount()).toBe(0)
+
+		await vi.advanceTimersByTimeAsync(60000)
+		expect(formatted.value).toBe('Invalid date')
+	})
+
+	it('recovers when the timestamp becomes valid again', async () => {
+		const timestamp = ref(Number.NaN)
+		const formatted = useFormatRelativeTime(timestamp)
+		expect(formatted.value).toBe('Invalid date')
+
+		timestamp.value = time
+		await nextTick()
+		expect(formatted.value).toBe('1 minute ago')
+
+		// updates are scheduled again
+		await vi.advanceTimersByTimeAsync(60000)
+		expect(formatted.value).toBe('2 minutes ago')
+	})
+
+	it('handles a timestamp becoming invalid', async () => {
+		const timestamp = ref(time)
+		const formatted = useFormatRelativeTime(timestamp)
+		expect(formatted.value).toBe('1 minute ago')
+
+		timestamp.value = Number.NaN
+		await nextTick()
+		expect(formatted.value).toBe('Invalid date')
 	})
 
 	it.each`


### PR DESCRIPTION
### ☑️ Resolves

In some cases an invalid Date object or timestamp is passed to the composable, this crashes the composable. To fix this we now properly check this and handle this edge case.

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable

### AI
AI was used for unit tests generation - code was reviewed by me.