### PR TITLE
fix: remove unnecessary exports from hovercard

### DIFF
--- a/src/components/NcProfileHoverCard/index.ts
+++ b/src/components/NcProfileHoverCard/index.ts
@@ -4,4 +4,3 @@
  */
 
 export { default } from './NcProfileHoverCard.vue'
-export type { IProfileAction, IProfileData, IProfileHoverCardAction, IUserStatus } from './NcProfileHoverCard.vue'


### PR DESCRIPTION
### Summary
Remove unnecessary exports from NcProfileHoverCard

### 🏁 Checklist

- [ ] ⛑️ Tests are included or are not applicable
- [ ] 📘 Component documentation has been extended, updated or is not applicable
- [ ] 2️⃣ Backport to `stable8` for maintained Vue 2 version or not applicable
