### PR TITLE
chore: prepare v9.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,7 @@ All notable changes to this project will be documented in this file.
 * fix(NcActionInput): display arrow icon for submit [\#8884](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8884) \([odzhychko](https://github.com/odzhychko)\)
 * fix(NcActions) Listen on afterHide instead of non-existing afterClosed. [\#8870](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8870) \([rotdrop](https://github.com/rotdrop)\)
 * fix(NcSelect): align the multiple variant width with the single one [\#8893](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8893) \([skjnldsv](https://github.com/skjnldsv)\)
-
-## New Contributors
-* @rotdrop made their first contribution in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8870
+* fix(NcAppNavigationItem): backwards tabbing action selection [\#8821](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8821) \([[GVodyanov](https://github.com/GVodyanov)\)
 
 ## [v9.10.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.10.0) (2026-08-24)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.9.0...v9.10.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v9.11.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.11.0) (2026-08-28)
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.10.0...v9.11.0)
+
+### 🚀 Enhancements
+* feat(NcAppSidebarTab): add animation effect for tab button [\#8793](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8793) \([jancborchardt](https://github.com/jancborchardt)\)
+* feat(NcSelect): add helperText support [\#8787](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8787) \([skjnldsv](https://github.com/skjnldsv)\)
+
+### 🐛 Fixed bugs
+* fix(NcActionInput): display arrow icon for submit [\#8884](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8884) \([odzhychko](https://github.com/odzhychko)\)
+* fix(NcActions) Listen on afterHide instead of non-existing afterClosed. [\#8870](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8870) \([rotdrop](https://github.com/rotdrop)\)
+* fix(NcSelect): align the multiple variant width with the single one [\#8893](https://github.com/nextcloud-libraries/nextcloud-vue/pull/8893) \([skjnldsv](https://github.com/skjnldsv)\)
+
+## New Contributors
+* @rotdrop made their first contribution in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8870
+
 ## [v9.10.0](https://github.com/nextcloud-libraries/nextcloud-vue/tree/v9.10.0) (2026-08-24)
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.9.0...v9.10.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.10.0",
+  "version": "9.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/vue",
-      "version": "9.10.0",
+      "version": "9.11.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/vue",
-  "version": "9.10.0",
+  "version": "9.11.0",
   "description": "Nextcloud vue components",
   "keywords": [
     "vuejs",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### 🚀 Enhancements
* feat(NcAppSidebarTab): add animation effect for tab button by @jancborchardt in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8793
* feat(NcSelect): add helperText support by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8787
### 🐛 Fixed bugs
* fix(NcActionInput): display arrow icon for submit by @odzhychko in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8884
* fix(NcActions) Listen on afterHide instead of non-existing afterClosed. by @rotdrop in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8870
* fix(NcSelect): align the multiple variant width with the single one by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8893
### Other Changes
* Updates for project Nextcloud vue library by @transifex-integration[bot] in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8878
* Updates for project Nextcloud vue library by @transifex-integration[bot] in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8883
* Updates for project Nextcloud vue library by @transifex-integration[bot] in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8887

## New Contributors
* @rotdrop made their first contribution in https://github.com/nextcloud-libraries/nextcloud-vue/pull/8870

**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-vue/compare/v9.10.0...v9.11.0
