### PR TITLE
fix(NcReferenceList): do not flash empty widget list before first fetch

### DIFF
--- a/src/components/NcRichText/NcReferenceList.vue
+++ b/src/components/NcRichText/NcReferenceList.vue
@@ -83,7 +83,7 @@ export default {
 	data() {
 		return {
 			references: null,
-			loading: true,
+			loading: false,
 		}
 	},
 
@@ -130,7 +130,7 @@ export default {
 		text: 'fetch',
 	},
 
-	mounted() {
+	created() {
 		this.fetch()
 	},
 

--- a/tests/unit/components/NcRichText/NcReferenceList.spec.js
+++ b/tests/unit/components/NcRichText/NcReferenceList.spec.js
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import NcReferenceList from '../../../../src/components/NcRichText/NcReferenceList.vue'
+
+vi.mock('@nextcloud/axios', () => ({
+	default: {
+		get: vi.fn().mockResolvedValue({ data: { ocs: { data: { references: {} } } } }),
+		post: vi.fn().mockResolvedValue({ data: { ocs: { data: { references: {} } } } }),
+	},
+}))
+
+describe('NcReferenceList', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('does not render anything and issues no request for text without a URL', () => {
+		const wrapper = mount(NcReferenceList, {
+			props: {
+				text: 'just some plain text, no link here',
+			},
+		})
+
+		expect(wrapper.find('.widgets--list').exists()).toBe(false)
+		expect(axios.get).not.toHaveBeenCalled()
+		expect(axios.post).not.toHaveBeenCalled()
+	})
+
+	it('renders the loading state immediately for text containing a URL', () => {
+		const wrapper = mount(NcReferenceList, {
+			props: {
+				text: 'check this out https://nextcloud.com',
+			},
+		})
+
+		expect(wrapper.find('.widgets--list').exists()).toBe(true)
+		expect(wrapper.find('.widgets--list').classes()).toContain('icon-loading')
+	})
+
+	it('renders without issuing a request when referenceData is provided', () => {
+		const referenceData = [
+			{
+				accessible: true,
+				openGraphObject: {
+					id: 'https://nextcloud.com',
+					link: 'https://nextcloud.com',
+					name: 'Nextcloud',
+				},
+				richObjectType: 'open-graph',
+			},
+		]
+
+		const wrapper = mount(NcReferenceList, {
+			props: {
+				text: 'https://nextcloud.com',
+				referenceData,
+			},
+		})
+
+		expect(wrapper.find('.widgets--list').exists()).toBe(true)
+		expect(wrapper.find('.widgets--list').classes()).not.toContain('icon-loading')
+		expect(axios.get).not.toHaveBeenCalled()
+		expect(axios.post).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
## Summary
The references / smart picker widgets change their size on loading a bit - seem to flash a little. Honestly it doesn't bother me - it is one frame - so if this fix doesn't make sense, we can just skip it ;-)

But it's a two-line change, so might make sense.

Description of the issue:

`NcReferenceList` initialised `loading: true` and only called `fetch()` from `mounted()`. `fetch()` returns synchronously when the text has no URL or `referenceData` is passed, but that happens after the first render — so every such instance paints one frame of `.widgets--list` (which carries `min-height: var(--default-clickable-area)`, 44px) before it disappears.

Every link-free message in **Talk**, comment in **Comments**, and preview node in **Text** shows that flash.

## Fix
- Initialise `loading: false`.
- Move the initial `fetch()` call from `mounted()` to `created()`.

`fetch()` sets `loading = true` itself before the async path, so links still get their placeholder. The no-URL and `referenceData` branches now resolve before first paint and render nothing. `fetch()` touches no DOM, so calling it from `created()` is safe. `watch: { text: 'fetch' }` is unchanged.

## Testing
- Added `tests/unit/components/NcRichText/NcReferenceList.spec.js` covering: no-URL text (no render, no request), URL text (immediate loading state), and `referenceData` passed in (renders without a request).
- `npm run test`, `npm run lint`, `npm run stylelint` all pass.

## Backport
This affects every consumer of `NcReferenceList` (Talk, Text, Comments) on the current v9 branch. Your call if it is worth backporting.

Assisted-by: Claude-code:claude-sonnet-5

### 🏁 Checklist

- [x] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
