### PR TITLE
fix(NcDateTimePicker): for week picker do not show time picker

### DIFF
--- a/src/components/NcDateTimePicker/NcDateTimePicker.vue
+++ b/src/components/NcDateTimePicker/NcDateTimePicker.vue
@@ -421,7 +421,7 @@ const props = withDefaults(defineProps<{
 	 *
 	 * @default 'date'
 	 */
-	type?: 'date' | 'datetime' | 'time' | 'week' | 'month' | 'year' | 'date-range' | 'time-range' | 'datetime-range'
+	type?: 'week' | 'month' | 'year' | 'date' | 'date-range' | 'time' | 'time-range' | 'datetime' | 'datetime-range'
 
 	/**
 	 * Render the calendar inline (no input field).
@@ -633,7 +633,10 @@ const pickerType = computed(() => ({
 		// but its not covered by our component interface (props / events) documentation so just disabled for now.
 		partialRange: false,
 	},
-	enableTimePicker: !(props.type === 'date' || props.type === 'date-range'),
+	// Show additional time picker only for 'datetime*'.
+	// 'month', 'year', 'time*' do not support it anyway.
+	// But for 'date*' and 'week' it has to be excplicitly disabled.
+	enableTimePicker: props.type === 'datetime' || props.type === 'datetime-range',
 	flow: props.type === 'datetime'
 		? ['calendar', 'time'] as ['calendar', 'time']
 		: undefined,

--- a/tests/unit/components/NcDateTimePicker/NcDateTimePicker.spec.js
+++ b/tests/unit/components/NcDateTimePicker/NcDateTimePicker.spec.js
@@ -78,4 +78,29 @@ describe('NcDateTimePicker.vue', () => {
 			})
 		})
 	})
+
+	describe('Time picker visibility', () => {
+		it.for([
+			['week', false],
+			['month', false],
+			['year', false],
+			['date', false],
+			['date-range', false],
+			['time', false],
+			['time-range', false],
+			['datetime', true],
+			['datetime-range', true],
+		])('renders the time picker button for type %s -> %s', async ([type, isRendered]) => {
+			const wrapper = mount(NcDateTimePicker, {
+				props: {
+					type,
+					inline: true,
+				},
+			})
+
+			await nextTick()
+
+			expect(wrapper.find('[data-test-id="open-time-picker-btn"]').exists()).toBe(isRendered)
+		})
+	})
 })


### PR DESCRIPTION
### ☑️ Resolves

Picker for weeks showed a superfluous time picker.
Now it will be hidden.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="953" height="948" alt="image" src="https://github.com/user-attachments/assets/ed69fbc6-e451-491e-b57d-1354a5a8e3b9" /> | <img width="953" height="948" alt="image" src="https://github.com/user-attachments/assets/ea86092d-de45-4d38-b313-65368a90feed" />

### 🏁 Checklist

- [x] ⛑️ Tests are **included** or are not applicable
- [x] 📘 Component documentation has been extended, updated or is **not applicable**
- [x] 2️⃣ Backport to `stable8` for maintained Vue 2 version or **not applicable**
