### PR TITLE
fix(NcActions) Listen on afterHide instead of non-existing afterClosed.

### DIFF
--- a/src/components/NcActions/NcActions.vue
+++ b/src/components/NcActions/NcActions.vue
@@ -1844,7 +1844,7 @@ export default {
 					noFocusTrap: !this.config.withFocusTrap,
 					'onUpdate:shown': this.toggleMenu,
 					onAfterShow: this.onOpened,
-					onAfterClose: this.onClosed,
+					onAfterHide: this.onClosed,
 				},
 				{
 					trigger: () => h(NcButton, {


### PR DESCRIPTION
It appears that NcPopover does emit an 'afterHide' but not an 'afterClose' event, so NcActions should listen on 'afterHide' instead of on 'afterClose'.

Affects v9.0.0 and up, v8.x.y seems not to be affected.

### ☑️ Resolves

- Fix #8869 
 
### 🖼️ Screenshots

not applicable

### 🚧 Tasks

- not applicable

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [x] 📘 Component documentation has been extended, updated or is not applicable
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version not needed, bug is only present for v9.0.0 and up