### PR TITLE
feat(NcModal): expose the slideshow state as a model

### DIFF
--- a/src/components/NcModal/NcModal.vue
+++ b/src/components/NcModal/NcModal.vue
@@ -29,6 +29,16 @@ defineOptions({ inheritAttrs: false })
  */
 const showModal = defineModel<boolean>('show', { default: true })
 
+/**
+ * Whether the slideshow is running.
+ *
+ * Bind it to start or stop the slideshow from outside, or to follow the
+ * play / pause button. It resets to `false` when the last slide is reached.
+ *
+ * @since 9.13.0
+ */
+const runSlideshow = defineModel<boolean>('slideshowRunning', { default: false })
+
 const props = withDefaults(defineProps<{
 	/**
 	 * Name to be shown with the modal
@@ -213,7 +223,6 @@ const {
 } = useIntervalFn(nextSlide, toRef(() => props.slideshowDelay), { immediate: false })
 
 const animationKey = ref(0)
-const runSlideshow = ref(false)
 watchEffect(() => {
 	if (runSlideshow.value && !props.slideshowPaused) {
 		startSlideshow()
@@ -963,8 +972,10 @@ export default {
 <template>
 	<div>
 		<NcButton @click="isOpen = true">Show Modal</NcButton>
+		<NcButton @click="isOpen = true; running = true">Show Modal and start the slideshow</NcButton>
 		<NcModal
 			v-if="isOpen"
+			v-model:slideshow-running="running"
 			close-button-outside
 			enable-slideshow
 			:has-next="page < lastPage"
@@ -975,6 +986,7 @@ export default {
 			@close="isOpen = false">
 			<div class="modal__content" :style="{ background: currentPage.background }">
 				<p class="model__content-text">{{ currentPage.text }}</p>
+				<p class="model__content-text">{{ running ? 'Slideshow running' : 'Slideshow stopped' }}</p>
 			</div>
 		</NcModal>
 	</div>
@@ -991,6 +1003,7 @@ export default {
 	data() {
 		return {
 			isOpen: false,
+			running: false,
 			page: 0,
 			lastPage: PAGES.length - 1,
 		}

--- a/tests/unit/components/NcModal/modal.spec.js
+++ b/tests/unit/components/NcModal/modal.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import NcModal from '../../../../src/components/NcModal/NcModal.vue'
 
 describe('NcModal', () => {
@@ -40,5 +40,62 @@ describe('NcModal', () => {
 		await wrapper.find('.modal-wrapper').trigger('mousedown')
 		// One emit('update:show', false)
 		expect(wrapper.emitted('update:show')).toEqual(undefined)
+	})
+
+	describe('slideshow', () => {
+		const props = { container: null, name: 'modal', enableSlideshow: true, hasNext: true, slideshowDelay: 100 }
+
+		beforeEach(() => {
+			vi.useFakeTimers()
+		})
+
+		afterEach(() => {
+			vi.useRealTimers()
+		})
+
+		it('does not run unless started', async () => {
+			const wrapper = mount(NcModal, { props })
+
+			await vi.advanceTimersByTimeAsync(250)
+			expect(wrapper.emitted('next')).toBe(undefined)
+			expect(wrapper.emitted('update:slideshowRunning')).toBe(undefined)
+		})
+
+		it('runs when `slideshowRunning` is bound to true', async () => {
+			const wrapper = mount(NcModal, { props: { ...props, slideshowRunning: true } })
+
+			await vi.advanceTimersByTimeAsync(250)
+			expect(wrapper.emitted('next')).toHaveLength(2)
+		})
+
+		it('stops when `slideshowRunning` is set to false', async () => {
+			const wrapper = mount(NcModal, { props: { ...props, slideshowRunning: true } })
+
+			await vi.advanceTimersByTimeAsync(150)
+			expect(wrapper.emitted('next')).toHaveLength(1)
+
+			await wrapper.setProps({ slideshowRunning: false })
+			await vi.advanceTimersByTimeAsync(250)
+			expect(wrapper.emitted('next')).toHaveLength(1)
+		})
+
+		it('reports the play / pause button through `update:slideshowRunning`', async () => {
+			const wrapper = mount(NcModal, { props })
+
+			await wrapper.find('.play-pause-icons').trigger('click')
+			expect(wrapper.emitted('update:slideshowRunning')).toEqual([[true]])
+
+			await wrapper.find('.play-pause-icons').trigger('click')
+			expect(wrapper.emitted('update:slideshowRunning')).toEqual([[true], [false]])
+		})
+
+		it('reports the stop on the last slide', async () => {
+			const wrapper = mount(NcModal, { props: { ...props, slideshowRunning: true } })
+
+			await wrapper.setProps({ hasNext: false })
+			await vi.advanceTimersByTimeAsync(150)
+			expect(wrapper.emitted('next')).toBe(undefined)
+			expect(wrapper.emitted('update:slideshowRunning')).toEqual([[false]])
+		})
 	})
 })


### PR DESCRIPTION
`NcModal` keeps its slideshow state in a private `runSlideshow` ref, so a parent can neither start the slideshow nor know it is running. The viewer used to reach in with `this.$refs.modal.togglePlayPause()` for its `startSlideshow` open option (Photos starts a slideshow from the Memories and Timeline views this way), and `@nextcloud/viewer` 2.x has no way to do the same on v9.

This turns the ref into `defineModel('slideshowRunning')`, so `v-model:slideshow-running` starts and stops the slideshow and follows the play / pause button. Unbound, the behaviour is unchanged. The end-of-slides reset still writes `false`, which the model now reports too.

Relates to nextcloud-libraries/nextcloud-viewer (the `startSlideshow` open option port).

Unit tests cover start, stop, the button round-trip and the last-slide reset. The docs example got a second button that opens the modal with the slideshow running.

*👾 This pull request was assisted by Claude Code, commits carry an `Assisted-by` trailer.*
