### PR TITLE
fix(NcActionInput): display arrow icon for submit

### DIFF
--- a/src/components/NcActionInput/NcActionInput.vue
+++ b/src/components/NcActionInput/NcActionInput.vue
@@ -241,7 +241,7 @@ For the `NcSelect` component, all events will be passed through. Please see the 
 							:disabled="disabled"
 							:inputClass="{ focusable: isFocusable }"
 							:type="type"
-							trailingButtonIcon="arrowRight"
+							trailingButtonIcon="arrowEnd"
 							:trailingButtonLabel="trailingButtonLabel"
 							:showTrailingButton="showTrailingButton && !disabled"
 							v-bind="$attrs"

--- a/tests/unit/components/NcActionInput/NcActionInput.spec.ts
+++ b/tests/unit/components/NcActionInput/NcActionInput.spec.ts
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mdiArrowRight } from '@mdi/js'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import NcActionInput from '../../../../src/components/NcActionInput/NcActionInput.vue'
+
+describe('NcActionInput', () => {
+	it('renders the arrow icon in the trailing button', () => {
+		const wrapper = mount(NcActionInput)
+
+		expect(wrapper.html()).toContain(mdiArrowRight)
+	})
+})


### PR DESCRIPTION
### ☑️ Resolves

"arrowRight" was not an allowed value and fallback to "close". This resulted in a cross icon.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1434" height="1019" alt="Screenshot From 2026-08-25 15-50-45" src="https://github.com/user-attachments/assets/299dd544-2e68-41d6-9cd2-0291e9d08985" /> |  <img width="1059" height="871" alt="Screenshot From 2026-08-25 15-47-25" src="https://github.com/user-attachments/assets/41228c29-3475-4b7c-9c13-beef70f508b8" />


### 🚧 Tasks

### 🏁 Checklist

- [x] ⛑️ Tests **are included** or are not applicable
- [x] 📘 Component documentation has been extended, updated or is **not applicable**
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or **not applicable**
  - Works already as expected in `stable8`