### PR TITLE
fix(NcSelect): align the multiple variant width with the single one

### DIFF
--- a/src/components/NcSelect/NcSelect.vue
+++ b/src/components/NcSelect/NcSelect.vue
@@ -1308,6 +1308,10 @@ export default {
 	// Multi-select: border on dropdown-toggle (contains tags + input)
 	// NcTextField is transparent; floating label via #header slot
 	&.vs--multiple {
+		// The multiple variant otherwise renders ~2px wider than the single one
+		// and overflows its container; inset it by 1px on each side to align.
+		margin-inline: 1px;
+
 		.vs__dropdown-toggle {
 			// Use transparent border in closed state to reserve the same space
 			// as the open state's real border, prevents layout jump on click


### PR DESCRIPTION
The multiple select rendered ~2px wider than the single select and could overflow its container. Inset it by 1px on each side so both variants have the same footprint.

It's mostly an issue because single-select entry are using a nested NcInput. which handles the border.
While a multiple-select handles things differently and outer box-shadow have to be used, that creates a slight difference in where the border/shadow starts.

| Before | After |
|:---------:|:------:|
|<img width="387" height="355" alt="2026-08-28_10-28" src="https://github.com/user-attachments/assets/a424a6f0-85a8-49b9-ae57-3291df2ccfe2" />|<img width="400" height="361" alt="image" src="https://github.com/user-attachments/assets/03183e04-319f-4c40-b834-a200476f0158" />|

Not easy to see, here is a more easy scree,shot of the issue
<img width="406" height="231" alt="image" src="https://github.com/user-attachments/assets/04193419-04a4-4f9d-a48a-cef6fb27ff91" />
