### PR TITLE
fix(NcAvatar): pick the avatar variant a display actually needs

### DIFF
--- a/src/components/NcAvatar/NcAvatar.vue
+++ b/src/components/NcAvatar/NcAvatar.vue
@@ -299,6 +299,25 @@ import NcUserStatusIcon from '../NcUserStatusIcon/index.js'
 const browserStorage = getBuilder('nextcloud').persist().build()
 
 /**
+ * How far to stretch the 64px avatar before switching to the 512px one.
+ *
+ * Only those two sizes exist: AvatarController clamps everything else. Without
+ * a tolerance, any display above 1x jumps straight to the 512px file, which is
+ * a few hundred KB for an uploaded photo.
+ */
+const SMALL_VARIANT_UPSCALE = 1.5
+
+/**
+ * Round a density to keep 4.3636... out of the markup.
+ *
+ * @param {number} value the density
+ * @return {number} the rounded density
+ */
+function density(value) {
+	return Number(value.toFixed(3))
+}
+
+/**
  * @param {string} userId The id of the user
  */
 function getUserHasAvatar(userId) {
@@ -795,9 +814,10 @@ export default {
 
 			if (this.size <= 64) {
 				const avatarUrl = this.avatarUrlGenerator(this.user, 64)
+				// Browsers pick the lowest density at or above their own.
 				const srcset = [
-					avatarUrl + ' 1x',
-					this.avatarUrlGenerator(this.user, 512) + ' 8x',
+					`${avatarUrl} ${density((64 * SMALL_VARIANT_UPSCALE) / this.size)}x`,
+					`${this.avatarUrlGenerator(this.user, 512)} ${density(512 / this.size)}x`,
 				].join(', ')
 
 				this.updateImageIfValid(avatarUrl, srcset)

--- a/tests/unit/components/NcAvatar/NcAvatar.spec.ts
+++ b/tests/unit/components/NcAvatar/NcAvatar.spec.ts
@@ -220,5 +220,34 @@ describe('NcAvatar.vue', () => {
 
 			expect(wrapper.find('img').exists()).toBeFalsy()
 		})
+
+		describe('Variant selection', () => {
+			// Hardcoded descriptors sent everything above 1x to the 512px file.
+			it.each([
+				[22, '4.364x', '23.273x'],
+				[32, '3x', '16x'],
+				[40, '2.4x', '12.8x'],
+				[64, '1.5x', '8x'],
+			])('describes both variants relative to a %ipx avatar', async (size, small, large) => {
+				const wrapper = mount(NcAvatar, {
+					props: { displayName: 'Alice', user: 'alice', size },
+				})
+				await nextTick()
+
+				const srcset = wrapper.find('img').attributes('srcset')
+				expect(srcset).toContain(`/avatar/alice/64?guestFallback=true ${small}`)
+				expect(srcset).toContain(`/avatar/alice/512?guestFallback=true ${large}`)
+			})
+
+			it('offers no second variant above 64px, where the large one is used directly', async () => {
+				const wrapper = mount(NcAvatar, {
+					props: { displayName: 'Alice', user: 'alice', size: 128 },
+				})
+				await nextTick()
+
+				expect(wrapper.find('img').attributes('src')).toContain('/avatar/alice/512')
+				expect(wrapper.find('img').attributes('srcset')).toBeUndefined()
+			})
+		})
 	})
 })


### PR DESCRIPTION
### Resolves

Related to https://github.com/nextcloud/server/issues/61726

`NcAvatar` described the 64px avatar as `1x` and the 512px one as `8x` regardless of the size it renders at. Browsers pick the lowest density at or above their own, and there's nothing in between, so any display above 1x fetched the 512px file.

Measured on a real Talk call, that's 267 KiB per avatar instead of 7 KiB, for participants rendered at 40px.

Both descriptors now come from the rendered size, with a 1.5x stretch allowed on the small variant since the backend only serves 64 and 512. Verified in Chromium and Firefox.

Visual change: worst case is a 1.5x upscale, most visible on a 64px avatar at DPR 1.5.

### Checklist

- [x] Tests included or not applicable
- [x] Component documentation extended/updated or not applicable
- [x] Backport to `stable8` for Vue 2 or not applicable

### AI

- [x] The content of this PR was partly generated using AI (tests, reviewed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar image selection for small display sizes, providing more appropriate image densities for sharper rendering.
  * Preserved direct use of the large avatar variant for larger display sizes.

* **Tests**
  * Added coverage for responsive avatar image selection across multiple sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->