### PR TITLE
fix: update role of NcHeaderMenu

### DIFF
--- a/src/components/NcHeaderMenu/NcHeaderMenu.vue
+++ b/src/components/NcHeaderMenu/NcHeaderMenu.vue
@@ -261,6 +261,7 @@ function clearFocusTrap() {
 		<NcButton
 			:id="isNav ? triggerId : null"
 			ref="triggerButton"
+			role="menuitem"
 			:aria-controls="`header-menu-${id}`"
 			:aria-expanded="isOpened.toString()"
 			:aria-label


### PR DESCRIPTION
### ☑️ Resolves

- Fix: https://github.com/nextcloud-gmbh/customer-feature-requests/issues/1591
- Related PR: https://github.com/nextcloud/server/pull/63239

### Summary
Update role of `NcHeaderMenu` to `menuitem`

### 🚧 Tasks

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
